### PR TITLE
Update AWS Bedrock for Llama

### DIFF
--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -144,8 +144,27 @@ func (a *Adaptor) GetDefaultModelPricing() map[string]adaptor.ModelConfig {
 		"claude-sonnet-4-20250514":   {Ratio: 3 * MilliTokensUsd, CompletionRatio: 5},       // $3/$15 per 1M tokens
 
 		// Llama Models on AWS Bedrock
-		"llama3-8b-8192":  {Ratio: 0.3 * MilliTokensUsd, CompletionRatio: 2},  // $0.3/$0.6 per 1M tokens
-		"llama3-70b-8192": {Ratio: 2.65 * MilliTokensUsd, CompletionRatio: 1}, // $2.65/$2.65 per 1M tokens
+		// Note: Pricing may need to be updated later; also this model is significantly faster on AWS GPUs.
+		// Llama 4 models
+		"llama4-maverick-17b-1m": {Ratio: 0.24 * MilliTokensUsd, CompletionRatio: 4.04}, // $0.00024/$0.00097 per 1K tokens
+		"llama4-scout-17b-3.5m":  {Ratio: 0.17 * MilliTokensUsd, CompletionRatio: 3.88}, // $0.00017/$0.00066 per 1K tokens
+
+		// Llama 3.3 models
+		"llama3-3-70b-128k": {Ratio: 0.72 * MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens
+
+		// Llama 3.2 models
+		"llama3-2-1b-131k":         {Ratio: 0.1 * MilliTokensUsd, CompletionRatio: 1},  // $0.0001/$0.0001 per 1K tokens
+		"llama3-2-3b-131k":         {Ratio: 0.15 * MilliTokensUsd, CompletionRatio: 1}, // $0.00015/$0.00015 per 1K tokens
+		"llama3-2-11b-vision-131k": {Ratio: 0.16 * MilliTokensUsd, CompletionRatio: 1}, // $0.00016/$0.00016 per 1K tokens
+		"llama3-2-90b-128k":        {Ratio: 0.72 * MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens
+
+		// Llama 3.1 models
+		"llama3-1-8b-128k":  {Ratio: 0.22 * MilliTokensUsd, CompletionRatio: 1}, // $0.00022/$0.00022 per 1K tokens
+		"llama3-1-70b-128k": {Ratio: 0.72 * MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens
+
+		// Llama 3 models (updated pricing)
+		"llama3-8b-8192":  {Ratio: 0.3 * MilliTokensUsd, CompletionRatio: 2},     // $0.0003/$0.0006 per 1K tokens
+		"llama3-70b-8192": {Ratio: 2.65 * MilliTokensUsd, CompletionRatio: 1.32}, // $0.00265/$0.0035 per 1K tokens
 
 		// Amazon Nova Models (if supported)
 		"amazon-nova-micro":   {Ratio: 0.035 * MilliTokensUsd, CompletionRatio: 4.28}, // $0.035/$0.15 per 1M tokens

--- a/relay/adaptor/aws/llama3/main_test.go
+++ b/relay/adaptor/aws/llama3/main_test.go
@@ -16,9 +16,14 @@ func TestRenderPrompt(t *testing.T) {
 			Content: "What's your name?",
 		},
 	}
-	prompt := aws.RenderPrompt(messages)
-	expected := `<|begin_of_text|><|start_header_id|>user<|end_header_id|>What's your name?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
-`
+	// Test with legacy model (Llama 3) - should use <|eot_id|>
+	prompt := aws.RenderPrompt(messages, "llama3-8b-8192")
+	expected := `<|begin_of_text|><|start_header_id|>user<|end_header_id|>What's your name?<|eot_id|><|start_header_id|>assistant<|end_header_id|>`
+	require.Equal(t, expected, prompt)
+
+	// Test with Llama 4 model - should use <|eot|>
+	prompt = aws.RenderPrompt(messages, "llama4-scout-17b-3.5m")
+	expected = `<|begin_of_text|><|start_header_id|>user<|end_header_id|>What's your name?<|eot|><|start_header_id|>assistant<|end_header_id|>`
 	require.Equal(t, expected, prompt)
 
 	messages = []relaymodel.Message{
@@ -39,8 +44,13 @@ func TestRenderPrompt(t *testing.T) {
 			Content: "What's your job?",
 		},
 	}
-	prompt = aws.RenderPrompt(messages)
-	expected = `<|begin_of_text|><|start_header_id|>system<|end_header_id|>Your name is Kat. You are a detective.<|eot_id|><|start_header_id|>user<|end_header_id|>What's your name?<|eot_id|><|start_header_id|>assistant<|end_header_id|>Kat<|eot_id|><|start_header_id|>user<|end_header_id|>What's your job?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
-`
+	// Test multi-message with legacy model
+	prompt = aws.RenderPrompt(messages, "llama3-70b-8192")
+	expected = `<|begin_of_text|><|start_header_id|>system<|end_header_id|>Your name is Kat. You are a detective.<|eot_id|><|start_header_id|>user<|end_header_id|>What's your name?<|eot_id|><|start_header_id|>assistant<|end_header_id|>Kat<|eot_id|><|start_header_id|>user<|end_header_id|>What's your job?<|eot_id|><|start_header_id|>assistant<|end_header_id|>`
+	require.Equal(t, expected, prompt)
+
+	// Test multi-message with Llama 4 model
+	prompt = aws.RenderPrompt(messages, "llama4-maverick-17b-1m")
+	expected = `<|begin_of_text|><|start_header_id|>system<|end_header_id|>Your name is Kat. You are a detective.<|eot|><|start_header_id|>user<|end_header_id|>What's your name?<|eot|><|start_header_id|>assistant<|end_header_id|>Kat<|eot|><|start_header_id|>user<|end_header_id|>What's your job?<|eot|><|start_header_id|>assistant<|end_header_id|>`
 	require.Equal(t, expected, prompt)
 }


### PR DESCRIPTION
- [+] feat(adaptors/aws): support for Llama 3.1, 3.2, 3.3 and 4 models

This PR Related #136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a broader set of AWS Bedrock Llama models, including Llama 3.1, 3.2, 3.3, and Llama 4 variants.
  - Model-aware prompt formatting ensures correct behavior across legacy Llama 3.x and Llama 4 models for more reliable responses.
  - Refreshed pricing data for supported models to improve cost estimates and transparency when using AWS Bedrock.
- Tests
  - Expanded tests to validate model-specific prompt rendering and behavior across legacy and Llama 4 models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->