### PR TITLE
Add Support for Remote MCP Server

### DIFF
--- a/relay/adaptor/anthropic/main.go
+++ b/relay/adaptor/anthropic/main.go
@@ -205,13 +205,19 @@ func ConvertRequest(c *gin.Context, textRequest model.GeneralOpenAIRequest) (*Re
 	claudeTools := make([]Tool, 0, len(textRequest.Tools))
 
 	for _, tool := range textRequest.Tools {
+		// Convert Parameters from any to map[string]interface{} before indexing
+		params, ok := tool.Function.Parameters.(map[string]interface{})
+		if !ok {
+			params = make(map[string]interface{})
+		}
+
 		claudeTools = append(claudeTools, Tool{
 			Name:        tool.Function.Name,
 			Description: tool.Function.Description,
 			InputSchema: InputSchema{
-				Type:       tool.Function.Parameters["type"].(string),
-				Properties: tool.Function.Parameters["properties"],
-				Required:   tool.Function.Parameters["required"],
+				Type:       params["type"].(string),
+				Properties: params["properties"],
+				Required:   params["required"],
 			},
 		})
 	}

--- a/relay/adaptor/gemini/main.go
+++ b/relay/adaptor/gemini/main.go
@@ -250,9 +250,11 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *ChatRequest {
 			if !ok {
 				// If type assertion fails, fallback to original parameters without additionalProperties
 				cleanedParamsMap = make(map[string]interface{})
-				for k, v := range tool.Function.Parameters {
-					if k != "additionalProperties" && k != "description" && k != "strict" {
-						cleanedParamsMap[k] = v
+				if originalParams, ok := tool.Function.Parameters.(map[string]interface{}); ok {
+					for k, v := range originalParams {
+						if k != "additionalProperties" && k != "description" && k != "strict" {
+							cleanedParamsMap[k] = v
+						}
 					}
 				}
 			}
@@ -277,9 +279,11 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) *ChatRequest {
 			if !ok {
 				// If type assertion fails, fallback to original parameters without additionalProperties
 				cleanedParamsMap = make(map[string]interface{})
-				for k, v := range function.Parameters {
-					if k != "additionalProperties" && k != "description" && k != "strict" {
-						cleanedParamsMap[k] = v
+				if originalParams, ok := function.Parameters.(map[string]interface{}); ok {
+					for k, v := range originalParams {
+						if k != "additionalProperties" && k != "description" && k != "strict" {
+							cleanedParamsMap[k] = v
+						}
 					}
 				}
 			}

--- a/relay/adaptor/gemini/main_test.go
+++ b/relay/adaptor/gemini/main_test.go
@@ -446,7 +446,11 @@ func TestConvertRequestWithToolsRegression(t *testing.T) {
 	}
 
 	// Verify that unsupported fields were removed
-	params := function.Parameters
+	// Convert Parameters from any to map[string]interface{} before indexing
+	params, ok := function.Parameters.(map[string]any)
+	if !ok {
+		t.Fatal("function.Parameters should be map[string]interface{}")
+	}
 
 	// Check that additionalProperties was removed
 	if _, exists := params["additionalProperties"]; exists {
@@ -735,7 +739,11 @@ func TestOriginalErrorScenario(t *testing.T) {
 	}
 
 	function := functions[0]
-	params := function.Parameters
+	// Convert Parameters from any to map[string]interface{} before indexing
+	params, ok := function.Parameters.(map[string]any)
+	if !ok {
+		t.Fatal("function.Parameters should be map[string]interface{}")
+	}
 
 	// Verify the critical fix: date format should be converted to date-time
 	if properties, ok := params["properties"].(map[string]interface{}); ok {

--- a/relay/adaptor/openai/mcp_conversion_test.go
+++ b/relay/adaptor/openai/mcp_conversion_test.go
@@ -1,0 +1,222 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+// TestConvertChatCompletionToResponseAPIWithMCP tests that MCP tools are properly converted
+// from ChatCompletion format to Response API format, preserving all MCP-specific fields
+func TestConvertChatCompletionToResponseAPIWithMCP(t *testing.T) {
+	// Create a ChatCompletion request with MCP tool (matches the failing curl example)
+	chatRequest := &model.GeneralOpenAIRequest{
+		Model: "gpt-4o",
+		Messages: []model.Message{
+			{
+				Role:    "user",
+				Content: "What transport protocols are supported in the 2025-03-26 version of the MCP spec?",
+			},
+		},
+		Tools: []model.Tool{
+			{
+				Type:            "mcp",
+				ServerLabel:     "deepwiki",
+				ServerUrl:       "https://mcp.deepwiki.com/mcp",
+				RequireApproval: "never",
+			},
+		},
+	}
+
+	// Convert to Response API format
+	responseAPI := ConvertChatCompletionToResponseAPI(chatRequest)
+
+	// Verify the conversion succeeded
+	if responseAPI == nil {
+		t.Fatal("ConvertChatCompletionToResponseAPI returned nil")
+	}
+
+	// Verify tools were converted properly
+	if len(responseAPI.Tools) != 1 {
+		t.Fatalf("Expected 1 tool, got %d", len(responseAPI.Tools))
+	}
+
+	tool := responseAPI.Tools[0]
+
+	// Verify MCP-specific fields are preserved
+	if tool.Type != "mcp" {
+		t.Errorf("Expected tool type 'mcp', got '%s'", tool.Type)
+	}
+
+	if tool.ServerLabel != "deepwiki" {
+		t.Errorf("Expected server_label 'deepwiki', got '%s'", tool.ServerLabel)
+	}
+
+	if tool.ServerUrl != "https://mcp.deepwiki.com/mcp" {
+		t.Errorf("Expected server_url 'https://mcp.deepwiki.com/mcp', got '%s'", tool.ServerUrl)
+	}
+
+	if tool.RequireApproval != "never" {
+		t.Errorf("Expected require_approval 'never', got %v", tool.RequireApproval)
+	}
+
+	// Verify function-specific fields are empty for MCP tools
+	if tool.Name != "" {
+		t.Errorf("Expected empty name for MCP tool, got '%s'", tool.Name)
+	}
+
+	if tool.Description != "" {
+		t.Errorf("Expected empty description for MCP tool, got '%s'", tool.Description)
+	}
+
+	if tool.Parameters != nil {
+		t.Errorf("Expected nil parameters for MCP tool, got %v", tool.Parameters)
+	}
+
+	// Verify the tool can be marshaled to JSON (important for the actual API request)
+	jsonData, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("Failed to marshal MCP tool to JSON: %v", err)
+	}
+
+	// Verify the JSON contains the required server_label field
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if serverLabel, exists := result["server_label"]; !exists {
+		t.Error("server_label field is missing from JSON - this would cause the original error")
+	} else if serverLabel != "deepwiki" {
+		t.Errorf("Expected server_label 'deepwiki' in JSON, got %v", serverLabel)
+	}
+
+	t.Logf("Successfully converted MCP tool to Response API format: %s", string(jsonData))
+}
+
+// TestConvertChatCompletionToResponseAPIWithMCPAndFunction tests mixed MCP and function tools
+func TestConvertChatCompletionToResponseAPIWithMCPAndFunction(t *testing.T) {
+	chatRequest := &model.GeneralOpenAIRequest{
+		Model: "gpt-4o",
+		Messages: []model.Message{
+			{
+				Role:    "user",
+				Content: "Test mixed tools",
+			},
+		},
+		Tools: []model.Tool{
+			{
+				Type: "function",
+				Function: model.Function{
+					Name:        "get_weather",
+					Description: "Get weather information",
+					Parameters: map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"location": map[string]interface{}{
+								"type": "string",
+							},
+						},
+					},
+				},
+			},
+			{
+				Type:        "mcp",
+				ServerLabel: "stripe",
+				ServerUrl:   "https://mcp.stripe.com",
+				RequireApproval: map[string]interface{}{
+					"never": map[string]interface{}{
+						"tool_names": []string{"create_payment_link"},
+					},
+				},
+				AllowedTools: []string{"create_payment_link", "get_balance"},
+				Headers: map[string]string{
+					"Authorization": "Bearer sk_test_123",
+				},
+			},
+		},
+	}
+
+	responseAPI := ConvertChatCompletionToResponseAPI(chatRequest)
+
+	if len(responseAPI.Tools) != 2 {
+		t.Fatalf("Expected 2 tools, got %d", len(responseAPI.Tools))
+	}
+
+	// Verify function tool
+	functionTool := responseAPI.Tools[0]
+	if functionTool.Type != "function" {
+		t.Errorf("Expected first tool type 'function', got '%s'", functionTool.Type)
+	}
+	if functionTool.Name != "get_weather" {
+		t.Errorf("Expected function name 'get_weather', got '%s'", functionTool.Name)
+	}
+	if functionTool.ServerLabel != "" {
+		t.Error("Function tool should not have server_label")
+	}
+
+	// Verify MCP tool
+	mcpTool := responseAPI.Tools[1]
+	if mcpTool.Type != "mcp" {
+		t.Errorf("Expected second tool type 'mcp', got '%s'", mcpTool.Type)
+	}
+	if mcpTool.ServerLabel != "stripe" {
+		t.Errorf("Expected server_label 'stripe', got '%s'", mcpTool.ServerLabel)
+	}
+	if len(mcpTool.AllowedTools) != 2 {
+		t.Errorf("Expected 2 allowed tools, got %d", len(mcpTool.AllowedTools))
+	}
+	if mcpTool.Headers["Authorization"] != "Bearer sk_test_123" {
+		t.Errorf("Expected Authorization header, got '%s'", mcpTool.Headers["Authorization"])
+	}
+	if mcpTool.Name != "" {
+		t.Error("MCP tool should not have function name")
+	}
+}
+
+// TestMCPToolJSONSerialization tests that the converted MCP tool produces valid JSON
+func TestMCPToolJSONSerialization(t *testing.T) {
+	chatRequest := &model.GeneralOpenAIRequest{
+		Model: "gpt-4o",
+		Messages: []model.Message{
+			{Role: "user", Content: "Test"},
+		},
+		Tools: []model.Tool{
+			{
+				Type:            "mcp",
+				ServerLabel:     "deepwiki",
+				ServerUrl:       "https://mcp.deepwiki.com/mcp",
+				RequireApproval: "never",
+			},
+		},
+	}
+
+	responseAPI := ConvertChatCompletionToResponseAPI(chatRequest)
+
+	// Marshal the entire request to JSON
+	jsonData, err := json.Marshal(responseAPI)
+	if err != nil {
+		t.Fatalf("Failed to marshal Response API request: %v", err)
+	}
+
+	// Verify it can be unmarshaled back
+	var unmarshaled ResponseAPIRequest
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal Response API request: %v", err)
+	}
+
+	// Verify MCP tool fields are preserved
+	if len(unmarshaled.Tools) != 1 {
+		t.Fatalf("Expected 1 tool after round-trip, got %d", len(unmarshaled.Tools))
+	}
+
+	tool := unmarshaled.Tools[0]
+	if tool.ServerLabel != "deepwiki" {
+		t.Errorf("server_label lost during JSON round-trip: got '%s'", tool.ServerLabel)
+	}
+
+	t.Logf("JSON serialization successful: %s", string(jsonData))
+}

--- a/relay/adaptor/openai/response_model_mcp_test.go
+++ b/relay/adaptor/openai/response_model_mcp_test.go
@@ -1,0 +1,345 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+// TestMCPOutputItemSerialization tests that MCP-specific OutputItem fields are properly serialized
+func TestMCPOutputItemSerialization(t *testing.T) {
+	// Test mcp_list_tools output item
+	mcpListTools := OutputItem{
+		Type:        "mcp_list_tools",
+		Id:          "mcpl_682d4379df088191886b70f4ec39f90403937d5f622d7a90",
+		ServerLabel: "deepwiki",
+		Tools: []model.Tool{
+			{
+				Type: "function",
+				Function: model.Function{
+					Name:        "read_wiki_structure",
+					Description: "Read repository structure",
+					Parameters: map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"repoName": map[string]interface{}{
+								"type":        "string",
+								"description": "GitHub repository: owner/repo (e.g. \"facebook/react\")",
+							},
+						},
+						"required": []string{"repoName"},
+					},
+				},
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(mcpListTools)
+	if err != nil {
+		t.Fatalf("Failed to marshal mcp_list_tools: %v", err)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify MCP-specific fields
+	if result["type"] != "mcp_list_tools" {
+		t.Errorf("Expected type 'mcp_list_tools', got %v", result["type"])
+	}
+	if result["server_label"] != "deepwiki" {
+		t.Errorf("Expected server_label 'deepwiki', got %v", result["server_label"])
+	}
+	if tools, ok := result["tools"].([]interface{}); !ok || len(tools) != 1 {
+		t.Errorf("Expected tools array with 1 item, got %v", result["tools"])
+	}
+}
+
+// TestMCPCallOutputItem tests mcp_call output item serialization
+func TestMCPCallOutputItem(t *testing.T) {
+	// Test successful mcp_call
+	mcpCall := OutputItem{
+		Type:        "mcp_call",
+		Id:          "mcp_682d437d90a88191bf88cd03aae0c3e503937d5f622d7a90",
+		ServerLabel: "deepwiki",
+		Name:        "ask_question",
+		Arguments:   "{\"repoName\":\"modelcontextprotocol/modelcontextprotocol\",\"question\":\"What transport protocols does the 2025-03-26 version of the MCP spec support?\"}",
+		Output:      "The 2025-03-26 version of the Model Context Protocol (MCP) specification supports two standard transport mechanisms: `stdio` and `Streamable HTTP`",
+	}
+
+	jsonData, err := json.Marshal(mcpCall)
+	if err != nil {
+		t.Fatalf("Failed to marshal mcp_call: %v", err)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify fields
+	if result["type"] != "mcp_call" {
+		t.Errorf("Expected type 'mcp_call', got %v", result["type"])
+	}
+	if result["name"] != "ask_question" {
+		t.Errorf("Expected name 'ask_question', got %v", result["name"])
+	}
+	if result["server_label"] != "deepwiki" {
+		t.Errorf("Expected server_label 'deepwiki', got %v", result["server_label"])
+	}
+	if result["output"] == "" {
+		t.Error("Expected output to be present")
+	}
+}
+
+// TestMCPCallWithError tests mcp_call output item with error
+func TestMCPCallWithError(t *testing.T) {
+	errorMsg := "Connection failed"
+	mcpCallError := OutputItem{
+		Type:        "mcp_call",
+		Id:          "mcp_error_123",
+		ServerLabel: "stripe",
+		Name:        "create_payment_link",
+		Arguments:   "{\"amount\":2000}",
+		Error:       &errorMsg,
+	}
+
+	jsonData, err := json.Marshal(mcpCallError)
+	if err != nil {
+		t.Fatalf("Failed to marshal mcp_call with error: %v", err)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result["error"] != "Connection failed" {
+		t.Errorf("Expected error 'Connection failed', got %v", result["error"])
+	}
+}
+
+// TestMCPApprovalRequest tests mcp_approval_request output item
+func TestMCPApprovalRequest(t *testing.T) {
+	approvalRequest := OutputItem{
+		Type:        "mcp_approval_request",
+		Id:          "mcpr_682d498e3bd4819196a0ce1664f8e77b04ad1e533afccbfa",
+		ServerLabel: "deepwiki",
+		Name:        "ask_question",
+		Arguments:   "{\"repoName\":\"modelcontextprotocol/modelcontextprotocol\",\"question\":\"What transport protocols are supported in the 2025-03-26 version of the MCP spec?\"}",
+	}
+
+	jsonData, err := json.Marshal(approvalRequest)
+	if err != nil {
+		t.Fatalf("Failed to marshal mcp_approval_request: %v", err)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify fields
+	if result["type"] != "mcp_approval_request" {
+		t.Errorf("Expected type 'mcp_approval_request', got %v", result["type"])
+	}
+	if result["server_label"] != "deepwiki" {
+		t.Errorf("Expected server_label 'deepwiki', got %v", result["server_label"])
+	}
+}
+
+// TestMCPApprovalResponseInput tests the MCP approval response input structure
+func TestMCPApprovalResponseInput(t *testing.T) {
+	approvalResponse := MCPApprovalResponseInput{
+		Type:              "mcp_approval_response",
+		Approve:           true,
+		ApprovalRequestId: "mcpr_682d498e3bd4819196a0ce1664f8e77b04ad1e533afccbfa",
+	}
+
+	jsonData, err := json.Marshal(approvalResponse)
+	if err != nil {
+		t.Fatalf("Failed to marshal MCPApprovalResponseInput: %v", err)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify fields
+	if result["type"] != "mcp_approval_response" {
+		t.Errorf("Expected type 'mcp_approval_response', got %v", result["type"])
+	}
+	if result["approve"] != true {
+		t.Errorf("Expected approve true, got %v", result["approve"])
+	}
+	if result["approval_request_id"] != "mcpr_682d498e3bd4819196a0ce1664f8e77b04ad1e533afccbfa" {
+		t.Errorf("Expected correct approval_request_id, got %v", result["approval_request_id"])
+	}
+
+	// Test deserialization
+	var deserializedResponse MCPApprovalResponseInput
+	err = json.Unmarshal(jsonData, &deserializedResponse)
+	if err != nil {
+		t.Fatalf("Failed to deserialize MCPApprovalResponseInput: %v", err)
+	}
+
+	if deserializedResponse.Type != "mcp_approval_response" {
+		t.Errorf("Expected type 'mcp_approval_response', got %s", deserializedResponse.Type)
+	}
+	if !deserializedResponse.Approve {
+		t.Error("Expected approve to be true")
+	}
+	if deserializedResponse.ApprovalRequestId != "mcpr_682d498e3bd4819196a0ce1664f8e77b04ad1e533afccbfa" {
+		t.Errorf("Expected correct approval_request_id, got %s", deserializedResponse.ApprovalRequestId)
+	}
+}
+
+// TestResponseAPIResponseWithMCPOutput tests complete ResponseAPIResponse with MCP output items
+func TestResponseAPIResponseWithMCPOutput(t *testing.T) {
+	response := ResponseAPIResponse{
+		Id:        "resp_123",
+		Object:    "response",
+		Model:     "gpt-4.1",
+		Status:    "completed",
+		CreatedAt: 1234567890,
+		Output: []OutputItem{
+			{
+				Type:        "mcp_list_tools",
+				Id:          "mcpl_456",
+				ServerLabel: "deepwiki",
+				Tools: []model.Tool{
+					{
+						Type: "function",
+						Function: model.Function{
+							Name:        "ask_question",
+							Description: "Ask a question",
+						},
+					},
+				},
+			},
+			{
+				Type:        "mcp_call",
+				Id:          "mcp_789",
+				ServerLabel: "deepwiki",
+				Name:        "ask_question",
+				Arguments:   "{\"question\":\"test\"}",
+				Output:      "Test response",
+			},
+		},
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("Failed to marshal ResponseAPIResponse with MCP output: %v", err)
+	}
+
+	var deserializedResponse ResponseAPIResponse
+	err = json.Unmarshal(jsonData, &deserializedResponse)
+	if err != nil {
+		t.Fatalf("Failed to deserialize ResponseAPIResponse: %v", err)
+	}
+
+	if len(deserializedResponse.Output) != 2 {
+		t.Errorf("Expected 2 output items, got %d", len(deserializedResponse.Output))
+	}
+
+	// Verify first output item (mcp_list_tools)
+	firstOutput := deserializedResponse.Output[0]
+	if firstOutput.Type != "mcp_list_tools" {
+		t.Errorf("Expected first output type 'mcp_list_tools', got %s", firstOutput.Type)
+	}
+	if len(firstOutput.Tools) != 1 {
+		t.Errorf("Expected 1 tool, got %d", len(firstOutput.Tools))
+	}
+
+	// Verify second output item (mcp_call)
+	secondOutput := deserializedResponse.Output[1]
+	if secondOutput.Type != "mcp_call" {
+		t.Errorf("Expected second output type 'mcp_call', got %s", secondOutput.Type)
+	}
+	if secondOutput.Output != "Test response" {
+		t.Errorf("Expected output 'Test response', got %s", secondOutput.Output)
+	}
+}
+
+// TestConvertResponseAPIToChatCompletionWithMCP tests MCP output conversion to ChatCompletion
+func TestConvertResponseAPIToChatCompletionWithMCP(t *testing.T) {
+	responseAPIResp := &ResponseAPIResponse{
+		Id:        "resp_mcp_test",
+		Model:     "gpt-4.1",
+		Status:    "completed",
+		CreatedAt: 1234567890,
+		Output: []OutputItem{
+			{
+				Type: "message",
+				Role: "assistant",
+				Content: []OutputContent{
+					{
+						Type: "output_text",
+						Text: "Hello! I'll help you with that.",
+					},
+				},
+			},
+			{
+				Type:        "mcp_list_tools",
+				ServerLabel: "deepwiki",
+				Tools: []model.Tool{
+					{Type: "function", Function: model.Function{Name: "ask_question"}},
+				},
+			},
+			{
+				Type:        "mcp_call",
+				ServerLabel: "deepwiki",
+				Name:        "ask_question",
+				Arguments:   "{\"question\":\"test\"}",
+				Output:      "The answer is 42",
+			},
+		},
+	}
+
+	chatResponse := ConvertResponseAPIToChatCompletion(responseAPIResp)
+
+	if chatResponse == nil {
+		t.Fatal("Expected non-nil chat response")
+	}
+
+	if chatResponse.Id != "resp_mcp_test" {
+		t.Errorf("Expected ID 'resp_mcp_test', got %s", chatResponse.Id)
+	}
+
+	if len(chatResponse.Choices) != 1 {
+		t.Errorf("Expected 1 choice, got %d", len(chatResponse.Choices))
+	}
+
+	choice := chatResponse.Choices[0]
+	content := choice.Message.Content.(string)
+
+	// Verify that MCP content was included in the response text
+	if !containsSubstring(content, "Hello! I'll help you with that.") {
+		t.Error("Expected original message content to be preserved")
+	}
+	if !containsSubstring(content, "MCP Server 'deepwiki' tools imported: 1 tools available") {
+		t.Error("Expected MCP list tools info to be included")
+	}
+	if !containsSubstring(content, "MCP Tool 'ask_question' result: The answer is 42") {
+		t.Error("Expected MCP call result to be included")
+	}
+}
+
+// Helper function to check if string contains substring
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/relay/model/tool.go
+++ b/relay/model/tool.go
@@ -1,17 +1,30 @@
 package model
 
+// Tool represents a tool definition used in AI model interactions.
+// It contains metadata about the tool and its associated function or MCP server configuration.
+// This struct supports both function-based tools and Remote MCP server tools.
 type Tool struct {
-	Id       string   `json:"id,omitempty"`
-	Type     string   `json:"type,omitempty"` // when splicing claude tools stream messages, it is empty
-	Function Function `json:"function"`
-	Index    *int     `json:"index,omitempty"` // Index identifies which function call the delta is for in streaming responses
+	Id       string   `json:"id,omitempty"`       // Unique identifier for the tool
+	Type     string   `json:"type,omitempty"`     // Tool type (e.g., "function", "mcp"), may be empty when splicing claude tools stream messages
+	Function Function `json:"function,omitempty"` // Function definition (for type="function")
+	Index    *int     `json:"index,omitempty"`    // Index identifies which function call the delta is for in streaming responses
+
+	// MCP-specific fields (for type="mcp")
+	ServerLabel     string            `json:"server_label,omitempty"`     // Label for the MCP server
+	ServerUrl       string            `json:"server_url,omitempty"`       // URL of the remote MCP server
+	RequireApproval any               `json:"require_approval,omitempty"` // Approval requirement: "never", or object with tool-specific settings
+	AllowedTools    []string          `json:"allowed_tools,omitempty"`    // List of allowed tool names from the MCP server
+	Headers         map[string]string `json:"headers,omitempty"`          // Additional headers for MCP server requests (e.g., Authorization)
 }
 
+// Function represents a function definition within a tool.
+// It contains the function's metadata including its description, name, parameters for requests,
+// and arguments for responses. Used for both tool calling requests and responses.
 type Function struct {
-	Description string         `json:"description,omitempty"`
-	Name        string         `json:"name,omitempty"`       // when splicing claude tools stream messages, it is empty
-	Parameters  map[string]any `json:"parameters,omitempty"` // request
-	Arguments   any            `json:"arguments,omitempty"`  // response
-	Required    []string       `json:"required,omitempty"`   // request
-	Strict      *bool          `json:"strict,omitempty"`     // request
+	Description string   `json:"description,omitempty"` // Human-readable description of what the function does
+	Name        string   `json:"name,omitempty"`        // Function name, may be empty when splicing claude tools stream messages
+	Parameters  any      `json:"parameters,omitempty"`  // Function parameters schema for requests (typically JSON Schema)
+	Arguments   any      `json:"arguments,omitempty"`   // Function arguments data for responses (actual values passed to function)
+	Required    []string `json:"required,omitempty"`    // Required parameter names for function validation
+	Strict      *bool    `json:"strict,omitempty"`      // Whether to enforce strict parameter validation
 }

--- a/relay/model/tool_test.go
+++ b/relay/model/tool_test.go
@@ -26,7 +26,7 @@ func TestToolIndexField(t *testing.T) {
 	}
 
 	// Verify that the index field is present in JSON
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(jsonData, &result)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
@@ -57,7 +57,7 @@ func TestToolIndexField(t *testing.T) {
 	}
 
 	// Verify that the index field is omitted in JSON (due to omitempty)
-	var result2 map[string]interface{}
+	var result2 map[string]any
 	err = json.Unmarshal(jsonData2, &result2)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
@@ -191,5 +191,332 @@ func TestToolIndexFieldDeserialization(t *testing.T) {
 	// Verify index field is nil
 	if nonStreamingTool.Index != nil {
 		t.Error("Index field should be nil for non-streaming tool")
+	}
+}
+
+// TestMCPToolSerialization tests that MCP tools are properly serialized with all MCP fields
+func TestMCPToolSerialization(t *testing.T) {
+	// Test MCP tool with all fields populated
+	mcpTool := Tool{
+		Id:              "mcp_001",
+		Type:            "mcp",
+		ServerLabel:     "deepwiki",
+		ServerUrl:       "https://mcp.deepwiki.com/mcp",
+		RequireApproval: "never",
+		AllowedTools:    []string{"ask_question", "read_wiki_structure"},
+		Headers: map[string]string{
+			"Authorization":   "Bearer token123",
+			"X-Custom-Header": "custom_value",
+		},
+	}
+
+	// Serialize to JSON
+	jsonData, err := json.Marshal(mcpTool)
+	if err != nil {
+		t.Fatalf("Failed to marshal MCP tool: %v", err)
+	}
+
+	// Verify all MCP fields are present
+	var result map[string]any
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Check all MCP-specific fields
+	if serverLabel, exists := result["server_label"]; !exists || serverLabel != "deepwiki" {
+		t.Errorf("Expected server_label to be 'deepwiki', got %v", serverLabel)
+	}
+
+	if serverUrl, exists := result["server_url"]; !exists || serverUrl != "https://mcp.deepwiki.com/mcp" {
+		t.Errorf("Expected server_url to be 'https://mcp.deepwiki.com/mcp', got %v", serverUrl)
+	}
+
+	if requireApproval, exists := result["require_approval"]; !exists || requireApproval != "never" {
+		t.Errorf("Expected require_approval to be 'never', got %v", requireApproval)
+	}
+
+	// Verify function field is present but empty (zero value struct is serialized as empty object)
+	if functionField, exists := result["function"]; !exists {
+		t.Error("Function field should be present in JSON")
+	} else {
+		// Function should be an empty object for MCP tools
+		functionMap, ok := functionField.(map[string]any)
+		if !ok {
+			t.Error("Function field should be an object")
+		} else if len(functionMap) > 0 {
+			t.Error("Function field should be empty for MCP tools")
+		}
+	}
+}
+
+// TestMCPToolDeserialization tests that MCP tools can be properly deserialized
+func TestMCPToolDeserialization(t *testing.T) {
+	// JSON for MCP tool
+	mcpJSON := `{
+		"id": "mcp_002",
+		"type": "mcp",
+		"server_label": "stripe",
+		"server_url": "https://mcp.stripe.com",
+		"require_approval": {
+			"never": {
+				"tool_names": ["create_payment_link", "get_balance"]
+			}
+		},
+		"allowed_tools": ["create_payment_link", "get_balance", "list_customers"],
+		"headers": {
+			"Authorization": "Bearer sk_test_123",
+			"Content-Type": "application/json"
+		}
+	}`
+
+	var mcpTool Tool
+	err := json.Unmarshal([]byte(mcpJSON), &mcpTool)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal MCP tool JSON: %v", err)
+	}
+
+	// Verify all fields are properly set
+	if mcpTool.Id != "mcp_002" {
+		t.Errorf("Expected id to be 'mcp_002', got '%s'", mcpTool.Id)
+	}
+
+	if mcpTool.Type != "mcp" {
+		t.Errorf("Expected type to be 'mcp', got '%s'", mcpTool.Type)
+	}
+
+	if mcpTool.ServerLabel != "stripe" {
+		t.Errorf("Expected server_label to be 'stripe', got '%s'", mcpTool.ServerLabel)
+	}
+
+	if mcpTool.ServerUrl != "https://mcp.stripe.com" {
+		t.Errorf("Expected server_url to be 'https://mcp.stripe.com', got '%s'", mcpTool.ServerUrl)
+	}
+
+	// Check allowed_tools slice
+	expectedTools := []string{"create_payment_link", "get_balance", "list_customers"}
+	if len(mcpTool.AllowedTools) != len(expectedTools) {
+		t.Errorf("Expected %d allowed tools, got %d", len(expectedTools), len(mcpTool.AllowedTools))
+	}
+
+	// Check headers map
+	if mcpTool.Headers["Authorization"] != "Bearer sk_test_123" {
+		t.Errorf("Expected Authorization header to be 'Bearer sk_test_123', got '%s'", mcpTool.Headers["Authorization"])
+	}
+}
+
+// TestMCPRequireApprovalVariations tests different RequireApproval configurations
+func TestMCPRequireApprovalVariations(t *testing.T) {
+	testCases := []struct {
+		name     string
+		approval any
+		jsonStr  string
+	}{
+		{
+			name:     "String never",
+			approval: "never",
+			jsonStr:  `"never"`,
+		},
+		{
+			name: "Object with tool names",
+			approval: map[string]any{
+				"never": map[string]any{
+					"tool_names": []string{"tool1", "tool2"},
+				},
+			},
+			jsonStr: `{"never":{"tool_names":["tool1","tool2"]}}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mcpTool := Tool{
+				Type:            "mcp",
+				ServerLabel:     "test",
+				RequireApproval: tc.approval,
+			}
+
+			jsonData, err := json.Marshal(mcpTool)
+			if err != nil {
+				t.Fatalf("Failed to marshal MCP tool: %v", err)
+			}
+
+			// Verify the require_approval field is serialized correctly
+			var result map[string]any
+			err = json.Unmarshal(jsonData, &result)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal JSON: %v", err)
+			}
+
+			// Convert require_approval back to JSON to compare
+			approvalBytes, err := json.Marshal(result["require_approval"])
+			if err != nil {
+				t.Fatalf("Failed to marshal require_approval: %v", err)
+			}
+
+			if string(approvalBytes) != tc.jsonStr {
+				t.Errorf("Expected require_approval JSON to be %s, got %s", tc.jsonStr, string(approvalBytes))
+			}
+		})
+	}
+}
+
+// TestMixedToolArray tests arrays containing both function and MCP tools
+func TestMixedToolArray(t *testing.T) {
+	tools := []Tool{
+		{
+			Id:   "func_001",
+			Type: "function",
+			Function: Function{
+				Name:        "get_weather",
+				Description: "Get weather information",
+				Parameters: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"location": map[string]any{
+							"type":        "string",
+							"description": "The location to get weather for",
+						},
+					},
+					"required": []string{"location"},
+				},
+			},
+		},
+		{
+			Id:              "mcp_001",
+			Type:            "mcp",
+			ServerLabel:     "deepwiki",
+			ServerUrl:       "https://mcp.deepwiki.com/mcp",
+			RequireApproval: "never",
+			AllowedTools:    []string{"ask_question"},
+			Headers: map[string]string{
+				"Authorization": "Bearer token123",
+			},
+		},
+	}
+
+	// Serialize the mixed array
+	jsonData, err := json.Marshal(tools)
+	if err != nil {
+		t.Fatalf("Failed to marshal mixed tool array: %v", err)
+	}
+
+	// Deserialize back
+	var deserializedTools []Tool
+	err = json.Unmarshal(jsonData, &deserializedTools)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal mixed tool array: %v", err)
+	}
+
+	// Verify we have 2 tools
+	if len(deserializedTools) != 2 {
+		t.Fatalf("Expected 2 tools, got %d", len(deserializedTools))
+	}
+
+	// Verify function tool
+	funcTool := deserializedTools[0]
+	if funcTool.Type != "function" {
+		t.Errorf("Expected first tool type to be 'function', got '%s'", funcTool.Type)
+	}
+	if funcTool.Function.Name != "get_weather" {
+		t.Errorf("Expected function name to be 'get_weather', got '%s'", funcTool.Function.Name)
+	}
+	if funcTool.ServerLabel != "" {
+		t.Error("Function tool should not have server_label")
+	}
+
+	// Verify MCP tool
+	mcpTool := deserializedTools[1]
+	if mcpTool.Type != "mcp" {
+		t.Errorf("Expected second tool type to be 'mcp', got '%s'", mcpTool.Type)
+	}
+	if mcpTool.ServerLabel != "deepwiki" {
+		t.Errorf("Expected server_label to be 'deepwiki', got '%s'", mcpTool.ServerLabel)
+	}
+	if mcpTool.Function.Name != "" {
+		t.Error("MCP tool should not have function name")
+	}
+}
+
+// TestMCPToolEdgeCases tests edge cases and validation scenarios for MCP tools
+func TestMCPToolEdgeCases(t *testing.T) {
+	// Test MCP tool with minimal fields
+	minimalMCP := Tool{
+		Type:        "mcp",
+		ServerLabel: "minimal",
+		ServerUrl:   "https://minimal.example.com",
+	}
+
+	jsonData, err := json.Marshal(minimalMCP)
+	if err != nil {
+		t.Fatalf("Failed to marshal minimal MCP tool: %v", err)
+	}
+
+	var result map[string]any
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Check that optional fields are omitted (except function which is always present as empty object)
+	optionalFields := []string{"require_approval", "allowed_tools", "headers", "id"}
+	for _, field := range optionalFields {
+		if _, exists := result[field]; exists {
+			t.Errorf("Field '%s' should be omitted for minimal MCP tool", field)
+		}
+	}
+
+	// Function field should be present but empty for MCP tools
+	if functionField, exists := result["function"]; !exists {
+		t.Error("Function field should be present in JSON")
+	} else {
+		functionMap, ok := functionField.(map[string]any)
+		if !ok {
+			t.Error("Function field should be an object")
+		} else if len(functionMap) > 0 {
+			t.Error("Function field should be empty for minimal MCP tool")
+		}
+	}
+
+	// Test empty headers map is omitted
+	emptyHeadersMCP := Tool{
+		Type:        "mcp",
+		ServerLabel: "test",
+		Headers:     map[string]string{},
+	}
+
+	jsonData, err = json.Marshal(emptyHeadersMCP)
+	if err != nil {
+		t.Fatalf("Failed to marshal MCP tool with empty headers: %v", err)
+	}
+
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if _, exists := result["headers"]; exists {
+		t.Error("Empty headers map should be omitted")
+	}
+
+	// Test empty allowed_tools slice is omitted
+	emptyToolsMCP := Tool{
+		Type:         "mcp",
+		ServerLabel:  "test",
+		AllowedTools: []string{},
+	}
+
+	jsonData, err = json.Marshal(emptyToolsMCP)
+	if err != nil {
+		t.Fatalf("Failed to marshal MCP tool with empty allowed_tools: %v", err)
+	}
+
+	err = json.Unmarshal(jsonData, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if _, exists := result["allowed_tools"]; exists {
+		t.Error("Empty allowed_tools slice should be omitted")
 	}
 }


### PR DESCRIPTION
- [+] feat: add support for MCP tools in the API, including serialization and deserialization for MCP-specific fields
- [+] fix: refactor tool parameter handling to ensure compatibility with both function and MCP tools
- [+] test: add unit tests for MCP tool serialization, deserialization, and response handling
- [+] chore: update tool model to include MCP-specific fields and adjust related tests

This PR Related #115

> [!NOTE]
> Testing may be needed on proxy frontends like Cloudflare. It works locally, but returns a Bad Gateway error on proxies such as Cloudflare.

