### PR TITLE
Improve Grok | xAI Models Support Image Generation

### DIFF
--- a/relay/adaptor/xai/adaptor.go
+++ b/relay/adaptor/xai/adaptor.go
@@ -155,9 +155,9 @@ func (a *Adaptor) handleImageResponse(c *gin.Context, resp *http.Response) (usag
 	openaiResponse := &ImageResponse{
 		Created: helper.GetTimestamp(),
 		Data:    imageDataList,
+		// Note: xAI doesn't provide detailed token usage for image generation.
+		// Setting minimal values to satisfy the interface; zero values should also be acceptable.
 		Usage: ImageUsage{
-			// XAI doesn't provide detailed token usage for image generation
-			// Set minimal values to satisfy the interface
 			TotalTokens:  0,
 			InputTokens:  0,
 			OutputTokens: 0,

--- a/relay/adaptor/xai/adaptor.go
+++ b/relay/adaptor/xai/adaptor.go
@@ -1,20 +1,53 @@
 package xai
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 
-	"github.com/Laisky/errors/v2"
 	"github.com/gin-gonic/gin"
 
+	"github.com/songquanpeng/one-api/common/helper"
 	"github.com/songquanpeng/one-api/relay/adaptor"
 	"github.com/songquanpeng/one-api/relay/adaptor/openai_compatible"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/model"
+	"github.com/songquanpeng/one-api/relay/relaymode"
 )
 
 type Adaptor struct {
 	adaptor.DefaultPricingMethods
+}
+
+// XAI Image Generation Response structures
+type XAIImageData struct {
+	B64Json       string `json:"b64_json,omitempty"`
+	Url           string `json:"url,omitempty"`
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
+}
+
+type XAIImageResponse struct {
+	Created int64          `json:"created"`
+	Data    []XAIImageData `json:"data"`
+}
+
+// OpenAI compatible image response structures
+type ImageData struct {
+	Url           string `json:"url,omitempty"`
+	B64Json       string `json:"b64_json,omitempty"`
+	RevisedPrompt string `json:"revised_prompt,omitempty"`
+}
+
+type ImageUsage struct {
+	TotalTokens  int `json:"total_tokens"`
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type ImageResponse struct {
+	Created int64       `json:"created"`
+	Data    []ImageData `json:"data"`
+	Usage   ImageUsage  `json:"usage"`
 }
 
 // Implement required adaptor interface methods (XAI uses OpenAI-compatible API)
@@ -48,7 +81,22 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 }
 
 func (a *Adaptor) ConvertImageRequest(c *gin.Context, request *model.ImageRequest) (any, error) {
-	return nil, errors.New("xai does not support image generation")
+	// XAI supports image generation with grok-2-image model
+	// The API is OpenAI-compatible, so we can pass the request through with minimal changes
+
+	// Ensure we're using the correct model name for xAI
+	if request.Model == "grok-2-image" {
+		// XAI API uses grok-2-image as the model name
+		request.Model = "grok-2-image"
+	}
+
+	// XAI doesn't support quality, size, or style parameters according to their docs
+	// Remove unsupported parameters
+	request.Quality = ""
+	request.Size = ""
+	request.Style = ""
+
+	return request, nil
 }
 
 func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, request *model.ClaudeRequest) (any, error) {
@@ -61,13 +109,69 @@ func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Read
 }
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
-	// Use the shared OpenAI-compatible response handling
+	// Handle image generation requests differently
+	if meta.Mode == relaymode.ImagesGenerations {
+		return a.handleImageResponse(c, resp, meta)
+	}
+
+	// Use the shared OpenAI-compatible response handling for text completions
 	if meta.IsStream {
 		err, usage = openai_compatible.StreamHandler(c, resp, meta.PromptTokens, meta.ActualModelName)
 	} else {
 		err, usage = openai_compatible.Handler(c, resp, meta.PromptTokens, meta.ActualModelName)
 	}
 	return
+}
+
+// handleImageResponse processes XAI image generation responses and converts them to OpenAI format
+func (a *Adaptor) handleImageResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	// Read the response body
+	responseBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, openai_compatible.ErrorWrapper(readErr, "read_response_body_failed", http.StatusInternalServerError)
+	}
+
+	// Parse the XAI image response
+	var xaiResponse XAIImageResponse
+	if parseErr := json.Unmarshal(responseBody, &xaiResponse); parseErr != nil {
+		return nil, openai_compatible.ErrorWrapper(parseErr, "parse_response_failed", http.StatusInternalServerError)
+	}
+
+	// Convert to OpenAI format
+	var imageDataList []ImageData
+	for _, xaiData := range xaiResponse.Data {
+		imageData := ImageData{
+			B64Json:       xaiData.B64Json,
+			Url:           xaiData.Url,
+			RevisedPrompt: xaiData.RevisedPrompt,
+		}
+		imageDataList = append(imageDataList, imageData)
+	}
+
+	// Create OpenAI compatible response
+	openaiResponse := &ImageResponse{
+		Created: helper.GetTimestamp(),
+		Data:    imageDataList,
+		Usage: ImageUsage{
+			// XAI doesn't provide detailed token usage for image generation
+			// Set minimal values to satisfy the interface
+			TotalTokens:  0,
+			InputTokens:  0,
+			OutputTokens: 0,
+		},
+	}
+
+	// Return the response as JSON
+	c.JSON(http.StatusOK, openaiResponse)
+
+	// Return minimal usage info for billing
+	usage = &model.Usage{
+		PromptTokens:     10, // Estimated tokens for the prompt
+		CompletionTokens: 0,  // Images don't have completion tokens
+		TotalTokens:      10,
+	}
+
+	return usage, nil
 }
 
 func (a *Adaptor) GetModelList() []string {

--- a/relay/adaptor/xai/adaptor.go
+++ b/relay/adaptor/xai/adaptor.go
@@ -111,7 +111,8 @@ func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Read
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
 	// Handle image generation requests differently
 	if meta.Mode == relaymode.ImagesGenerations {
-		return a.handleImageResponse(c, resp, meta)
+		// TODO: Do we need a meta tag to include the actual model name for this image generation?
+		return a.handleImageResponse(c, resp)
 	}
 
 	// Use the shared OpenAI-compatible response handling for text completions
@@ -124,7 +125,7 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Met
 }
 
 // handleImageResponse processes XAI image generation responses and converts them to OpenAI format
