### PR TITLE
Adds Support for Unicode-Escaped Thinking Tags in Unified Streaming OpenAI-Compatible Responses

### DIFF
--- a/relay/adaptor/openai_compatible/unified_streaming_test.go
+++ b/relay/adaptor/openai_compatible/unified_streaming_test.go
@@ -164,6 +164,27 @@ func TestThinkingProcessor_ProcessThinkingContent(t *testing.T) {
 			expectedReasoning: stringPtr("first"),
 			expectedModified:  true,
 		},
+		{
+			name:              "JSON-escaped Unicode thinking block (complete)",
+			input:             "Hello \\u003cthink\\u003ereasoning\\u003c/think\\u003e world",
+			expectedContent:   "Hello  world",
+			expectedReasoning: stringPtr("reasoning"),
+			expectedModified:  true,
+		},
+		{
+			name:              "JSON-escaped Unicode thinking block (opening only)",
+			input:             "Hello \\u003cthink\\u003epartial reasoning",
+			expectedContent:   "Hello ",
+			expectedReasoning: stringPtr("partial reasoning"),
+			expectedModified:  true,
+		},
+		{
+			name:              "Mixed normal and Unicode thinking blocks",
+			input:             "Hello \\u003cthink\\u003eunicode first\\u003c/think\\u003e <think>normal second</think>",
+			expectedContent:   "Hello  <think>normal second</think>",
+			expectedReasoning: stringPtr("unicode first"),
+			expectedModified:  true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- [+] fix(openai_compatible): add support for Unicode-escaped thinking tags in streaming responses
- [+] feat(openai_compatible): add tests for Unicode-escaped thinking tags in streaming responses

This PR related #207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Unicode-escaped think tags in streamed responses, alongside standard tags.
  - Correctly extracts and removes the first reasoning block, including mixed standard/Unicode cases.
  - Improved handling across chunked streams to avoid leaking hidden reasoning content.

- Documentation
  - Clarified behavior and examples for Unicode-escaped tags and mixed tag scenarios.

- Tests
  - Added comprehensive test cases covering Unicode-escaped tags, empty/mixed tags, and edge positions to ensure consistent extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->