### PR TITLE
Fix Unified Streaming OpenAI Compatible

### DIFF
--- a/relay/adaptor/openai_compatible/unified_streaming.go
+++ b/relay/adaptor/openai_compatible/unified_streaming.go
@@ -1017,18 +1017,19 @@ func UnifiedStreamProcessing(c *gin.Context, resp *http.Response, promptTokens i
 			reasoningFormat := c.Query("reasoning_format")
 			// This fixes an issue where other providers (such as self-hosted GPU) don't have query parameters, so we default to reasoning_content
 			// when extracting <think></think> content
-			if reasoningFormat != "" {
-				for i := range streamResponse.Choices {
-					if streamResponse.Choices[i].Delta.ReasoningContent != nil {
-						rc := *streamResponse.Choices[i].Delta.ReasoningContent
-						streamResponse.Choices[i].Delta.SetReasoningContent(reasoningFormat, rc)
-						// If the requested format is not reasoning_content, clear ReasoningContent to avoid duplicate fields
-						if strings.ToLower(strings.TrimSpace(reasoningFormat)) != string(model.ReasoningFormatReasoningContent) {
-							streamResponse.Choices[i].Delta.ReasoningContent = nil
-						}
+			if reasoningFormat == "" {
+				reasoningFormat = string(model.ReasoningFormatReasoningContent)
+			}
+
+			for i := range streamResponse.Choices {
+				if streamResponse.Choices[i].Delta.ReasoningContent != nil {
+					rc := *streamResponse.Choices[i].Delta.ReasoningContent
+					streamResponse.Choices[i].Delta.SetReasoningContent(reasoningFormat, rc)
+					// If the requested format is not reasoning_content, clear ReasoningContent to avoid duplicate fields
+					if strings.ToLower(strings.TrimSpace(reasoningFormat)) != string(model.ReasoningFormatReasoningContent) {
+						streamResponse.Choices[i].Delta.ReasoningContent = nil
 					}
 				}
-
 			}
 		}
 


### PR DESCRIPTION
- [+] fix(unified_streaming.go): handle reasoning_format query parameter for non-empty values

This PR related #203 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures reasoning content is correctly recognized and labeled even when no reasoning_format parameter is provided, so providers without that parameter map <think> content to reasoning by default.
  * Prevents unintended loss of reasoning content and keeps streaming responses consistent across providers.
  * Existing integrations that explicitly set the parameter remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->