### PR TITLE
Support for Writer models on AWS Bedrock

### DIFF
--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -460,8 +460,8 @@ func GetModelCapabilities(modelName string) ProviderCapabilities {
 		}
 	case AwsWriter:
 		baseCapabilities = ProviderCapabilities{
-			SupportsTools:               false, // Writer models don't support tool calling
-			SupportsFunctions:           false, // Writer models don't support OpenAI functions
+			SupportsTools:               false, // Writer models don't support tool calling yet - only chat conversation is supported for now
+			SupportsFunctions:           false, // Writer models don't support OpenAI functions - only chat conversation is supported for now
 			SupportsLogprobs:            false,
 			SupportsResponseFormat:      false,
 			SupportsReasoningEffort:     false, // Writer models don't support reasoning content

--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -280,6 +280,11 @@ func (a *Adaptor) GetDefaultModelPricing() map[string]adaptor.ModelConfig {
 		// These models work similarly to DeepSeek-R1 with reasoning content and use converse method
 		"gpt-oss-20b":  {Ratio: 0.07 * ratio.MilliTokensUsd, CompletionRatio: 4.29}, // $0.00007/$0.0003 per 1K tokens = $0.07/$0.3 per 1M tokens
 		"gpt-oss-120b": {Ratio: 0.15 * ratio.MilliTokensUsd, CompletionRatio: 4},    // $0.00015/$0.0006 per 1K tokens = $0.15/$0.6 per 1M tokens
+
+		// Writer Models (Supported) - Updated pricing as of 2025-09-17 - Note: These are per 1K tokens, converted to 1M tokens using MilliTokensUsd
+		// Simple text/chat models without reasoning content support.
+		"palmyra-x4": {Ratio: 2.5 * ratio.MilliTokensUsd, CompletionRatio: 4},  // $0.0025/$0.010 per 1K tokens = $2.5/$10 per 1M tokens
+		"palmyra-x5": {Ratio: 0.6 * ratio.MilliTokensUsd, CompletionRatio: 10}, // $0.0006/$0.006 per 1K tokens = $0.6/$6 per 1M tokens
 	}
 }
 
@@ -452,6 +457,27 @@ func GetModelCapabilities(modelName string) ProviderCapabilities {
 			SupportsStop:                false, // OpenAI OSS models don't support stop parameter
 			SupportsImageGeneration:     false, // OpenAI OSS models don't support image generation
 			SupportsEmbedding:           false, // OpenAI OSS models don't support embedding
+		}
+	case AwsWriter:
+		baseCapabilities = ProviderCapabilities{
+			SupportsTools:               false, // Writer models don't support tool calling
+			SupportsFunctions:           false, // Writer models don't support OpenAI functions
+			SupportsLogprobs:            false,
+			SupportsResponseFormat:      false,
+			SupportsReasoningEffort:     false, // Writer models don't support reasoning content
+			SupportsModalities:          false,
+			SupportsAudio:               false,
+			SupportsWebSearch:           false,
+			SupportsThinking:            false,
+			SupportsLogitBias:           false,
+			SupportsServiceTier:         false,
+			SupportsParallelToolCalls:   false,
+			SupportsTopLogprobs:         false,
+			SupportsPrediction:          false,
+			SupportsMaxCompletionTokens: false,
+			SupportsStop:                true,  // Writer models support stop sequences
+			SupportsImageGeneration:     false, // Writer models don't support image generation
+			SupportsEmbedding:           false, // Writer models don't support embedding
 		}
 	default:
 		// Default to minimal capabilities for unknown models

--- a/relay/adaptor/aws/registry.go
+++ b/relay/adaptor/aws/registry.go
@@ -12,6 +12,7 @@ import (
 	mistral "github.com/songquanpeng/one-api/relay/adaptor/aws/mistral"
 	openai "github.com/songquanpeng/one-api/relay/adaptor/aws/openai"
 	"github.com/songquanpeng/one-api/relay/adaptor/aws/utils"
+	writer "github.com/songquanpeng/one-api/relay/adaptor/aws/writer"
 )
 
 type AwsModelType int
