### PR TITLE
ratelimit should always be available

### DIFF
--- a/web/default/src/pages/Channel/EditChannel.js
+++ b/web/default/src/pages/Channel/EditChannel.js
@@ -1121,22 +1121,17 @@ const EditChannel = () => {
                 />
               </Form.Field>
             )}
-            {inputs.type !== 3 &&
-              inputs.type !== 33 &&
-              inputs.type !== 8 &&
-                inputs.type !== 50 &&
-              inputs.type !== 22 && (
-                <Form.Field>
-                  <Form.Input
-                      label={t('channel.edit.ratelimit')}
-                    name='ratelimit'
-                      placeholder={t('channel.edit.ratelimit_placeholder')}
-                    onChange={handleInputChange}
-                    value={inputs.ratelimit}
-                    autoComplete='new-password'
-                  />
-                </Form.Field>
-              )}
+
+            <Form.Field>
+              <Form.Input
+                  label={t('channel.edit.ratelimit')}
+                name='ratelimit'
+                  placeholder={t('channel.edit.ratelimit_placeholder')}
+                onChange={handleInputChange}
+                value={inputs.ratelimit}
+                autoComplete='new-password'
+              />
+            </Form.Field>
 
             {/* Channel-specific pricing fields - now handled through model_configs */}
 


### PR DESCRIPTION
close #108 

我已确认该 PR 已自测通过，相关截图如下：
<img width="1132" height="168" alt="image" src="https://github.com/user-attachments/assets/1b434ad3-1a88-42b6-b04d-0c2326d019e1" />
<img width="1129" height="89" alt="image" src="https://github.com/user-attachments/assets/7fd0bbbc-e3b7-4a53-b4df-f1ae588a1db3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The "ratelimit" input field is now always displayed when editing a channel, regardless of the channel type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->