-func (a *Adaptor) handleImageResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+func (a *Adaptor) handleImageResponse(c *gin.Context, resp *http.Response) (usage *model.Usage, err *model.ErrorWithStatusCode) {
 	// Always close the upstream body
 	defer resp.Body.Close()
 	// Read the response body

--- a/relay/adaptor/xai/adaptor.go
+++ b/relay/adaptor/xai/adaptor.go
@@ -38,16 +38,9 @@ type ImageData struct {
 	RevisedPrompt string `json:"revised_prompt,omitempty"`
 }
 
-type ImageUsage struct {
-	TotalTokens  int `json:"total_tokens"`
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
-}
-
 type ImageResponse struct {
 	Created int64       `json:"created"`
 	Data    []ImageData `json:"data"`
-	Usage   ImageUsage  `json:"usage"`
 }
 
 // Implement required adaptor interface methods (XAI uses OpenAI-compatible API)
@@ -151,17 +144,11 @@ func (a *Adaptor) handleImageResponse(c *gin.Context, resp *http.Response) (usag
 		imageDataList = append(imageDataList, imageData)
 	}
 
-	// Create OpenAI compatible response
+	// Create OpenAI-compatible response
 	openaiResponse := &ImageResponse{
 		Created: helper.GetTimestamp(),
 		Data:    imageDataList,
-		// Note: xAI doesn't provide detailed token usage for image generation.
-		// Setting minimal values to satisfy the interface; zero values should also be acceptable.
-		Usage: ImageUsage{
-			TotalTokens:  0,
-			InputTokens:  0,
-			OutputTokens: 0,
-		},
+		// Note: The Usage field might be better removed for xAI
 	}
 
 	// Return the response as JSON

--- a/relay/adaptor/xai/adaptor.go
+++ b/relay/adaptor/xai/adaptor.go
@@ -125,6 +125,8 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Met
 
 // handleImageResponse processes XAI image generation responses and converts them to OpenAI format
 func (a *Adaptor) handleImageResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	// Always close the upstream body
+	defer resp.Body.Close()
 	// Read the response body
 	responseBody, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {

--- a/relay/adaptor/xai/adaptor.go
+++ b/relay/adaptor/xai/adaptor.go
@@ -167,13 +167,7 @@ func (a *Adaptor) handleImageResponse(c *gin.Context, resp *http.Response) (usag
 	// Return the response as JSON
 	c.JSON(http.StatusOK, openaiResponse)
 
-	// Return minimal usage info for billing
-	usage = &model.Usage{
-		PromptTokens:     10, // Estimated tokens for the prompt
-		CompletionTokens: 0,  // Images don't have completion tokens
-		TotalTokens:      10,
-	}
-
+	// Per-image billing is handled by the controller; no token usage to return.
 	return usage, nil
 }
 

--- a/relay/adaptor/xai/constants.go
+++ b/relay/adaptor/xai/constants.go
@@ -20,6 +20,7 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 
 	// Image generation model (no per-token charge)
 	"grok-2-image-1212": {Ratio: 0, CompletionRatio: 1.0, ImagePriceUsd: 0.07}, // $0.07 per image
+	"grok-2-image":      {Ratio: 0, CompletionRatio: 1.0, ImagePriceUsd: 0.07}, // $0.07 per image
 
 	// Legacy aliases for backward compatibility
 	"grok-beta":        {Ratio: 2.0 * ratio.MilliTokensUsd, CompletionRatio: 5.0}, // Updated to match grok-2-1212

--- a/relay/billing/ratio/image.go
+++ b/relay/billing/ratio/image.go
@@ -43,6 +43,12 @@ var ImageSizeRatios = map[string]map[string]float64{
 		"1280x800":  1,
 		"800x1280":  1,
 	},
+	"grok-2-image": {
+		"1024x1024": 1, // Standard size for Grok-2 image generation
+	},
+	"grok-2-image-1212": {
+		"1024x1024": 1, // Standard size for Grok-2 image generation
+	},
 }
 
 var ImageGenerationAmounts = map[string][2]int{
@@ -54,6 +60,8 @@ var ImageGenerationAmounts = map[string][2]int{
 	"wanx-v1":                   {1, 4}, // Ali
 	"cogview-3":                 {1, 1},
 	"step-1x-medium":            {1, 1},
+	"grok-2-image":              {1, 10}, // Grok-2 supports 1-10 images per xAI docs
+	"grok-2-image-1212":         {1, 10}, // Grok-2 supports 1-10 images per xAI docs
 }
 
 var ImagePromptLengthLimitations = map[string]int{
@@ -65,6 +73,8 @@ var ImagePromptLengthLimitations = map[string]int{
 	"wanx-v1":                   4000,
 	"cogview-3":                 833,
 	"step-1x-medium":            4000,
+	"grok-2-image":              4000, // Grok-2 supports long prompts similar to other modern models
+	"grok-2-image-1212":         4000, // Grok-2 supports long prompts similar to other modern models
 }
 
 var ImageOriginModelName = map[string]string{
@@ -163,6 +173,17 @@ var ImageTierTables = map[string]map[string]map[string]float64{
 			"1024x1024": 1,
 			"1280x800":  1,
 			"800x1280":  1,
+		},
+	},
+	// Grok-2 Image: simple default tier (no quality variations since xAI doesn't support quality parameter)
+	"grok-2-image": {
+		"default": {
+			"1024x1024": 1, // Base pricing for Grok-2 image generation
+		},
+	},
+	"grok-2-image-1212": {
+		"default": {
+			"1024x1024": 1, // Base pricing for Grok-2 image generation
 		},
 	},
 }

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -66,7 +66,7 @@ func getImageRequest(c *gin.Context, _ int) (*relaymodel.ImageRequest, error) {
 			// OpenAI only supports 'standard' and 'hd' for DALL·E 3; 'auto' is invalid
 			imageRequest.Quality = "standard"
 		case "gpt-image-1":
-			imageRequest.Quality = "standard"
+			imageRequest.Quality = "high"
 		case "grok-2-image", "grok-2-image-1212":
 			imageRequest.Quality = "standard" // Default quality for Grok-2 image generation
 		}

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -50,9 +50,10 @@ func getImageRequest(c *gin.Context, _ int) (*relaymodel.ImageRequest, error) {
 			imageRequest.Size = "1024x1024"
 		case "gpt-image-1":
 			imageRequest.Size = "1024x1536"
+		case "grok-2-image", "grok-2-image-1212":
+			imageRequest.Size = "1024x1024" // Default size for Grok-2 image generation
 		}
 	}
-
 	if imageRequest.Model == "" {
 		imageRequest.Model = "dall-e-2"
 	}
@@ -65,10 +66,11 @@ func getImageRequest(c *gin.Context, _ int) (*relaymodel.ImageRequest, error) {
 			// OpenAI only supports 'standard' and 'hd' for DALL·E 3; 'auto' is invalid
 			imageRequest.Quality = "standard"
 		case "gpt-image-1":
-			imageRequest.Quality = "high"
+			imageRequest.Quality = "standard"
+		case "grok-2-image", "grok-2-image-1212":
+			imageRequest.Quality = "standard" // Default quality for Grok-2 image generation
 		}
 	}
