### PR TITLE
feature: ratelimit for channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ oneapi:
     GLOBAL_API_RATE_LIMIT: 1000
     # (optional) GLOBAL_WEB_RATE_LIMIT maximum web page requests per IP within three minutes, default is 1000
     GLOBAL_WEB_RATE_LIMIT: 1000
+    # /v1 API ratelimit for each token
+    GLOBAL_RELAY_RATE_LIMIT: 1000
+    # Whether to ratelimit for channel, 0 is unlimited, 1 is to enable the ratelimit
+    GLOBAL_CHANNEL_RATE_LIMIT: 1
     # (optional) REDIS_CONN_STRING set REDIS cache connection
     REDIS_CONN_STRING: redis://100.122.41.16:6379/1
     # (optional) FRONTEND_BASE_URL redirect page requests to specified address, server-side setting only

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -158,6 +158,9 @@ var (
 	GlobalRelayRateLimitNum            = env.Int("GLOBAL_RELAY_RATE_LIMIT", 480)
 	GlobalRelayRateLimitDuration int64 = 3 * 60
 
+	ChannelRateLimitNum            = 0
+	ChannelRateLimitDuration int64 = 3 * 60
+
 	UploadRateLimitNum            = 10
 	UploadRateLimitDuration int64 = 60
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -158,8 +158,7 @@ var (
 	GlobalRelayRateLimitNum            = env.Int("GLOBAL_RELAY_RATE_LIMIT", 480)
 	GlobalRelayRateLimitDuration int64 = 3 * 60
 
-	// GLOBAL_CHANNEL_RATE_LIMIT 1 is enabled ratelimit, 0 is unlimited
-	ChannelRateLimitEnabled        = env.Int("GLOBAL_CHANNEL_RATE_LIMIT", 1)
+	ChannelRateLimitEnabled        = env.Bool("GLOBAL_CHANNEL_RATE_LIMIT", false)
 	ChannelRateLimitDuration int64 = 3 * 60
 
 	UploadRateLimitNum            = 10

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -158,7 +158,8 @@ var (
 	GlobalRelayRateLimitNum            = env.Int("GLOBAL_RELAY_RATE_LIMIT", 480)
 	GlobalRelayRateLimitDuration int64 = 3 * 60
 
-	ChannelRateLimitNum            = 0
+	// GLOBAL_CHANNEL_RATE_LIMIT 1 is enabled ratelimit, 0 is unlimited
+	ChannelRateLimitEnabled        = env.Int("GLOBAL_CHANNEL_RATE_LIMIT", 1)
 	ChannelRateLimitDuration int64 = 3 * 60
 
 	UploadRateLimitNum            = 10

--- a/common/ctxkey/key.go
+++ b/common/ctxkey/key.go
@@ -30,4 +30,5 @@ const (
 	KeyRequestBody      = gin.BodyBytesKey
 	SystemPrompt        = "system_prompt"
 	Meta                = "meta"
+	RateLimit           = "rate_limit"
 )

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -38,6 +38,7 @@ func buildTestRequest(model string) *relaymodel.GeneralOpenAIRequest {
 		model = "gpt-3.5-turbo"
 	}
 	testRequest := &relaymodel.GeneralOpenAIRequest{
+		MaxTokens: 2,
 		Model: model,
 	}
 	testMessage := relaymodel.Message{

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -95,7 +95,12 @@ func SetupContextForSelectedChannel(c *gin.Context, channel *model.Channel, mode
 	c.Set(ctxkey.OriginalModel, modelName) // for retry
 	c.Request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", channel.Key))
 	c.Set(ctxkey.BaseURL, channel.GetBaseURL())
-	c.Set(ctxkey.RateLimit, *channel.RateLimit)
+	if channel.RateLimit != nil {
+		c.Set(ctxkey.RateLimit, *channel.RateLimit)
+	} else {
+		c.Set(ctxkey.RateLimit, 0)
+	}
+	
 	cfg, _ := channel.LoadConfig()
 	// this is for backward compatibility
 	if channel.Other != nil {

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -95,6 +95,7 @@ func SetupContextForSelectedChannel(c *gin.Context, channel *model.Channel, mode
 	c.Set(ctxkey.OriginalModel, modelName) // for retry
 	c.Request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", channel.Key))
 	c.Set(ctxkey.BaseURL, channel.GetBaseURL())
+	c.Set(ctxkey.RateLimit, channel.RateLimit)
 	cfg, _ := channel.LoadConfig()
 	// this is for backward compatibility
 	if channel.Other != nil {

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -95,7 +95,7 @@ func SetupContextForSelectedChannel(c *gin.Context, channel *model.Channel, mode
 	c.Set(ctxkey.OriginalModel, modelName) // for retry
 	c.Request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", channel.Key))
 	c.Set(ctxkey.BaseURL, channel.GetBaseURL())
-	c.Set(ctxkey.RateLimit, channel.RateLimit)
+	c.Set(ctxkey.RateLimit, *channel.RateLimit)
 	cfg, _ := channel.LoadConfig()
 	// this is for backward compatibility
 	if channel.Other != nil {

--- a/middleware/rate-limit.go
+++ b/middleware/rate-limit.go
@@ -146,5 +146,9 @@ func GlobalRelayRateLimit() func(c *gin.Context) {
 }
 
 func ChannelRateLimit() func(c *gin.Context) {
-	return rateLimitFactory(config.ChannelRateLimitEnabled, config.ChannelRateLimitDuration, "CR")
+	maxRequestNum := 0
+	if config.ChannelRateLimitEnabled {
+		maxRequestNum = 1
+	}
+	return rateLimitFactory(maxRequestNum, config.ChannelRateLimitDuration, "CR")
 }

--- a/model/channel.go
+++ b/model/channel.go
@@ -38,6 +38,7 @@ type Channel struct {
 	Priority           *int64  `json:"priority" gorm:"bigint;default:0"`
 	Config             string  `json:"config"`
 	SystemPrompt       *string `json:"system_prompt" gorm:"type:text"`
+	RateLimit          int     `json:"rate_limit" gorm:"default:0"`
 }
 
 type ChannelConfig struct {

--- a/model/channel.go
+++ b/model/channel.go
@@ -38,7 +38,7 @@ type Channel struct {
 	Priority           *int64  `json:"priority" gorm:"bigint;default:0"`
 	Config             string  `json:"config"`
 	SystemPrompt       *string `json:"system_prompt" gorm:"type:text"`
-	RateLimit          int     `json:"rate_limit" gorm:"default:0"`
+	RateLimit          *int     `json:"ratelimit" gorm:"column:ratelimit;default:0"`
 }
 
 type ChannelConfig struct {

--- a/model/main.go
+++ b/model/main.go
@@ -19,6 +19,7 @@ import (
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	// glogger "gorm.io/gorm/logger"
 )
 
 var DB *gorm.DB
@@ -91,6 +92,7 @@ func openPostgreSQL(dsn string) (*gorm.DB, error) {
 		PreferSimpleProtocol: true, // disables implicit prepared statement usage
 	}), &gorm.Config{
 		PrepareStmt: true, // precompile SQL
+		// Logger: glogger.Default.LogMode(glogger.Info),  // debug sql
 	})
 }
 

--- a/router/relay.go
+++ b/router/relay.go
@@ -20,6 +20,7 @@ func SetRelayRouter(router *gin.Engine) {
 	relayV1Router := router.Group("/v1")
 	relayV1Router.Use(middleware.RelayPanicRecover(), middleware.TokenAuth(), middleware.Distribute())
 	relayV1Router.Use(middleware.GlobalRelayRateLimit())
+	relayV1Router.Use(middleware.ChannelRateLimit())
 	{
 		relayV1Router.Any("/oneapi/proxy/:channelid/*target", controller.Relay)
 		relayV1Router.POST("/completions", controller.Relay)

--- a/web/default/src/locales/en/translation.json
+++ b/web/default/src/locales/en/translation.json
@@ -108,6 +108,8 @@
       "proxy_url_placeholder": "This is optional and used for API calls via a proxy. Please enter the proxy URL, formatted as: https://domain.com",
       "base_url": "Base URL",
       "base_url_placeholder": "The Base URL required by the OpenAPI SDK",
+      "ratelimit": "Channel RateLimit",
+      "ratelimit_placeholder": "Limit the rate for each token in each channel (3min), The default(0) is Unlimited",
       "key": "Key",
       "key_placeholder": "Please enter key",
       "batch": "Batch Create",

--- a/web/default/src/locales/zh/translation.json
+++ b/web/default/src/locales/zh/translation.json
@@ -108,6 +108,8 @@
       "proxy_url_placeholder": "此项可选，用于通过代理站来进行 API 调用，请输入代理站地址，格式为：https://domain.com。注意，这里所需要填入的代理地址仅会在实际请求时替换域名部分，如果你想填入 OpenAI SDK 中所要求的 Base URL，请使用 OpenAI 兼容渠道类型",
       "base_url": "Base URL",
       "base_url_placeholder": "OpenAPI SDK 中所要求的 Base URL",
+      "ratelimit": "渠道限速",
+      "ratelimit_placeholder": "为每个Token 的每个Channel限速 (3分钟), 默认0为不限速",
       "key": "密钥",
       "key_placeholder": "请输入密钥",
       "batch": "批量创建",

--- a/web/default/src/pages/Channel/EditChannel.js
+++ b/web/default/src/pages/Channel/EditChannel.js
@@ -57,6 +57,7 @@ const EditChannel = () => {
     system_prompt: '',
     models: [],
     groups: ['default'],
+    ratelimit: 0,
   };
   const [batch, setBatch] = useState(false);
   const [inputs, setInputs] = useState(originInputs);
@@ -247,6 +248,7 @@ const EditChannel = () => {
     let res;
     localInputs.models = localInputs.models.join(',');
     localInputs.group = localInputs.groups.join(',');
+    localInputs.ratelimit = parseInt(localInputs.ratelimit);
     localInputs.config = JSON.stringify(config);
     if (isEdit) {
       res = await API.put(`/api/channel/`, {
@@ -767,6 +769,22 @@ const EditChannel = () => {
                 />
               </Form.Field>
             )}
+            {inputs.type !== 3 &&
+              inputs.type !== 33 &&
+              inputs.type !== 8 &&
+                inputs.type !== 50 &&
+              inputs.type !== 22 && (
+                <Form.Field>
+                  <Form.Input
+                      label={t('channel.edit.ratelimit')}
+                    name='ratelimit'
+                      placeholder={t('channel.edit.ratelimit_placeholder')}
+                    onChange={handleInputChange}
+                    value={inputs.ratelimit}
+                    autoComplete='new-password'
+                  />
+                </Form.Field>
+              )}
             <Button onClick={handleCancel}>
               {t('channel.edit.buttons.cancel')}
             </Button>


### PR DESCRIPTION
close #72 

该PR中实现了对每token的每个channel的限速，channel总限速=channel ratelimit * token number

- 这里还需要再讨论的是，对channel的限速需要在哪个级别进行

    - **token**：宽松，但如果token是由用户创建，则channel总限速不可控。当前PR在该层级实现
    - **user**：严格，但是否会有其他问题，由于我对这个仓库不熟悉，所以不能判断
    - **channel**：最严格，真正意义的channel限速，但对用户不友好

我已确认该 PR 已自测通过，相关截图如下：

- 前端页面

    ![image](https://github.com/user-attachments/assets/3cd2c5e6-c649-41e8-a0a3-0d9b6058928d)

- 限速测试

  - 通过token限速
    
    ![image](https://github.com/user-attachments/assets/ac4aa544-acc7-4775-852b-4784f376f7e7)
    
    ![image](https://github.com/user-attachments/assets/7d1e7616-8645-4405-92f8-1a0b71ecc4ac)


  - 对channel限速(前端展示： 每token对该渠道的限速为5次/3分钟)

    ![image](https://github.com/user-attachments/assets/90486cf5-4d39-4a9d-89f7-bfcf4686d877)

