### PR TITLE
Adds Support DeepSeek V3 Models for AWS Bedrock Adaptors

### DIFF
--- a/relay/adaptor/aws/adaptor.go
+++ b/relay/adaptor/aws/adaptor.go
@@ -260,8 +260,9 @@ func (a *Adaptor) GetDefaultModelPricing() map[string]adaptor.ModelConfig {
 		"ai21-j2-ultra":  {Ratio: 18.8 * ratio.MilliTokensUsd, CompletionRatio: 1}, // $18.8 per 1M tokens
 		"ai21-jamba-1.5": {Ratio: 2 * ratio.MilliTokensUsd, CompletionRatio: 4},    // $2/$8 per 1M tokens
 
-		// DeepSeek Models (Supported) - Updated pricing as of 2025-08-28 - Note: These are per 1K tokens, converted to 1M tokens using ratio.MilliTokensUsd
-		"deepseek-r1": {Ratio: 1.35 * ratio.MilliTokensUsd, CompletionRatio: 4}, // $0.00135/$0.0054 per 1K tokens = $1.35/$5.4 per 1M tokens
+		// DeepSeek Models (Supported) - Updated pricing as of 2025-09-19 - Note: These are per 1K tokens, converted to 1M tokens using MilliTokensUsd
+		"deepseek-r1": {Ratio: 1.35 * ratio.MilliTokensUsd, CompletionRatio: 4},   // $0.00135/$0.0054 per 1K tokens = $1.35/$5.4 per 1M tokens
+		"deepseek-v3": {Ratio: 0.58 * ratio.MilliTokensUsd, CompletionRatio: 2.9}, // $0.00058/$0.00168 per 1K tokens = $0.58/$1.68 per 1M tokens
 
 		// Mistral Models (Supported) - Updated pricing as of 2025-08-27 - Note: These are per 1K tokens, converted to 1M tokens using ratio.MilliTokensUsd
 		//

--- a/relay/adaptor/aws/deepseek/main.go
+++ b/relay/adaptor/aws/deepseek/main.go
@@ -28,6 +28,7 @@ import (
 // https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
 var AwsModelIDMap = map[string]string{
 	"deepseek-r1": "deepseek.r1-v1:0",
+	"deepseek-v3": "deepseek.v3-v1:0",
 }
 
 func awsModelID(requestModel string) (string, error) {


### PR DESCRIPTION
- [+] fix(adaptor/aws): update deepseek model pricing and add new model id

This PR related #195
