### PR TITLE
Enhance AWS Bedrock Validator

### DIFF
--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -117,7 +117,7 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, request *model.ImageReques
 	}
 	a.awsAdapter = adaptor
 
-	// Store the image request in context for the Titan adapter to use later
+	// Store the image request in context for the Titan or Canvas adapter to use later
 	c.Set("imageRequest", *request)
 	c.Set(ctxkey.RequestModel, request.Model)
 


### PR DESCRIPTION
- [+] feat(adaptor.go): add support for per-model capabilities
- [+] fix(adaptor.go): pass context to ConvertImageRequest
- [+] fix(adaptor.go): update GetModelCapabilities to use model registry
- [+] feat(adaptor.go): add support for stop parameter in Llama and Mistral models
- [+] fix(adaptor.go): update ValidateUnsupportedParameters to check for stop support


This PR Related #156.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added stop-sequence support for select models (e.g., Llama, Mistral); providers now expose stop capability.

- Bug Fixes
  - Clear validation and explicit error when using stop with models that don’t support it (e.g., Claude), avoiding silent ignores.

- Refactor
  - Unified image generation request handling for more consistent behavior and reliability across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->