### PR TITLE
feat: add support for gemini-2.0-flash-thinking-exp model

### DIFF
--- a/relay/adaptor/gemini/adaptor.go
+++ b/relay/adaptor/gemini/adaptor.go
@@ -25,7 +25,8 @@ func (a *Adaptor) Init(meta *meta.Meta) {
 
 func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 	defaultVersion := config.GeminiVersion
-	if meta.ActualModelName == "gemini-2.0-flash-exp" {
+	// gemini-2.0-flash-exp and gemini-2.0-flash-thinking-exp use v1beta
+	if meta.ActualModelName == "gemini-2.0-flash-exp" || meta.ActualModelName == "gemini-2.0-flash-thinking-exp" {
 		defaultVersion = "v1beta"
 	}
 

--- a/relay/adaptor/gemini/adaptor.go
+++ b/relay/adaptor/gemini/adaptor.go
@@ -24,10 +24,13 @@ func (a *Adaptor) Init(meta *meta.Meta) {
 }
 
 func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
-	defaultVersion := config.GeminiVersion
-	// gemini-2.0-flash-exp and gemini-2.0-flash-thinking-exp use v1beta
-	if meta.ActualModelName == "gemini-2.0-flash-exp" || meta.ActualModelName == "gemini-2.0-flash-thinking-exp" {
+	var defaultVersion string
+	switch meta.ActualModelName {
+	case "gemini-2.0-flash-exp",
+		"gemini-2.0-flash-thinking-exp":
 		defaultVersion = "v1beta"
+	default:
+		defaultVersion = config.GeminiVersion
 	}
 
 	version := helper.AssignOrDefault(meta.Config.APIVersion, defaultVersion)

--- a/relay/adaptor/gemini/constants.go
+++ b/relay/adaptor/gemini/constants.go
@@ -6,5 +6,5 @@ var ModelList = []string{
 	"gemini-pro", "gemini-1.0-pro",
 	"gemini-1.5-flash", "gemini-1.5-pro",
 	"text-embedding-004", "aqa",
-	"gemini-2.0-flash-exp",
+	"gemini-2.0-flash-exp", "gemini-2.0-flash-thinking-exp",
 }

--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -54,6 +54,10 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *ChatRequest {
 				Category:  "HARM_CATEGORY_DANGEROUS_CONTENT",
 				Threshold: config.GeminiSafetySetting,
 			},
+			{
+				Category:  "HARM_CATEGORY_CIVIC_INTEGRITY",
+				Threshold: config.GeminiSafetySetting,
+			},
 		},
 		GenerationConfig: ChatGenerationConfig{
 			Temperature:     textRequest.Temperature,
@@ -246,7 +250,14 @@ func responseGeminiChat2OpenAI(response *ChatResponse) *openai.TextResponse {
 			if candidate.Content.Parts[0].FunctionCall != nil {
 				choice.Message.ToolCalls = getToolCalls(&candidate)
 			} else {
-				choice.Message.Content = candidate.Content.Parts[0].Text
+				var builder strings.Builder
+				for _, part := range candidate.Content.Parts {
+					if i > 0 {
+						builder.WriteString("\n")
+					}
+					builder.WriteString(part.Text)
+				}
+				choice.Message.Content = builder.String()
 			}
 		} else {
 			choice.Message.Content = ""

--- a/relay/adaptor/vertexai/gemini/adapter.go
+++ b/relay/adaptor/vertexai/gemini/adapter.go
@@ -18,7 +18,7 @@ var ModelList = []string{
 	"gemini-pro", "gemini-pro-vision",
 	"gemini-1.5-pro-001", "gemini-1.5-flash-001",
 	"gemini-1.5-pro-002", "gemini-1.5-flash-002",
-	"gemini-2.0-flash-exp",
+	"gemini-2.0-flash-exp", "gemini-2.0-flash-thinking-exp",
 }
 
 type Adaptor struct {

--- a/relay/billing/ratio/model.go
+++ b/relay/billing/ratio/model.go
@@ -110,15 +110,15 @@ var ModelRatio = map[string]float64{
 	"bge-large-en":       0.002 * RMB,
 	"tao-8k":             0.002 * RMB,
 	// https://ai.google.dev/pricing
-	"gemini-pro":           1, // $0.00025 / 1k characters -> $0.001 / 1k tokens
-	"gemini-1.0-pro":       1,
-	"gemini-1.5-pro":       1,
-	"gemini-1.5-pro-001":   1,
-	"gemini-1.5-flash":     1,
-	"gemini-1.5-flash-001": 1,
-	"gemini-2.0-flash-exp": 1,
+	"gemini-pro":                    1, // $0.00025 / 1k characters -> $0.001 / 1k tokens
+	"gemini-1.0-pro":                1,
+	"gemini-1.5-pro":                1,
+	"gemini-1.5-pro-001":            1,
+	"gemini-1.5-flash":              1,
+	"gemini-1.5-flash-001":          1,
+	"gemini-2.0-flash-exp":          1,
 	"gemini-2.0-flash-thinking-exp": 1,
-	"aqa":                  1,
+	"aqa":                           1,
 	// https://open.bigmodel.cn/pricing
 	"glm-4":         0.1 * RMB,
 	"glm-4v":        0.1 * RMB,

--- a/relay/billing/ratio/model.go
+++ b/relay/billing/ratio/model.go
@@ -117,6 +117,7 @@ var ModelRatio = map[string]float64{
 	"gemini-1.5-flash":     1,
 	"gemini-1.5-flash-001": 1,
 	"gemini-2.0-flash-exp": 1,
+	"gemini-2.0-flash-thinking-exp": 1,
 	"aqa":                  1,
 	// https://open.bigmodel.cn/pricing
 	"glm-4":         0.1 * RMB,


### PR DESCRIPTION
参考的原始repo这个PR: https://github.com/songquanpeng/one-api/pull/1995
测试：在Linux arm64上构建的docker镜像可以正常使用gemini-2.0-flash-thinking-exp模型。