### PR TITLE
Improve Models Page for Modern Theme

### DIFF
--- a/web/modern/src/pages/models/ModelsPage.tsx
+++ b/web/modern/src/pages/models/ModelsPage.tsx
@@ -105,6 +105,14 @@ export function ModelsPage() {
     return maxTokens.toString()
   }
 
+  const formatChannelName = (channelName: string): string => {
+    const colonIndex = channelName.indexOf(':')
+    if (colonIndex !== -1) {
+      return channelName.substring(colonIndex + 1)
+    }
+    return channelName
+  }
+
   const toggleChannelFilter = (channelName: string) => {
     if (selectedChannels.includes(channelName)) {
       setSelectedChannels(selectedChannels.filter(ch => ch !== channelName))
@@ -131,7 +139,7 @@ export function ModelsPage() {
       <Card key={channelName} className="mb-6">
         <CardHeader>
           <CardTitle className="text-lg">
-            {channelName} ({models.length} models)
+            {formatChannelName(channelName)} ({models.length} models)
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -210,7 +218,7 @@ export function ModelsPage() {
                     className="cursor-pointer"
                     onClick={() => toggleChannelFilter(channelName)}
                   >
-                    {channelName} ({Object.keys(modelsData[channelName].models).length})
+                    {formatChannelName(channelName)} ({Object.keys(modelsData[channelName].models).length})
                   </Badge>
                 ))}
               </div>


### PR DESCRIPTION
- [+] fix(ModelsPage.tsx): change channel name formatting to display only the part after the colon

This PR Related #161.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability of channel labels on the Models page by removing technical prefixes before the first colon.
  * Updated channel names in card titles and filter badges to display cleaner, user-friendly labels.
  * Visual-only change; no impact on filtering, data, or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->