### PR TITLE
Support for Attachment Images for Llama on AWS Bedrock

### DIFF
--- a/common/image/image.go
+++ b/common/image/image.go
@@ -200,6 +200,17 @@ func GenerateTextImage(text string) (imageData []byte, mimeType string, err erro
 		imageHeight = 100
 	}
 
+	// Check if the estimated image size would exceed the configured limit
+	// Estimate PNG size: RGBA (4 bytes per pixel) + PNG overhead (~20% compression ratio)
+	estimatedSizeBytes := int64(imageWidth * imageHeight * 4)          // RGBA pixels
+	estimatedSizeBytes = estimatedSizeBytes + (estimatedSizeBytes / 5) // Add ~20% for PNG overhead
+	maxSizeBytes := int64(config.MaxInlineImageSizeMB) * 1024 * 1024
+
+	if estimatedSizeBytes > maxSizeBytes {
+		return nil, "", errors.Errorf("generated image size would exceed %dMB limit: estimated %d bytes for text length %d",
+			config.MaxInlineImageSizeMB, estimatedSizeBytes, len(text))
+	}
+
 	// Create image
 	img := image.NewRGBA(image.Rect(0, 0, imageWidth, imageHeight))
 

--- a/common/image/image.go
+++ b/common/image/image.go
@@ -4,15 +4,22 @@ import (
 	"bytes"
 	"encoding/base64"
 	"image"
+	"image/color"
+	"image/draw"
 	_ "image/gif"
 	_ "image/jpeg"
+	"image/png"
 	_ "image/png"
+	"math"
 	"net/http"
 	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/Laisky/errors/v2"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/basicfont"
+	"golang.org/x/image/math/fixed"
 	_ "golang.org/x/image/webp"
 
 	"github.com/songquanpeng/one-api/common/client"
@@ -154,4 +161,133 @@ func GetImageSize(image string) (width int, height int, err error) {
 		return GetImageSizeFromBase64(image)
 	}
 	return GetImageSizeFromUrl(image)
+}
+
+// GenerateTextImage creates a PNG image with the specified text and returns it as base64 encoded data.
+// This is useful for creating fallback images when image downloads fail, particularly for vision-capable models.
+// The function creates a white background with black text, automatically sizing the image based on the text content.
+func GenerateTextImage(text string) (imageData []byte, mimeType string, err error) {
+	if text == "" {
+		text = "Image not available"
+	}
+
+	// Calculate image dimensions based on text length
+	// Using basic font metrics for sizing
+	charWidth := 8.0   // Approximate character width for basic font
+	charHeight := 16.0 // Approximate character height for basic font
+	padding := 20.0    // Padding around text
+
+	// Calculate text dimensions with word wrapping
+	maxCharsPerLine := 50 // Maximum characters per line
+	lines := wrapText(text, maxCharsPerLine)
+
+	// Calculate image size
+	maxLineWidth := 0
+	for _, line := range lines {
+		if len(line) > maxLineWidth {
+			maxLineWidth = len(line)
+		}
+	}
+
+	imageWidth := int(math.Ceil(float64(maxLineWidth)*charWidth + padding*2))
+	imageHeight := int(math.Ceil(float64(len(lines))*charHeight + padding*2))
+
+	// Ensure minimum size for readability
+	if imageWidth < 200 {
+		imageWidth = 200
+	}
+	if imageHeight < 100 {
+		imageHeight = 100
+	}
+
+	// Create image
+	img := image.NewRGBA(image.Rect(0, 0, imageWidth, imageHeight))
+
+	// Fill with white background
+	white := color.RGBA{255, 255, 255, 255}
+	draw.Draw(img, img.Bounds(), &image.Uniform{white}, image.Point{}, draw.Src)
+
+	// Set up text drawing
+	black := color.RGBA{0, 0, 0, 255}
+	face := basicfont.Face7x13 // Use basic font
+	drawer := &font.Drawer{
+		Dst:  img,
+		Src:  image.NewUniform(black),
+		Face: face,
+	}
+
+	// Draw each line of text
+	lineHeight := int(charHeight)
+	startY := int(padding + charHeight)
+
+	for i, line := range lines {
+		y := startY + i*lineHeight
+		drawer.Dot = fixed.Point26_6{
+			X: fixed.Int26_6(int(padding) * 64),
+			Y: fixed.Int26_6(y * 64),
+		}
+		drawer.DrawString(line)
+	}
+
+	// Encode to PNG
+	var buf bytes.Buffer
+	err = png.Encode(&buf, img)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to encode image to PNG")
+	}
+
+	return buf.Bytes(), "image/png", nil
+}
+
+// GenerateTextImageBase64 creates a PNG image with the specified text and returns it as base64 encoded string.
+// This is a convenience function that wraps GenerateTextImage and returns base64 encoded data.
+func GenerateTextImageBase64(text string) (base64Data string, mimeType string, err error) {
+	imageData, mimeType, err := GenerateTextImage(text)
+	if err != nil {
+		return "", "", err
+	}
+
+	base64Data = base64.StdEncoding.EncodeToString(imageData)
+	return base64Data, mimeType, nil
+}
+
+// wrapText breaks long text into multiple lines for better display
+func wrapText(text string, maxCharsPerLine int) []string {
+	if len(text) <= maxCharsPerLine {
+		return []string{text}
+	}
+
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{text}
+	}
+
+	var lines []string
+	currentLine := ""
+
+	for _, word := range words {
+		// If adding this word would exceed the line length
+		if len(currentLine)+len(word)+1 > maxCharsPerLine && currentLine != "" {
+			lines = append(lines, currentLine)
+			currentLine = word
+		} else {
+			if currentLine == "" {
+				currentLine = word
+			} else {
+				currentLine += " " + word
+			}
+		}
+
+		// Handle very long words by breaking them
+		for len(currentLine) > maxCharsPerLine {
+			lines = append(lines, currentLine[:maxCharsPerLine])
+			currentLine = currentLine[maxCharsPerLine:]
+		}
+	}
+
+	if currentLine != "" {
+		lines = append(lines, currentLine)
+	}
+
+	return lines
 }

