### PR TITLE
Fix Endpoint "v1/messages" crashes on AWS Bedrock Claude

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -244,6 +244,11 @@ func testChannel(ctx context.Context, channel *model.Channel, request *relaymode
 		return "", errors.Wrap(err, "failed to do request"), nil
 	}
 
+	// Handle nil response (e.g., AWS Bedrock uses SDK directly, not HTTP)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
 	if resp != nil && resp.StatusCode != http.StatusOK {
 		// Use context-aware error handler to capture and log upstream error response
 		wrappedErr := controller.RelayErrorHandlerWithContext(c, resp)

--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -135,6 +135,12 @@ func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, request *model.ClaudeRequ
 		return nil, errors.New("request is nil")
 	}
 
+	// Check if this model supports Claude Messages API (v1/messages)
+	// Only Claude models should use this endpoint; other models should use v1/chat/completions
+	if !IsClaudeModel(request.Model) {
+		return nil, errors.Errorf("model '%s' does not support the v1/messages endpoint. Please use v1/chat/completions instead", request.Model)
+	}
+
 	// AWS Bedrock supports Claude Messages natively. Do not convert payload.
 	// Just set context for billing/routing and mark direct pass-through.
 	sub := GetAdaptor(request.Model)

--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -157,6 +157,15 @@ func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, request *model.ClaudeRequ
 }
 
 func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Reader) (*http.Response, error) {
+	// AWS Bedrock doesn't use HTTP requests - it uses the AWS SDK directly
+	// For Claude Messages API, we should return nil to indicate DoResponse should handle everything
+	// But we need to ensure the controller doesn't try to access a nil response
+	if a.awsAdapter == nil {
+		return nil, errors.New("AWS sub-adapter not initialized")
+	}
+
+	// For AWS Bedrock, we don't make HTTP requests - we use the AWS SDK directly
+	// Return nil response to indicate DoResponse should handle the entire flow
 	return nil, nil
 }
 

--- a/relay/adaptor/aws/claude/adapter.go
+++ b/relay/adaptor/aws/claude/adapter.go
@@ -39,6 +39,27 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	return claudeReq, nil
 }
 
