### PR TITLE
add default max_tokens for env config

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -201,3 +201,5 @@ var TestPrompt = env.String("TEST_PROMPT", "2 + 2 = ?")
 
 // OpenrouterProviderSort is used to determine the order of the providers in the openrouter
 var OpenrouterProviderSort = env.String("OPENROUTER_PROVIDER_SORT", "")
+
+var DefaultMaxToken = env.Int("DEFAULT_MAX_TOKEN", 2000)

--- a/relay/adaptor/aws/claude/main.go
+++ b/relay/adaptor/aws/claude/main.go
@@ -179,6 +179,9 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 	if err = copier.Copy(awsClaudeReq, claudeReq); err != nil {
 		return utils.WrapErr(errors.Wrap(err, "copy request")), nil
 	}
+	if awsClaudeReq.MaxTokens == 0 {
+		awsClaudeReq.MaxTokens = config.DefaultMaxToken
+	}
 	awsReq.Body, err = json.Marshal(awsClaudeReq)
 	if err != nil {
 		return utils.WrapErr(errors.Wrap(err, "marshal request")), nil

--- a/relay/adaptor/aws/claude/main.go
+++ b/relay/adaptor/aws/claude/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/songquanpeng/one-api/common/config"
 	"io"
 	"net/http"
 	"time"
@@ -107,7 +108,9 @@ func Handler(c *gin.Context, awsCli *bedrockruntime.Client, modelName string) (*
 	if err = copier.Copy(awsClaudeReq, claudeReq); err != nil {
 		return utils.WrapErr(errors.Wrap(err, "copy request")), nil
 	}
-
+	if awsClaudeReq.MaxTokens == 0 {
+		awsClaudeReq.MaxTokens = config.DefaultMaxToken
+	}
 	awsReq.Body, err = json.Marshal(awsClaudeReq)
 	if err != nil {
 		return utils.WrapErr(errors.Wrap(err, "marshal request")), nil


### PR DESCRIPTION
部分用户不传max_tokens， 平台支持一个启的默认值， 保证能调通接口， 否则aws-claude会拦截

我已确认该 PR 已自测通过，相关截图如下：
（此处放上测试通过的截图，如果不涉及前端改动或从 UI 上无法看出，请放终端启动成功的截图）
![image](https://github.com/user-attachments/assets/9b8019a4-af2e-49e4-a465-cfc5033ff2b3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a default maximum token limit for requests, which is configurable via an environment variable.
  * Requests to AWS Bedrock will now automatically use this default token limit if no value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->