### PR TITLE
feat: replace vite's file hash algorithm

### DIFF
--- a/web/modern/vite.config.ts
+++ b/web/modern/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig(({ mode }) => ({
           const assetContent = assetInfo.name || 'asset'
           const contentHash = generateContentHash(assetContent)
           const extension = assetInfo.name?.split('.').pop() || 'asset'
-          return `${contentHash}.${extension}`
+          return `[name].${contentHash}.${extension}`
         },
         manualChunks: {
           vendor: ['react', 'react-dom'],

--- a/web/modern/vite.config.ts
+++ b/web/modern/vite.config.ts
@@ -6,11 +6,14 @@ import { fileURLToPath } from 'node:url'
 import { createHash } from 'node:crypto'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-// Helper function to generate short SHA256 hash from chunk content
+// Helper function to generate short SHA256 hash from chunk content with date and time
 //
 // This is a better approach than using the default hash provided by Vite (I'm not sure what algorithm they use).
+// Now includes date and time for dynamic file naming and better cache busting.
 function generateContentHash(content: string): string {
-  return createHash('sha256').update(content).digest('hex').substring(0, 8)
+  const currentDateTime = new Date().toISOString() // Full ISO timestamp format (YYYY-MM-DDTHH:mm:ss.sssZ)
+  const contentWithDateTime = `${content}-${currentDateTime}`
+  return createHash('sha256').update(contentWithDateTime).digest('hex').substring(0, 8)
 }
 
 export default defineConfig(({ mode }) => ({


### PR DESCRIPTION
- [+] feat(vite.config.ts): implement custom SHA256 content hashing for chunk, entry, and asset filenames

This PR Related #145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Build output now uses content-based hashing for bundles and assets to improve cache busting and CDN/browser caching behavior.
  - JavaScript entry and chunk files adopt concise 8‑character digest suffixes (e.g., [name].<8-char-digest>.js) so filenames change only when content changes.
  - Static assets use digest-based filenames (<digest>.<ext>) for reliable cache invalidation and shorter, readable names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->