--- a/relay/adaptor/aws/llama3/main.go
+++ b/relay/adaptor/aws/llama3/main.go
@@ -146,7 +146,12 @@ func convertLlamaToConverseRequest(c *gin.Context, llamaReq *Request, modelID st
 							imageData, imageFormat, err := utils.DownloadImageFromURL(gmw.Ctx(c), content.ImageURL.Url)
 							if err != nil {
 								// If image download fails, add error as text content to maintain functionality
+								lg := gmw.GetLogger(c)
+								lg.Warn("image download failed", zap.Error(err))
 								contentBlocks = append(contentBlocks, &types.ContentBlockMemberText{
+									// TODO: Consider enhancing this by utilizing a fallback image containing the text "Image download failed",
+									// thereby improving the response for vision-capable models.
+									// For instance, if the fallback image displays the text "Image download failed", the vision model is likely to respond by acknowledging the image download failure.
 									Value: fmt.Sprintf("[Image download failed: %s]", err),
 								})
 							} else {

--- a/relay/adaptor/aws/utils/token.go
+++ b/relay/adaptor/aws/utils/token.go
@@ -24,6 +24,13 @@ const (
 	imageDownloadTimeout = 30 * time.Second
 )
 
+// DownloadImageFromURL downloads an image from a URL and returns the image data and format
+// Supports both HTTP/HTTPS URLs and data URIs with base64-encoded images
+// This is a public wrapper for the image downloading functionality used by adapters
+func DownloadImageFromURL(ctx context.Context, imageURL string) ([]byte, types.ImageFormat, error) {
+	return downloadImageFromURL(ctx, imageURL)
+}
+
 // downloadImageFromURL downloads an image from a URL and returns the image data and format
 // Supports both HTTP/HTTPS URLs and data URIs with base64-encoded images
 func downloadImageFromURL(ctx context.Context, imageURL string) ([]byte, types.ImageFormat, error) {
@@ -114,7 +121,7 @@ func downloadImageFromHTTPURL(ctx context.Context, imageURL string) ([]byte, typ
 	}
 
 	// Set user agent to avoid blocking
-	req.Header.Set("User-Agent", "OneAPI-AWS-TokenCounter/1.0")
+	req.Header.Set("User-Agent", "OneAPI-AWS-Image-Downloader/1.0")
 
 	// Make the request
 	resp, err := client.Do(req)


### PR DESCRIPTION
- [+] feat(main.go): add support for image content in user messages
- [+] fix(token.go): update user agent header to 'OneAPI-AWS-Image-Downloader/1.0' for image downloads

This PR Related #179.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer message content: user messages can include images (URLs/data URIs) alongside text; server-side retrieval with graceful text-or-image fallback.
  * Built-in text-to-image generator producing PNG/base64 fallbacks when images are unavailable.
* **Bug Fixes**
  * More accurate stop-reason reporting in OpenAI-compatible responses, preserving provider reasons with known mappings.
* **Tests**
  * Added comprehensive tests for text-to-image generation and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->