@@ -23,6 +24,7 @@ const (
 	AwsLlama3
 	AwsMistral
 	AwsOpenAI
+	AwsWriter
 )
 
 var (
@@ -49,6 +51,9 @@ func init() {
 	}
 	for model := range openai.AwsModelIDMap {
 		adaptors[model] = AwsOpenAI
+	}
+	for model := range writer.AwsModelIDMap {
+		adaptors[model] = AwsWriter
 	}
 
 	match, err := regexp.Compile("arn:aws:bedrock.+claude")
@@ -88,6 +93,8 @@ func GetAdaptor(model string) utils.AwsAdapter {
 		return &mistral.Adaptor{}
 	case AwsOpenAI:
 		return &openai.Adaptor{}
+	case AwsWriter:
+		return &writer.Adaptor{}
 	default:
 		return nil
 	}

--- a/relay/adaptor/aws/writer/adapter.go
+++ b/relay/adaptor/aws/writer/adapter.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+
+	"github.com/songquanpeng/one-api/common/ctxkey"
+
+	"github.com/Laisky/errors/v2"
+	"github.com/gin-gonic/gin"
+
+	"github.com/songquanpeng/one-api/relay/adaptor/aws/utils"
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+// Ensure Adaptor implements the AwsAdapter interface at compile time.
+var _ utils.AwsAdapter = new(Adaptor)
+
+// Adaptor implements the AwsAdapter interface for Writer models.
+// It handles request conversion and response processing for Writer's Palmyra series models
+// running on AWS Bedrock using the Converse API.
+type Adaptor struct {
+}
+
+// ConvertRequest converts a GeneralOpenAIRequest to Writer-specific format.
+// It transforms the incoming OpenAI-compatible request into a Writer request structure
+// and stores necessary context information for downstream processing.
+func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+
+	writerReq := ConvertRequest(*request)
+	c.Set(ctxkey.RequestModel, request.Model)
+	c.Set(ctxkey.ConvertedRequest, writerReq)
+	return writerReq, nil
+}
+
+// DoResponse handles the response processing for Writer models.
+// It determines whether to use streaming or non-streaming response handling
+// based on the request metadata and delegates to the appropriate handler.
+func (a *Adaptor) DoResponse(c *gin.Context, awsCli *bedrockruntime.Client, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	if meta.IsStream {
+		err, usage = StreamHandler(c, awsCli)
+	} else {
+		err, usage = Handler(c, awsCli, meta.ActualModelName)
+	}
+	return
+}

--- a/relay/adaptor/aws/writer/docs.go
+++ b/relay/adaptor/aws/writer/docs.go
@@ -1,0 +1,44 @@
+/*
+Package aws provides AWS Bedrock integration for Writer language models.
+
+This package implements support for Writer's Palmyra models (X4 and X5) through
+AWS Bedrock, enabling OpenAI-compatible API access to these models.
+
+# Supported Models
+
+Writer models available through AWS Bedrock:
+  - writer.palmyra-x4-v1:0
+  - writer.palmyra-x5-v1:0
+
+# Supported Parameters
+
+Writer models support the following parameters:
+  - max_tokens: Maximum number of tokens to generate
+  - temperature: Randomness in generation (0.0 to 1.0)
+  - top_p: Nucleus sampling parameter (0.0 to 1.0)
+  - stop: Stop sequences to terminate generation
+
+# Features
+
+Writer models provide:
+  - Simple text/chat completion capabilities
+  - Both streaming and non-streaming responses
+  - Token usage tracking for billing
+  - OpenAI-compatible request/response format
+  - No reasoning content (unlike DeepSeek/OpenAI models)
+
+# Usage
+
+Writer models are accessed through the standard One API endpoints with
+AWS Bedrock configuration. The adapter handles conversion between OpenAI
+format and Writer's native format automatically.
+
+# Implementation Details
+
+The Writer adapter follows the standard AWS Bedrock adapter pattern:
+  - Uses AWS Converse API for optimal token counting
+  - Supports both streaming and non-streaming modes
+  - Provides proper error handling and usage tracking
+  - Implements simple text content processing (no reasoning)
+*/
+package aws

