### PR TITLE
Change Llama Method in AWS Bedrock

### DIFF
--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/songquanpeng/one-api/relay/adaptor"
 	anthropicAdaptor "github.com/songquanpeng/one-api/relay/adaptor/anthropic"
 	"github.com/songquanpeng/one-api/relay/adaptor/aws/utils"
+	"github.com/songquanpeng/one-api/relay/billing/ratio"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/model"
 )
@@ -145,26 +146,26 @@ func (a *Adaptor) GetDefaultModelPricing() map[string]adaptor.ModelConfig {
 
 		// Llama Models on AWS Bedrock
 		// Note: Pricing may need to be updated later; also this model is significantly faster on AWS GPUs.
-		// Llama 4 models
-		"llama4-maverick-17b-1m": {Ratio: 0.24 * MilliTokensUsd, CompletionRatio: 4.04}, // $0.00024/$0.00097 per 1K tokens
-		"llama4-scout-17b-3.5m":  {Ratio: 0.17 * MilliTokensUsd, CompletionRatio: 3.88}, // $0.00017/$0.00066 per 1K tokens
+		// Llama 4 models - Note: These are per 1K tokens, converted to 1M tokens using MilliTokensUsd
+		"llama4-maverick-17b-1m": {Ratio: 0.24 * ratio.MilliTokensUsd, CompletionRatio: 4.04}, // $0.00024/$0.00097 per 1K tokens = $0.24/$0.97 per 1M tokens
+		"llama4-scout-17b-3.5m":  {Ratio: 0.17 * ratio.MilliTokensUsd, CompletionRatio: 3.88}, // $0.00017/$0.00066 per 1K tokens = $0.17/$0.66 per 1M tokens
 
-		// Llama 3.3 models
-		"llama3-3-70b-128k": {Ratio: 0.72 * MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens
+		// Llama 3.3 models - Note: These are per 1K tokens, converted to 1M tokens using MilliTokensUsd
+		"llama3-3-70b-128k": {Ratio: 0.72 * ratio.MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens = $0.72/$0.72 per 1M tokens
 
-		// Llama 3.2 models
-		"llama3-2-1b-131k":         {Ratio: 0.1 * MilliTokensUsd, CompletionRatio: 1},  // $0.0001/$0.0001 per 1K tokens
-		"llama3-2-3b-131k":         {Ratio: 0.15 * MilliTokensUsd, CompletionRatio: 1}, // $0.00015/$0.00015 per 1K tokens
-		"llama3-2-11b-vision-131k": {Ratio: 0.16 * MilliTokensUsd, CompletionRatio: 1}, // $0.00016/$0.00016 per 1K tokens
-		"llama3-2-90b-128k":        {Ratio: 0.72 * MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens
+		// Llama 3.2 models - Note: These are per 1K tokens, converted to 1M tokens using MilliTokensUsd
+		"llama3-2-1b-131k":         {Ratio: 0.1 * ratio.MilliTokensUsd, CompletionRatio: 1},  // $0.0001/$0.0001 per 1K tokens = $0.1/$0.1 per 1M tokens
+		"llama3-2-3b-131k":         {Ratio: 0.15 * ratio.MilliTokensUsd, CompletionRatio: 1}, // $0.00015/$0.00015 per 1K tokens = $0.15/$0.15 per 1M tokens
+		"llama3-2-11b-vision-131k": {Ratio: 0.16 * ratio.MilliTokensUsd, CompletionRatio: 1}, // $0.00016/$0.00016 per 1K tokens = $0.16/$0.16 per 1M tokens
+		"llama3-2-90b-128k":        {Ratio: 0.72 * ratio.MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens = $0.72/$0.72 per 1M tokens
 
-		// Llama 3.1 models
-		"llama3-1-8b-128k":  {Ratio: 0.22 * MilliTokensUsd, CompletionRatio: 1}, // $0.00022/$0.00022 per 1K tokens
-		"llama3-1-70b-128k": {Ratio: 0.72 * MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens
+		// Llama 3.1 models - Note: These are per 1K tokens, converted to 1M tokens using MilliTokensUsd
+		"llama3-1-8b-128k":  {Ratio: 0.22 * ratio.MilliTokensUsd, CompletionRatio: 1}, // $0.00022/$0.00022 per 1K tokens = $0.22/$0.22 per 1M tokens
+		"llama3-1-70b-128k": {Ratio: 0.72 * ratio.MilliTokensUsd, CompletionRatio: 1}, // $0.00072/$0.00072 per 1K tokens = $0.72/$0.72 per 1M tokens
 
-		// Llama 3 models (updated pricing)
-		"llama3-8b-8192":  {Ratio: 0.3 * MilliTokensUsd, CompletionRatio: 2},     // $0.0003/$0.0006 per 1K tokens
-		"llama3-70b-8192": {Ratio: 2.65 * MilliTokensUsd, CompletionRatio: 1.32}, // $0.00265/$0.0035 per 1K tokens
+		// Llama 3 models - Note: These are per 1K tokens, converted to 1M tokens using MilliTokensUsd
+		"llama3-8b-8192":  {Ratio: 0.3 * ratio.MilliTokensUsd, CompletionRatio: 2},     // $0.0003/$0.0006 per 1K tokens = $0.3/$0.6 per 1M tokens
+		"llama3-70b-8192": {Ratio: 2.65 * ratio.MilliTokensUsd, CompletionRatio: 1.32}, // $0.00265/$0.0035 per 1K tokens = $2.65/$3.5 per 1M tokens
 
 		// Amazon Nova Models (if supported)
 		"amazon-nova-micro":   {Ratio: 0.035 * MilliTokensUsd, CompletionRatio: 4.28}, // $0.035/$0.15 per 1M tokens

--- a/relay/adaptor/aws/llama3/main_test.go
+++ b/relay/adaptor/aws/llama3/main_test.go
@@ -9,48 +9,62 @@ import (
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 )
 
-func TestRenderPrompt(t *testing.T) {
-	messages := []relaymodel.Message{
-		{
-			Role:    "user",
-			Content: "What's your name?",
+func TestConvertRequest(t *testing.T) {
+	// Test basic message conversion
+	openaiReq := relaymodel.GeneralOpenAIRequest{
+		Messages: []relaymodel.Message{
+			{
+				Role:    "user",
+				Content: "What's your name?",
+			},
 		},
+		MaxTokens:   100,
+		Temperature: &[]float64{0.7}[0],
+		TopP:        &[]float64{0.9}[0],
+		Stop:        []string{"stop1", "stop2"},
 	}
-	// Test with legacy model (Llama 3) - should use <|eot_id|>
-	prompt := aws.RenderPrompt(messages, "llama3-8b-8192")
-	expected := `<|begin_of_text|><|start_header_id|>user<|end_header_id|>What's your name?<|eot_id|><|start_header_id|>assistant<|end_header_id|>`
-	require.Equal(t, expected, prompt)
 
-	// Test with Llama 4 model - should use <|eot|>
-	prompt = aws.RenderPrompt(messages, "llama4-scout-17b-3.5m")
-	expected = `<|begin_of_text|><|start_header_id|>user<|end_header_id|>What's your name?<|eot|><|start_header_id|>assistant<|end_header_id|>`
-	require.Equal(t, expected, prompt)
+	llamaReq := aws.ConvertRequest(openaiReq)
 
-	messages = []relaymodel.Message{
-		{
-			Role:    "system",
-			Content: "Your name is Kat. You are a detective.",
+	require.NotNil(t, llamaReq)
+	require.Equal(t, 1, len(llamaReq.Messages))
+	require.Equal(t, "user", llamaReq.Messages[0].Role)
+	require.Equal(t, "What's your name?", llamaReq.Messages[0].Content)
+	require.Equal(t, 100, llamaReq.MaxTokens)
+	require.Equal(t, 0.7, *llamaReq.Temperature)
+	require.Equal(t, 0.9, *llamaReq.TopP)
+	require.Equal(t, []string{"stop1", "stop2"}, llamaReq.Stop)
+
+	// Test multi-message conversation
+	multiMessageReq := relaymodel.GeneralOpenAIRequest{
+		Messages: []relaymodel.Message{
+			{
+				Role:    "system",
+				Content: "Your name is L. You are a detective.",
+			},
+			{
+				Role:    "user",
+				Content: "What's your name?",
+			},
+			{
+				Role:    "assistant",
+				Content: "L",
+			},
+			{
+				Role:    "user",
+				Content: "What's your job?",
+			},
 		},
-		{
-			Role:    "user",
-			Content: "What's your name?",
-		},
-		{
-			Role:    "assistant",
-			Content: "Kat",
-		},
-		{
-			Role:    "user",
-			Content: "What's your job?",
-		},
+		MaxTokens: 0, // Should use default
 	}
-	// Test multi-message with legacy model
-	prompt = aws.RenderPrompt(messages, "llama3-70b-8192")
-	expected = `<|begin_of_text|><|start_header_id|>system<|end_header_id|>Your name is Kat. You are a detective.<|eot_id|><|start_header_id|>user<|end_header_id|>What's your name?<|eot_id|><|start_header_id|>assistant<|end_header_id|>Kat<|eot_id|><|start_header_id|>user<|end_header_id|>What's your job?<|eot_id|><|start_header_id|>assistant<|end_header_id|>`
-	require.Equal(t, expected, prompt)
 
-	// Test multi-message with Llama 4 model
-	prompt = aws.RenderPrompt(messages, "llama4-maverick-17b-1m")
-	expected = `<|begin_of_text|><|start_header_id|>system<|end_header_id|>Your name is Kat. You are a detective.<|eot|><|start_header_id|>user<|end_header_id|>What's your name?<|eot|><|start_header_id|>assistant<|end_header_id|>Kat<|eot|><|start_header_id|>user<|end_header_id|>What's your job?<|eot|><|start_header_id|>assistant<|end_header_id|>`
-	require.Equal(t, expected, prompt)
+	llamaReq = aws.ConvertRequest(multiMessageReq)
+
+	require.NotNil(t, llamaReq)
+	require.Equal(t, 4, len(llamaReq.Messages))
+	require.Equal(t, "system", llamaReq.Messages[0].Role)
+	require.Equal(t, "user", llamaReq.Messages[1].Role)
+	require.Equal(t, "assistant", llamaReq.Messages[2].Role)
+	require.Equal(t, "user", llamaReq.Messages[3].Role)
+	require.True(t, llamaReq.MaxTokens > 0) // Should use default config value
 }

--- a/relay/adaptor/aws/llama3/model.go
+++ b/relay/adaptor/aws/llama3/model.go
@@ -1,29 +1,39 @@
 package aws
 
-// Request is the request to AWS Llama3
-//
-// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
+import (
+	relaymodel "github.com/songquanpeng/one-api/relay/model"
+)
+
+// Request is the request for AWS Llama3 using Converse API
 type Request struct {
-	Prompt      string   `json:"prompt"`
-	MaxGenLen   int      `json:"max_gen_len,omitempty"`
+	// Messages contains the conversation history using the relay model format.
+	// This field is required and must contain at least one message.
+	// Llama models process these messages through AWS Bedrock's Converse API
+	// to generate contextually aware responses with high performance.
+	Messages []relaymodel.Message `json:"messages"`
+
+	// MaxTokens specifies the maximum number of tokens to generate in the response.
+	// Optional field that helps control response length and API costs.
+	// Llama models use this to limit generation while maintaining coherent responses
+	// across different model sizes and conversation contexts.
+	MaxTokens int `json:"max_tokens,omitempty"`
+
+	// Temperature controls the randomness of the model's responses.
+	// Range: 0.0 to 1.0, where 0.0 is deterministic and 1.0 is most random.
+	// Optional field, uses model default if not specified.
+	// Llama models maintain coherence and quality across different temperature values,
+	// making them suitable for both creative and analytical tasks.
 	Temperature *float64 `json:"temperature,omitempty"`
-	TopP        *float64 `json:"top_p,omitempty"`
-}
 
-// Response is the response from AWS Llama3
-//
-// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
-type Response struct {
-	Generation           string `json:"generation"`
-	PromptTokenCount     int    `json:"prompt_token_count"`
-	GenerationTokenCount int    `json:"generation_token_count"`
-	StopReason           string `json:"stop_reason"`
-}
+	// TopP controls nucleus sampling, limiting the cumulative probability of token choices.
+	// Range: 0.0 to 1.0, where lower values make responses more focused.
+	// Optional field, uses model default if not specified.
+	// Optimized for Llama's text generation capabilities and conversation quality.
+	TopP *float64 `json:"top_p,omitempty"`
 
-// {'generation': 'Hi', 'prompt_token_count': 15, 'generation_token_count': 1, 'stop_reason': None}
-type StreamResponse struct {
-	Generation           string `json:"generation"`
-	PromptTokenCount     int    `json:"prompt_token_count"`
-	GenerationTokenCount int    `json:"generation_token_count"`
-	StopReason           string `json:"stop_reason"`
+	// Stop contains custom strings that will stop generation when encountered.
+	// Optional field that allows fine-grained control over response termination.
+	// Useful for controlling when Llama models stop generating in specific contexts,
+	// supporting both conversational and task-specific applications.
+	Stop []string `json:"stop,omitempty"`
 }

--- a/relay/adaptor/aws/llama3/model.go
+++ b/relay/adaptor/aws/llama3/model.go
@@ -4,7 +4,7 @@ import (
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 )
 
-// Request is the request for AWS Llama3 using Converse API
+// Request is the request for AWS Llama using Converse API
 type Request struct {
 	// Messages contains the conversation history using the relay model format.
 	// This field is required and must contain at least one message.


### PR DESCRIPTION
- [+] feat(aws): add Converse API support for Llama models
- [+] feat(aws): add Handler and StreamHandler functions for Converse API
- [+] feat(aws): add ConvertRequest function to convert OpenAI requests to Converse API format
- [+] feat(aws): add test cases for ConvertRequest function
- [+] feat(aws): remove legacy prompt template and related functions
- [+] feat(aws): update Request and Response types for Converse API
- [+] feat(aws): add Stop field to Request type for custom stop sequences
- [+] feat(aws): add inference configuration fields to Request type
- [+] feat(aws): update Handler function to use Converse API
- [+] feat(aws): update StreamHandler function to use ConverseStream API
- [+] feat(aws): add convertConverseResponseToOpenAI function to convert Converse responses to OpenAI format
- [+] feat(aws): add convertStopReason function to convert stop reasons to OpenAI format
- [+] feat(aws): update StreamHandler to use ConverseStream API and new helper functions
- [+] feat(aws): update test cases for StreamHandler function


This PR Related #151.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Conversation-based requests with multi-message support and OpenAI-compatible streaming payloads including model attribution and finish reasons.

- Improvements
  - Unified streaming and non-streaming flow using the same conversation path.
  - Controls for max tokens (with sensible default), temperature, top_p, and stop sequences.
  - More accurate usage/token reporting and trace-based stable chat IDs.
  - Pricing constant references updated for several models.

- Bug Fixes
  - Reduced streaming buffering via improved HTTP streaming headers.

- Tests
  - Updated tests to validate conversion and message-order preservation for multi-message requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->