### PR TITLE
fix: import path

### DIFF
--- a/relay/adaptor/common.go
+++ b/relay/adaptor/common.go
@@ -3,8 +3,8 @@ package adaptor
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	"github.com/songquanpeng/one-api/common/client"
 	"github.com/songquanpeng/one-api/common/ctxkey"
-	"github.com/songquanpeng/one-api/relay/client"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"io"
 	"net/http"


### PR DESCRIPTION
regression of #46
 
fix lint 的时候，自动导包导致引错包导致请求会超时