-
 	if imageRequest.Model == "gpt-image-1" {
 		imageRequest.ResponseFormat = nil
 	}
@@ -268,7 +270,8 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	case channeltype.Zhipu,
 		channeltype.Ali,
 		channeltype.VertextAI,
-		channeltype.Baidu:
+		channeltype.Baidu,
+		channeltype.XAI:
 		finalRequest, err := adaptor.ConvertImageRequest(c, imageRequest)
 		if err != nil {
 			return openai.ErrorWrapper(err, "convert_image_request_failed", http.StatusInternalServerError)


### PR DESCRIPTION
- [+] feat(xai): implement support for grok-2-image model in image generation requests
- [+] feat(xai): add handling for XAI image generation responses and convert them to OpenAI format
- [+] fix(constants): add grok-2-image model configuration for pricing and usage
- [+] fix(image): set default size and quality for grok-2-image in image requests
- [+] fix(image): update image generation amounts and prompt length limitations for grok-2-image

This PR Related #132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added OpenAI-compatible image generation via xAI, including grok-2-image and grok-2-image-1212.
  - Image responses now return in OpenAI ImageResponse format with basic usage info.
  - Supports 1–10 images per request and up to 4000-token prompts for Grok-2 image models.

- Behavior Changes
  - /v1/messages chat requests are routed compatibly with OpenAI chat endpoints.
  - grok-2-image requests strip unsupported image parameters so generation proceeds.
  - Default size set to 1024x1024 and quality to standard for Grok-2 models when unspecified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->