--- a/relay/adaptor/aws/writer/main.go
+++ b/relay/adaptor/aws/writer/main.go
@@ -1,0 +1,445 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/songquanpeng/one-api/common/ctxkey"
+	"github.com/songquanpeng/one-api/common/tracing"
+
+	"github.com/Laisky/errors/v2"
+	gmw "github.com/Laisky/gin-middlewares/v6"
+	"github.com/Laisky/zap"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/gin-gonic/gin"
+
+	"github.com/songquanpeng/one-api/common"
+	"github.com/songquanpeng/one-api/common/config"
+	"github.com/songquanpeng/one-api/common/helper"
+	"github.com/songquanpeng/one-api/relay/adaptor/aws/utils"
+	"github.com/songquanpeng/one-api/relay/adaptor/openai"
+	relaymodel "github.com/songquanpeng/one-api/relay/model"
+)
+
+// AwsModelIDMap maps Writer model names to their AWS Bedrock model IDs.
+// Support for Writer models (Palmyra series)
+// https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
+var AwsModelIDMap = map[string]string{
+	// Writer Palmyra models
+	"palmyra-x4": "writer.palmyra-x4-v1:0",
+	"palmyra-x5": "writer.palmyra-x5-v1:0",
+}
+
+// awsModelID retrieves the AWS Bedrock model ID for a given Writer model name.
+// It returns an error if the requested model is not supported.
+func awsModelID(requestModel string) (string, error) {
+	if awsModelID, ok := AwsModelIDMap[requestModel]; ok {
+		return awsModelID, nil
+	}
+
+	return "", errors.Errorf("model %s not found", requestModel)
+}
+
+// ConvertRequest converts a GeneralOpenAIRequest to a Writer-specific request format.
+// It handles parameter mapping including max tokens, temperature, top_p, and stop sequences.
+func ConvertRequest(textRequest relaymodel.GeneralOpenAIRequest) *Request {
+	writerRequest := &Request{
+		Messages:    textRequest.Messages,
+		Temperature: textRequest.Temperature,
+		TopP:        textRequest.TopP,
+	}
+
+	// Handle max tokens
+	if textRequest.MaxTokens == 0 {
+		writerRequest.MaxTokens = config.DefaultMaxToken
+	} else {
+		writerRequest.MaxTokens = textRequest.MaxTokens
+	}
+
+	// Handle stop sequences
+	if textRequest.Stop != nil {
+		if stopSlice, ok := textRequest.Stop.([]interface{}); ok {
+			stopSequences := make([]string, 0, len(stopSlice))
+			for _, stop := range stopSlice {
+				if stopStr, ok := stop.(string); ok && stopStr != "" {
+					stopSequences = append(stopSequences, stopStr)
+				}
+			}
+			if len(stopSequences) > 0 {
+				writerRequest.Stop = stopSequences
+			}
+		} else if stopStr, ok := textRequest.Stop.(string); ok {
+			if stopStr != "" {
+				writerRequest.Stop = []string{stopStr}
+			}
+		} else if stopSlice, ok := textRequest.Stop.([]string); ok {
+			filt := stopSlice[:0]
+			for _, s := range stopSlice {
+				if s != "" {
+					filt = append(filt, s)
+				}
+			}
+			if len(filt) > 0 {
+				writerRequest.Stop = filt
+			}
+		}
+	}
+
+	return writerRequest
+}
+
+// convertWriterToConverseRequest converts Writer request to Converse API format.
+// It transforms Writer-specific parameters into AWS Bedrock Converse API format,
+// handling message role conversion and inference configuration setup.
+func convertWriterToConverseRequest(writerReq *Request, modelID string) (*bedrockruntime.ConverseInput, error) {
+	var converseMessages []types.Message
+	var systemMessages []types.SystemContentBlock
+
+	// Convert messages using standard Converse API format
+	for _, msg := range writerReq.Messages {
+		switch msg.Role {
+		case "system":
+			// System messages go to the system field in Converse API
+			systemMessages = append(systemMessages, &types.SystemContentBlockMemberText{
+				Value: msg.StringContent(),
+			})
+		case "user":
+			// User messages use standard Converse API format
+			contentBlocks := []types.ContentBlock{
+				&types.ContentBlockMemberText{
+					Value: msg.StringContent(),
+				},
+			}
+
+			converseMessages = append(converseMessages, types.Message{
+				Role:    types.ConversationRole(msg.Role),
+				Content: contentBlocks,
+			})
+		case "assistant":
+			// Assistant messages use standard Converse API format
+			contentBlocks := []types.ContentBlock{
+				&types.ContentBlockMemberText{
+					Value: msg.StringContent(),
+				},
+			}
+
+			converseMessages = append(converseMessages, types.Message{
+				Role:    types.ConversationRole(msg.Role),
+				Content: contentBlocks,
+			})
+		}
+	}
+
+	// Create inference configuration
+	inferenceConfig := &types.InferenceConfiguration{}
+	if writerReq.MaxTokens != 0 {
+		inferenceConfig.MaxTokens = aws.Int32(int32(writerReq.MaxTokens))
+	}
+
+	if writerReq.Temperature != nil {
+		inferenceConfig.Temperature = aws.Float32(float32(*writerReq.Temperature))
+	}
+	if writerReq.TopP != nil {
+		inferenceConfig.TopP = aws.Float32(float32(*writerReq.TopP))
+	}
+	if len(writerReq.Stop) > 0 {
+		stopSequences := make([]string, len(writerReq.Stop))
+		copy(stopSequences, writerReq.Stop)
+		inferenceConfig.StopSequences = stopSequences
+	}
+
+	converseReq := &bedrockruntime.ConverseInput{
+		ModelId:         aws.String(modelID),
+		Messages:        converseMessages,
+		InferenceConfig: inferenceConfig,
+	}
+
+	// Add system messages if any
+	if len(systemMessages) > 0 {
+		converseReq.System = systemMessages
+	}
+
+	return converseReq, nil
+}
+
+// convertWriterToConverseStreamRequest converts Writer request to Converse Stream API format.
+// It reuses the standard Converse conversion and adapts it for streaming.
+func convertWriterToConverseStreamRequest(writerReq *Request, modelID string) (*bedrockruntime.ConverseStreamInput, error) {
+	converseReq, err := convertWriterToConverseRequest(writerReq, modelID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &bedrockruntime.ConverseStreamInput{
+		ModelId:         converseReq.ModelId,
+		Messages:        converseReq.Messages,
+		System:          converseReq.System,
+		InferenceConfig: converseReq.InferenceConfig,
+	}, nil
+}
+
+// convertStopReason converts AWS Bedrock stop reasons to OpenAI-compatible finish reasons.
+// It maps AWS-specific stop reasons to standardized OpenAI format for consistency.
+func convertStopReason(awsReason string) *string {
+	switch awsReason {
+	case "end_turn":
+		return aws.String("stop")
+	case "tool_use":
+		return aws.String("tool_calls")
+	case "max_tokens":
+		return aws.String("length")
+	case "stop_sequence":
+		return aws.String("stop")
+	case "content_filtered":
+		return aws.String("content_filter")
+	default:
+		// Return the original reason if unknown
+		return aws.String(awsReason)
+	}
+}
+
+// convertConverseResponseToOpenAI converts AWS Bedrock Converse response to OpenAI format.
+// It extracts text content and usage information, transforming them into OpenAI-compatible response structure.
+func convertConverseResponseToOpenAI(c *gin.Context, converseResp *bedrockruntime.ConverseOutput, modelName string) *openai.TextResponse {
+	var responseText string
+	var finishReason string
+
+	// Extract response content from Converse API response
+	if converseResp.Output != nil {
+		switch outputValue := converseResp.Output.(type) {
+		case *types.ConverseOutputMemberMessage:
+			if len(outputValue.Value.Content) > 0 {
+				// Process content blocks
+				for _, contentBlock := range outputValue.Value.Content {
+					switch contentValue := contentBlock.(type) {
+					case *types.ContentBlockMemberText:
+						// Add text content
+						if contentValue.Value != "" {
+							responseText = contentValue.Value
+							break
+						}
+					}
+				}
+			}
+			// Convert stop reason
+			if stopReason := convertStopReason(string(converseResp.StopReason)); stopReason != nil {
+				finishReason = *stopReason
+			}
+		}
+	}
+
+	// Create OpenAI-compatible choice
+	choice := openai.TextResponseChoice{
+		Index: 0,
+		Message: relaymodel.Message{
+			Role:    "assistant",
+			Content: responseText,
+			Name:    nil,
+		},
+		FinishReason: finishReason,
+	}
+
+	// Create OpenAI-compatible response
+	fullTextResponse := openai.TextResponse{
+		Id:      fmt.Sprintf("chatcmpl-oneapi-%s", tracing.GetTraceIDFromContext(c)),
+		Object:  "chat.completion",
+		Created: helper.GetTimestamp(),
+		Model:   modelName,
+		Choices: []openai.TextResponseChoice{choice},
+	}
+
+	return &fullTextResponse
+}
+
+// Handler handles non-streaming Writer model requests using AWS Bedrock Converse API.
+// It processes the request, calls the Writer model, and returns the response in OpenAI format
+// along with token usage information for billing purposes.
+func Handler(c *gin.Context, awsCli *bedrockruntime.Client, modelName string) (*relaymodel.ErrorWithStatusCode, *relaymodel.Usage) {
+	awsModelName, err := awsModelID(c.GetString(ctxkey.RequestModel))
+	if err != nil {
+		return utils.WrapErr(errors.Wrap(err, "awsModelID")), nil
+	}
+	awsModelName = utils.ConvertModelID2CrossRegionProfile(gmw.Ctx(c), awsModelName, awsCli.Options().Region)
+
+	writerReq, ok := c.Get(ctxkey.ConvertedRequest)
+	if !ok {
+		return utils.WrapErr(errors.New("request not found")), nil
+	}
+
+	// Convert Writer request to Converse API format
+	converseReq, err := convertWriterToConverseRequest(writerReq.(*Request), awsModelName)
+	if err != nil {
+		return utils.WrapErr(errors.Wrap(err, "convert to converse request")), nil
+	}
+
+	// Use Converse API to get actual token counts
+	awsResp, err := awsCli.Converse(gmw.Ctx(c), converseReq)
+	if err != nil {
+		return utils.WrapErr(errors.Wrap(err, "Converse")), nil
+	}
+
+	// Convert Converse response to OpenAI format
+	openaiResp := convertConverseResponseToOpenAI(c, awsResp, modelName)
+
+	// Convert usage to relaymodel.Usage for billing
+	var usage relaymodel.Usage
+	if awsResp.Usage != nil {
+		if awsResp.Usage.InputTokens != nil {
+			usage.PromptTokens = int(*awsResp.Usage.InputTokens)
+		}
+		if awsResp.Usage.OutputTokens != nil {
+			usage.CompletionTokens = int(*awsResp.Usage.OutputTokens)
+		}
+		if awsResp.Usage.TotalTokens != nil {
+			usage.TotalTokens = int(*awsResp.Usage.TotalTokens)
+		} else {
+			// Calculate total if not provided
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+		}
+	}
+
+	c.JSON(http.StatusOK, openaiResp)
+	return nil, &usage
+}
+
+// StreamHandler handles streaming Writer model requests using AWS Bedrock Converse Stream API.
+// It processes streaming requests, handles real-time response chunks, and converts them to
+// OpenAI-compatible streaming format while tracking token usage for billing.
+func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.ErrorWithStatusCode, *relaymodel.Usage) {
+	lg := gmw.GetLogger(c)
+	createdTime := helper.GetTimestamp()
+	awsModelName, err := awsModelID(c.GetString(ctxkey.RequestModel))
+	if err != nil {
+		return utils.WrapErr(errors.Wrap(err, "awsModelID")), nil
+	}
+	awsModelName = utils.ConvertModelID2CrossRegionProfile(gmw.Ctx(c), awsModelName, awsCli.Options().Region)
+
+	writerReq, ok := c.Get(ctxkey.ConvertedRequest)
+	if !ok {
+		return utils.WrapErr(errors.New("request not found")), nil
+	}
+
+	// Convert Writer request to Converse API format
+	converseReq, err := convertWriterToConverseStreamRequest(writerReq.(*Request), awsModelName)
+	if err != nil {
+		return utils.WrapErr(errors.Wrap(err, "convert to converse request")), nil
+	}
+
+	awsResp, err := awsCli.ConverseStream(gmw.Ctx(c), converseReq)
+	if err != nil {
+		return utils.WrapErr(errors.Wrap(err, "ConverseStream")), nil
+	}
+	stream := awsResp.GetStream()
+	defer stream.Close()
+
+	// Set response headers for SSE
+	common.SetEventStreamHeaders(c)
+
+	var usage relaymodel.Usage
+	var id string
+
+	c.Stream(func(w io.Writer) bool {
+		event, ok := <-stream.Events()
+		if !ok {
+			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
+			return false
+		}
+
+		switch v := event.(type) {
+		case *types.ConverseStreamOutputMemberMessageStart:
+			// Handle message start
+			id = fmt.Sprintf("chatcmpl-oneapi-%s", tracing.GetTraceIDFromContext(c))
+			return true
+
+		case *types.ConverseStreamOutputMemberContentBlockDelta:
+			// Handle content delta - this is where the actual text content comes from ConverseStream
+			if v.Value.Delta != nil {
+				var response *openai.ChatCompletionsStreamResponse
+
+				// Check if this is a text delta (AWS SDK union type pattern)
+				switch deltaValue := v.Value.Delta.(type) {
+				case *types.ContentBlockDeltaMemberText:
+					if textDelta := deltaValue.Value; textDelta != "" {
+						// Create OpenAI-compatible streaming response with simple string content
+						response = &openai.ChatCompletionsStreamResponse{
+							Id:      id,
+							Object:  "chat.completion.chunk",
+							Created: createdTime,
+							Model:   c.GetString(ctxkey.RequestModel),
+							Choices: []openai.ChatCompletionsStreamResponseChoice{
+								{
+									Index: 0,
+									Delta: relaymodel.Message{
+										Role:    "assistant",
+										Content: textDelta,
+									},
+								},
+							},
+						}
+					}
+				}
+
+				// Send the response if we have one
+				if response != nil {
+					jsonStr, err := json.Marshal(response)
+					if err != nil {
+						lg.Error("error marshalling stream response", zap.Error(err))
+						return true
+					}
+					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+				}
+			}
+			return true
+
+		case *types.ConverseStreamOutputMemberMessageStop:
+			// Handle message stop with OpenAI-compatible response structure
+			finishReason := convertStopReason(string(v.Value.StopReason))
+			response := &openai.ChatCompletionsStreamResponse{
+				Id:      id,
+				Object:  "chat.completion.chunk",
+				Created: createdTime,
+				Model:   c.GetString(ctxkey.RequestModel),
+				Choices: []openai.ChatCompletionsStreamResponseChoice{
+					{
+						Index:        0,
+						Delta:        relaymodel.Message{},
+						FinishReason: finishReason,
+					},
+				},
+			}
+
+			jsonStr, err := json.Marshal(response)
+			if err != nil {
+				lg.Error("error marshalling final stream response", zap.Error(err))
+				return false
+			}
+			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+			return true
+
+		case *types.ConverseStreamOutputMemberMetadata:
+			// Handle metadata (usage)
+			if streamUsage := v.Value.Usage; streamUsage != nil {
+				if streamUsage.InputTokens != nil {
+					usage.PromptTokens = int(*streamUsage.InputTokens)
+				}
+				if streamUsage.OutputTokens != nil {
+					usage.CompletionTokens = int(*streamUsage.OutputTokens)
+				}
+				if streamUsage.TotalTokens != nil {
+					usage.TotalTokens = int(*streamUsage.TotalTokens)
+				}
+			}
+			return true
+
+		default:
+			// Handle other event types
+			return true
+		}
+	})
+
+	return nil, &usage
+}

