### PR TITLE
fix: refactor SuspendAbility to support MySQL.

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -165,7 +165,10 @@ func SuspendAbility(ctx context.Context, group string, modelName string, channel
 		return errors.New("group, modelName, and channelId must be specified for suspending ability")
 	}
 	suspendTime := time.Now().Add(duration)
-	return DB.Model(&Ability{}).
-		Where("group = ? AND model = ? AND channel_id = ?", group, modelName, channelId).
-		Update("suspend_until", suspendTime).Error
+	ability := Ability{
+		Group:     group,
+		Model:     modelName,
+		ChannelId: channelId,
+	}
+	return DB.Model(&ability).Update("suspend_until", suspendTime).Error
 }


### PR DESCRIPTION
Solve MySQL error:
`controller/relay.go:161 [processChannelRelayError] failed to suspend ability for channel 12, model gpt-4.1, group vip: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'group = ? AND model = ? AND channel_id = ?' at line 1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal process for updating suspension times for abilities, with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->