### PR TITLE
Update Mistral AI Model Pricing and Add Embedding Support

### DIFF
--- a/relay/adaptor/mistral/adaptor.go
+++ b/relay/adaptor/mistral/adaptor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/songquanpeng/one-api/relay/adaptor/openai_compatible"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/model"
+	"github.com/songquanpeng/one-api/relay/relaymode"
 )
 
 type Adaptor struct {
@@ -98,6 +99,12 @@ func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Read
 }
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	// Handle embedding requests using the openai_compatible.EmbeddingHandler
+	if meta.Mode == relaymode.Embeddings {
+		err, usage = openai_compatible.EmbeddingHandler(c, resp)
+		return usage, err
+	}
+
 	return openai_compatible.HandleClaudeMessagesResponse(c, resp, meta, func(c *gin.Context, resp *http.Response, promptTokens int, modelName string) (*model.ErrorWithStatusCode, *model.Usage) {
 		if meta.IsStream {
 			return openai_compatible.StreamHandler(c, resp, promptTokens, modelName)

--- a/relay/adaptor/mistral/constants.go
+++ b/relay/adaptor/mistral/constants.go
@@ -8,18 +8,28 @@ import (
 // ModelRatios contains all supported models and their pricing ratios
 // Model list is derived from the keys of this map, eliminating redundancy
 // Based on Mistral pricing: https://docs.mistral.ai/platform/pricing/
+// Updated with new models and pricing from issue description (2025-09-17)
 var ModelRatios = map[string]adaptor.ModelConfig{
-	// Open Models
-	"open-mistral-7b":   {Ratio: 0.25 * ratio.MilliTokensUsd, CompletionRatio: 1},
-	"open-mixtral-8x7b": {Ratio: 0.7 * ratio.MilliTokensUsd, CompletionRatio: 1},
-
-	// Mistral Models
-	"mistral-small-latest":  {Ratio: 2.0 * ratio.MilliTokensUsd, CompletionRatio: 1},
-	"mistral-medium-latest": {Ratio: 2.7 * ratio.MilliTokensUsd, CompletionRatio: 1},
-	"mistral-large-latest":  {Ratio: 8.0 * ratio.MilliTokensUsd, CompletionRatio: 1},
+	"mistral-medium-latest":   {Ratio: 0.4 * ratio.MilliTokensUsd, CompletionRatio: 5.0},  // $0.4 input, $2 output
+	"magistral-medium-latest": {Ratio: 2.0 * ratio.MilliTokensUsd, CompletionRatio: 2.5},  // $2 input, $5 output
+	"devstral-medium-2507":    {Ratio: 0.4 * ratio.MilliTokensUsd, CompletionRatio: 5.0},  // $0.4 input, $2 output
+	"codestral-latest":        {Ratio: 0.3 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $0.3 input, $0.9 output
+	"mistral-large-latest":    {Ratio: 2.0 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $2 input, $6 output
+	"pixtral-large-latest":    {Ratio: 2.0 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $2 input, $6 output
+	"mistral-saba-latest":     {Ratio: 0.2 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $0.2 input, $0.6 output
+	"mistral-small-latest":    {Ratio: 0.1 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $0.1 input, $0.3 output
+	"magistral-small-latest":  {Ratio: 0.5 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $0.5 input, $1.5 output
+	"devstral-small-2507":     {Ratio: 0.1 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $0.1 input, $0.3 output
+	"pixtral-12b":             {Ratio: 0.15 * ratio.MilliTokensUsd, CompletionRatio: 1.0}, // $0.15 input, $0.15 output
+	"open-mistral-7b":         {Ratio: 0.25 * ratio.MilliTokensUsd, CompletionRatio: 1.0}, // $0.25 input, $0.25 output
+	"open-mixtral-8x7b":       {Ratio: 0.7 * ratio.MilliTokensUsd, CompletionRatio: 1.0},  // $0.7 input, $0.7 output
+	"open-mixtral-8x22b":      {Ratio: 2.0 * ratio.MilliTokensUsd, CompletionRatio: 3.0},  // $2 input, $6 output
+	"ministral-8b-latest":     {Ratio: 0.1 * ratio.MilliTokensUsd, CompletionRatio: 1.0},  // $0.1 input, $0.1 output
+	"ministral-3b-latest":     {Ratio: 0.04 * ratio.MilliTokensUsd, CompletionRatio: 1.0}, // $0.04 input, $0.04 output
 
 	// Embedding Models
-	"mistral-embed": {Ratio: 0.1 * ratio.MilliTokensUsd, CompletionRatio: 1},
+	"mistral-embed":        {Ratio: 0.1 * ratio.MilliTokensUsd, CompletionRatio: 1.0},  // $0.1 input only
+	"codestral-embed-2505": {Ratio: 0.15 * ratio.MilliTokensUsd, CompletionRatio: 1.0}, // $0.15 input only
 }
 
 // ModelList derived from ModelRatios for backward compatibility


### PR DESCRIPTION
- [+] fix(mistral/adaptor): update model ratios and add new models
- [+] feat(mistral/adaptor): add support for embedding requests in relaymode.Embeddings
- [+] refactor(mistral/constants): update model ratios and add new models

This PR related #187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added embeddings support for Mistral-compatible requests, with accurate usage reporting.

- Changes
  - Updated Mistral model lineup to the latest offerings (e.g., mistral-medium/large/small-latest, pixtral, ministral, codestral), removing deprecated entries.
  - Revised pricing ratios and output multipliers to reflect current input/output costs across models.
  - Added new embedding model option (codestral-embed-2505) and updated pricing for mistral-embed.
  - Cost estimates/billing calculations now align with the latest model pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->