+func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, request *model.ClaudeRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+
+	// AWS Bedrock supports Claude Messages natively. Do not convert payload.
+	// Just set context for billing/routing and mark direct pass-through.
+	c.Set(ctxkey.ClaudeMessagesNative, true)
+	c.Set(ctxkey.ClaudeDirectPassthrough, true)
+	c.Set(ctxkey.OriginalClaudeRequest, request)
+	c.Set(ctxkey.RequestModel, request.Model)
+	// Also parse into anthropic.Request for AWS SDK payload building
+	if parsed, perr := anthropic.ConvertClaudeRequest(c, *request); perr == nil {
+		c.Set(ctxkey.ConvertedRequest, parsed)
+	} else {
+		return nil, perr
+	}
+	// Return the original request object; controller will forward original body
+	return request, nil
+}
+
 func (a *Adaptor) DoResponse(c *gin.Context, awsCli *bedrockruntime.Client, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
 	if meta.IsStream {
 		err, usage = StreamHandler(c, awsCli)

--- a/relay/adaptor/aws/registry.go
+++ b/relay/adaptor/aws/registry.go
@@ -89,7 +89,8 @@ func GetAdaptor(model string) utils.AwsAdapter {
 // IsClaudeModel checks if the given model is a Claude model that supports v1/messages endpoint
 func IsClaudeModel(model string) bool {
 	adaptorType := adaptors[model]
-	if awsArnMatch.MatchString(model) {
+	// Suggested by CodeRabbitAI
+	if awsArnMatch != nil && awsArnMatch.MatchString(model) {
 		adaptorType = AwsClaude
 	}
 	return adaptorType == AwsClaude

--- a/relay/adaptor/aws/registry.go
+++ b/relay/adaptor/aws/registry.go
@@ -85,3 +85,12 @@ func GetAdaptor(model string) utils.AwsAdapter {
 		return nil
 	}
 }
+
+// IsClaudeModel checks if the given model is a Claude model that supports v1/messages endpoint
+func IsClaudeModel(model string) bool {
+	adaptorType := adaptors[model]
+	if awsArnMatch.MatchString(model) {
+		adaptorType = AwsClaude
+	}
+	return adaptorType == AwsClaude
+}

--- a/relay/controller/claude_messages.go
+++ b/relay/controller/claude_messages.go
@@ -159,55 +159,67 @@ func RelayClaudeMessagesHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 
 	if passthrough, ok := c.Get(ctxkey.ClaudeDirectPassthrough); ok && passthrough.(bool) && meta.IsStream {
 		// Streaming direct passthrough: forward Claude SSE events verbatim
-		respErr, usage = anthropic.ClaudeNativeStreamHandler(c, resp)
+		// For AWS Bedrock, resp might be nil since it uses SDK calls
+		if resp != nil {
+			respErr, usage = anthropic.ClaudeNativeStreamHandler(c, resp)
+		} else {
+			// For AWS Bedrock streaming, delegate to adapter's DoResponse
+			usage, respErr = adaptorInstance.DoResponse(c, resp, meta)
+		}
 	} else if passthrough, ok := c.Get(ctxkey.ClaudeDirectPassthrough); ok && passthrough.(bool) && !meta.IsStream {
 		// Non-streaming direct passthrough: copy headers/body exactly as upstream returned
 		// and extract usage for billing from the Claude response
-		body, rerr := io.ReadAll(resp.Body)
-		if rerr != nil {
-			respErr = openai.ErrorWrapper(rerr, "read_upstream_response_failed", http.StatusInternalServerError)
-		} else {
-			// Close upstream body
-			_ = resp.Body.Close()
-
-			// Forward headers
-			for k, v := range resp.Header {
-				if len(v) > 0 {
-					c.Header(k, v[0])
-				}
-			}
-			c.Status(resp.StatusCode)
-			c.Data(resp.StatusCode, resp.Header.Get("Content-Type"), body)
-
-			// Parse usage from Claude native response for billing
-			var claudeResp anthropic.Response
-			if perr := json.Unmarshal(body, &claudeResp); perr == nil {
-				usage = &relaymodel.Usage{
-					PromptTokens:     claudeResp.Usage.InputTokens,
-					CompletionTokens: claudeResp.Usage.OutputTokens,
-					TotalTokens:      claudeResp.Usage.InputTokens + claudeResp.Usage.OutputTokens,
-					ServiceTier:      claudeResp.Usage.ServiceTier,
-				}
-				// Map cached prompt token details
-				if claudeResp.Usage.CacheReadInputTokens > 0 {
-					usage.PromptTokensDetails = &relaymodel.UsagePromptTokensDetails{CachedTokens: claudeResp.Usage.CacheReadInputTokens}
-				}
-				if claudeResp.Usage.CacheCreation != nil {
-					usage.CacheWrite5mTokens = claudeResp.Usage.CacheCreation.Ephemeral5mInputTokens
-					usage.CacheWrite1hTokens = claudeResp.Usage.CacheCreation.Ephemeral1hInputTokens
-				} else if claudeResp.Usage.CacheCreationInputTokens > 0 {
-					// Legacy field: treat as 5m cache write
-					usage.CacheWrite5mTokens = claudeResp.Usage.CacheCreationInputTokens
-				}
+		// For AWS Bedrock, resp might be nil since it uses SDK calls
+		if resp != nil {
+			body, rerr := io.ReadAll(resp.Body)
+			if rerr != nil {
+				respErr = openai.ErrorWrapper(rerr, "read_upstream_response_failed", http.StatusInternalServerError)
 			} else {
-				// Fallback usage on parse error
-				promptTokens := getClaudeMessagesPromptTokens(ctx, claudeRequest)
-				usage = &relaymodel.Usage{
-					PromptTokens:     promptTokens,
-					CompletionTokens: 0,
-					TotalTokens:      promptTokens,
+				// Close upstream body
+				_ = resp.Body.Close()
+
+				// Forward headers
+				for k, v := range resp.Header {
+					if len(v) > 0 {
+						c.Header(k, v[0])
+					}
+				}
+				c.Status(resp.StatusCode)
+				c.Data(resp.StatusCode, resp.Header.Get("Content-Type"), body)
+
+				// Parse usage from Claude native response for billing
+				var claudeResp anthropic.Response
+				if perr := json.Unmarshal(body, &claudeResp); perr == nil {
+					usage = &relaymodel.Usage{
+						PromptTokens:     claudeResp.Usage.InputTokens,
+						CompletionTokens: claudeResp.Usage.OutputTokens,
+						TotalTokens:      claudeResp.Usage.InputTokens + claudeResp.Usage.OutputTokens,
+						ServiceTier:      claudeResp.Usage.ServiceTier,
+					}
+					// Map cached prompt token details
+					if claudeResp.Usage.CacheReadInputTokens > 0 {
+						usage.PromptTokensDetails = &relaymodel.UsagePromptTokensDetails{CachedTokens: claudeResp.Usage.CacheReadInputTokens}
+					}
+					if claudeResp.Usage.CacheCreation != nil {
+						usage.CacheWrite5mTokens = claudeResp.Usage.CacheCreation.Ephemeral5mInputTokens
+						usage.CacheWrite1hTokens = claudeResp.Usage.CacheCreation.Ephemeral1hInputTokens
+					} else if claudeResp.Usage.CacheCreationInputTokens > 0 {
+						// Legacy field: treat as 5m cache write
+						usage.CacheWrite5mTokens = claudeResp.Usage.CacheCreationInputTokens
+					}
+				} else {
+					// Fallback usage on parse error
+					promptTokens := getClaudeMessagesPromptTokens(ctx, claudeRequest)
+					usage = &relaymodel.Usage{
+						PromptTokens:     promptTokens,
+						CompletionTokens: 0,
+						TotalTokens:      promptTokens,
+					}
 				}
 			}
+		} else {
+			// For AWS Bedrock non-streaming, delegate to adapter's DoResponse
+			usage, respErr = adaptorInstance.DoResponse(c, resp, meta)
 		}
 	} else {
 		// Call the adapter's DoResponse method to handle response conversion

--- a/relay/controller/text.go
+++ b/relay/controller/text.go
@@ -96,7 +96,8 @@ func RelayTextHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 		// based on proprietary systems such as OpenAI, etc.
 		switch {
 		case strings.Contains(err.Error(), "validation failed"),
-			strings.Contains(err.Error(), "does not support embedding"):
+			strings.Contains(err.Error(), "does not support embedding"),
+			strings.Contains(err.Error(), "does not support the v1/messages endpoint"):
 			return openai.ErrorWrapper(err, "invalid_request_error", http.StatusBadRequest)
 		default:
 			return openai.ErrorWrapper(err, "convert_request_failed", http.StatusInternalServerError)

--- a/relay/controller/text.go
+++ b/relay/controller/text.go
@@ -96,8 +96,7 @@ func RelayTextHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 		// based on proprietary systems such as OpenAI, etc.
 		switch {
 		case strings.Contains(err.Error(), "validation failed"),
-			strings.Contains(err.Error(), "does not support embedding"),
-			strings.Contains(err.Error(), "does not support the v1/messages endpoint"):
+			strings.Contains(err.Error(), "does not support embedding"):
 			return openai.ErrorWrapper(err, "invalid_request_error", http.StatusBadRequest)
 		default:
 			return openai.ErrorWrapper(err, "convert_request_failed", http.StatusInternalServerError)


### PR DESCRIPTION
- [+] fix(controller): handle nil response in RelayClaudeMessagesHelper
- [+] feat(adaptor): add ConvertClaudeRequest method
- [+] feat(adaptor): add DoRequest method

This PR Related #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct passthrough support for Claude Messages on AWS Bedrock for streaming and non‑streaming flows.

* **Bug Fixes**
  * Ensures Bedrock responses are delegated and processed so response content and usage are reported reliably.
  * Prevents resource leaks by ensuring upstream response bodies are closed.

* **Improvements**
  * Clearer error when using Messages API with non‑Claude models (guides to correct endpoint).
  * Better initialization checks with informative errors when AWS integration isn’t configured.
  * Adds upstream request logging and model-detection support for Claude models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->