### PR TITLE
add a default for aws claude request

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -201,3 +201,5 @@ var TestPrompt = env.String("TEST_PROMPT", "2 + 2 = ?")
 
 // OpenrouterProviderSort is used to determine the order of the providers in the openrouter
 var OpenrouterProviderSort = env.String("OPENROUTER_PROVIDER_SORT", "")
+
+var DefaultMaxToken = env.Int("DEFAULT_MAX_TOKEN", 2000)

--- a/relay/adaptor/aws/claude/main.go
+++ b/relay/adaptor/aws/claude/main.go
@@ -179,6 +179,9 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 	if err = copier.Copy(awsClaudeReq, claudeReq); err != nil {
 		return utils.WrapErr(errors.Wrap(err, "copy request")), nil
 	}
+	if awsClaudeReq.MaxTokens == 0 {
+		awsClaudeReq.MaxTokens = config.DefaultMaxToken
+	}
 	awsReq.Body, err = json.Marshal(awsClaudeReq)
 	if err != nil {
 		return utils.WrapErr(errors.Wrap(err, "marshal request")), nil

--- a/relay/adaptor/aws/claude/main.go
+++ b/relay/adaptor/aws/claude/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/songquanpeng/one-api/common/config"
 	"io"
 	"net/http"
 	"time"
@@ -107,7 +108,9 @@ func Handler(c *gin.Context, awsCli *bedrockruntime.Client, modelName string) (*
 	if err = copier.Copy(awsClaudeReq, claudeReq); err != nil {
 		return utils.WrapErr(errors.Wrap(err, "copy request")), nil
 	}
-
+	if awsClaudeReq.MaxTokens == 0 {
+		awsClaudeReq.MaxTokens = config.DefaultMaxToken
+	}
 	awsReq.Body, err = json.Marshal(awsClaudeReq)
 	if err != nil {
 		return utils.WrapErr(errors.Wrap(err, "marshal request")), nil


### PR DESCRIPTION
aws-claude的部分用户习惯不传max_tokens , 导致请求不通， 给这些用户加一个默认值，可以从环境变量中获取

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default maximum token value for AWS Claude requests, automatically applying when no value is specified by the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->