--- a/relay/adaptor/aws/writer/model.go
+++ b/relay/adaptor/aws/writer/model.go
@@ -1,0 +1,25 @@
+package aws
+
+import relaymodel "github.com/songquanpeng/one-api/relay/model"
+
+// Request represents a Writer-specific request structure for AWS Bedrock.
+// It contains the essential parameters needed for Writer model inference,
+// including conversation messages, generation parameters, and control options.
+type Request struct {
+	// Messages contains the conversation history including system, user, and assistant messages
+	Messages []relaymodel.Message `json:"messages"`
+
+	// Temperature controls randomness in the response generation (0.0 to 1.0)
+	// Lower values make the output more deterministic
+	Temperature *float64 `json:"temperature,omitempty"`
+
+	// TopP controls nucleus sampling, affecting the diversity of the response
+	// It represents the cumulative probability threshold for token selection
+	TopP *float64 `json:"top_p,omitempty"`
+
+	// MaxTokens specifies the maximum number of tokens to generate in the response
+	MaxTokens int `json:"max_tokens,omitempty"`
+
+	// Stop contains sequences that will cause the generation to stop when encountered
+	Stop []string `json:"stop,omitempty"`
+}


### PR DESCRIPTION
- [+] feat(aws/writer): add support for Writer models on AWS Bedrock
- [+] feat(aws/writer): add adapter, request/response conversion, and streaming support
- [+] feat(aws/writer): add support for Palmyra-X4 and Palmyra-X5 models
- [+] feat(aws/writer): add usage tracking and error handling
- [+] feat(aws/writer): implement AWS Converse and ConverseStream APIs
- [+] feat(aws/writer): provide OpenAI-compatible request/response format

This PR related #183.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for AWS Bedrock Writer models (Palmyra X4/X5) for text/chat completions with streaming and non‑streaming responses in OpenAI‑compatible format.
  - Supports max_tokens, temperature, top_p, stop sequences, and usage tracking; stop-reason mapping applied.
  - Model capabilities default to disabling tools/functions/embeddings/images by default.

- Documentation
  - Added usage guide outlining supported parameters, behaviors, and integration notes.

- Chores
  - Updated default pricing to include Palmyra X4 and X5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->