### PR TITLE
Adds support for sub-adaptors (DeepSeek, OpenAI, Qwen) via Vertex AI API Services

### DIFF
--- a/relay/adaptor/vertexai/adaptor_test.go
+++ b/relay/adaptor/vertexai/adaptor_test.go
@@ -6,7 +6,10 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/songquanpeng/one-api/model"
+	"github.com/songquanpeng/one-api/relay/adaptor/vertexai/deepseek"
+	"github.com/songquanpeng/one-api/relay/adaptor/vertexai/qwen"
 	"github.com/songquanpeng/one-api/relay/meta"
+	relayModel "github.com/songquanpeng/one-api/relay/model"
 )
 
 func TestAdaptor_GetRequestURL(t *testing.T) {
@@ -244,6 +247,148 @@ func TestIsRequireGlobalEndpoint(t *testing.T) {
 	})
 }
 
+func TestIsDeepSeekModel(t *testing.T) {
+	Convey("isDeepSeekModel", t, func() {
+		cases := []struct {
+			model    string
+			expected bool
+		}{
+			{"deepseek-ai/deepseek-v3.1-maas", true},
+			{"deepseek-ai/deepseek-r1-0528-maas", true},
+			{"deepseek-ai/deepseek-v2", true},
+			{"gemini-1.5-pro", false},
+			{"claude-3-sonnet", false},
+			{"", false},
+		}
+		for _, c := range cases {
+			Convey("model "+c.model, func() {
+				So(isDeepSeekModel(c.model), ShouldEqual, c.expected)
+			})
+		}
+	})
+}
+
+func TestDeepSeekRequestURL(t *testing.T) {
+	Convey("DeepSeek GetRequestURL", t, func() {
+		adaptor := &Adaptor{}
+
+		Convey("deepseek-v3.1-maas should use us-west2 endpoint", func() {
+			meta := &meta.Meta{
+				ActualModelName: "deepseek-ai/deepseek-v3.1-maas",
+				IsStream:        false,
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://us-west2-aiplatform.googleapis.com/v1/projects/test-project/locations/us-west2/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("deepseek-r1-0528-maas should use us-central1 endpoint", func() {
+			meta := &meta.Meta{
+				ActualModelName: "deepseek-ai/deepseek-r1-0528-maas",
+				IsStream:        false,
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("deepseek models with custom BaseURL and region", func() {
+			meta := &meta.Meta{
+				ActualModelName: "deepseek-ai/deepseek-v3.1-maas",
+				IsStream:        false,
+				BaseURL:         "https://custom-deepseek-proxy.example.com",
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+					Region:            "us-west1",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://custom-deepseek-proxy.example.com/v1/projects/test-project/locations/us-west1/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("deepseek models without project ID should return error", func() {
+			meta := &meta.Meta{
+				ActualModelName: "deepseek-ai/deepseek-v3.1-maas",
+				IsStream:        false,
+				Config:          model.ChannelConfig{
+					// Missing VertexAI project ID
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldNotBeNil)
+			So(url, ShouldEqual, "")
+			So(err.Error(), ShouldContainSubstring, "VertexAI project ID is required")
+		})
+	})
+}
+
+func TestDeepSeekConvertRequest(t *testing.T) {
+	Convey("DeepSeek ConvertRequest", t, func() {
+		adaptor := &deepseek.Adaptor{}
+
+		Convey("should convert max_completion_tokens to max_tokens", func() {
+			maxCompletionTokens := 1000
+			request := &relayModel.GeneralOpenAIRequest{
+				Model:               "deepseek-ai/deepseek-v3.1-maas",
+				MaxTokens:           0, // Not set
+				MaxCompletionTokens: &maxCompletionTokens,
+				Messages: []relayModel.Message{
+					{Role: "user", Content: "Hello"},
+				},
+			}
+
+			result, err := adaptor.ConvertRequest(nil, 0, request)
+			So(err, ShouldBeNil)
+			So(result, ShouldNotBeNil)
+
+			convertedRequest := result.(*relayModel.GeneralOpenAIRequest)
+			So(convertedRequest.MaxTokens, ShouldEqual, 1000)
+			So(convertedRequest.MaxCompletionTokens, ShouldBeNil)
+		})
+
+		Convey("should preserve max_tokens if already set", func() {
+			maxCompletionTokens := 1000
+			request := &relayModel.GeneralOpenAIRequest{
+				Model:               "deepseek-ai/deepseek-v3.1-maas",
+				MaxTokens:           500, // Already set
+				MaxCompletionTokens: &maxCompletionTokens,
+				Messages: []relayModel.Message{
+					{Role: "user", Content: "Hello"},
+				},
+			}
+
+			result, err := adaptor.ConvertRequest(nil, 0, request)
+			So(err, ShouldBeNil)
+			So(result, ShouldNotBeNil)
+
+			convertedRequest := result.(*relayModel.GeneralOpenAIRequest)
+			So(convertedRequest.MaxTokens, ShouldEqual, 500) // Should preserve original
+			So(convertedRequest.MaxCompletionTokens, ShouldBeNil)
+		})
+
+		Convey("should handle nil request", func() {
+			result, err := adaptor.ConvertRequest(nil, 0, nil)
+			So(err, ShouldNotBeNil)
+			So(result, ShouldBeNil)
+			So(err.Error(), ShouldContainSubstring, "request is nil")
+		})
+	})
+}
+
 func TestIsImagenModel(t *testing.T) {
 	Convey("isImagenModel", t, func() {
 		cases := []struct {
@@ -260,6 +405,292 @@ func TestIsImagenModel(t *testing.T) {
 		for _, c := range cases {
 			Convey("model "+c.model, func() {
 				So(isImagenModel(c.model), ShouldEqual, c.expected)
+			})
+		}
+	})
+}
+
+func TestIsOpenAIModel(t *testing.T) {
+	Convey("isOpenAIModel", t, func() {
+		cases := []struct {
+			model    string
+			expected bool
+		}{
+			{"openai/gpt-oss-20b-maas", true},
+			{"openai/gpt-oss-120b-maas", true},
+			{"gemini-1.5-pro", false},
+			{"claude-3-sonnet", false},
+			{"", false},
+		}
+		for _, c := range cases {
+			Convey("model "+c.model, func() {
+				So(isOpenAIModel(c.model), ShouldEqual, c.expected)
+			})
+		}
+	})
+}
+
+func TestIsQwenModel(t *testing.T) {
+	Convey("isQwenModel", t, func() {
+		cases := []struct {
+			model    string
+			expected bool
+		}{
+			{"qwen/qwen3-coder-480b-a35b-instruct-maas", true},
+			{"qwen/qwen3-235b-a22b-instruct-2507-maas", true},
+			{"qwen/qwen3-next-80b-a3b-instruct-maas", true},
+			{"qwen/qwen-turbo", true},
+			{"qwen/qwen-plus", true},
+			{"openai/gpt-oss-20b-maas", false},
+			{"gemini-1.5-pro", false},
+			{"claude-3-sonnet", false},
+			{"", false},
+		}
+		for _, c := range cases {
+			Convey("model "+c.model, func() {
+				So(isQwenModel(c.model), ShouldEqual, c.expected)
+			})
+		}
+	})
+}
+
+func TestQwenRequestURL(t *testing.T) {
+	Convey("Qwen GetRequestURL", t, func() {
+		adaptor := &Adaptor{}
+
+		Convey("qwen3-coder-480b-a35b-instruct-maas should use us-south1 endpoint", func() {
+			meta := &meta.Meta{
+				ActualModelName: "qwen/qwen3-coder-480b-a35b-instruct-maas",
+				IsStream:        false,
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://us-south1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("qwen3-235b-a22b-instruct-2507-maas should use us-south1 endpoint", func() {
+			meta := &meta.Meta{
+				ActualModelName: "qwen/qwen3-235b-a22b-instruct-2507-maas",
+				IsStream:        false,
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://us-south1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("qwen3-next-80b-a3b-instruct-maas should use global endpoint", func() {
+			meta := &meta.Meta{
+				ActualModelName: "qwen/qwen3-next-80b-a3b-instruct-maas",
+				IsStream:        false,
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("qwen models with custom BaseURL and region", func() {
+			meta := &meta.Meta{
+				ActualModelName: "qwen/qwen3-235b-a22b-instruct-2507-maas",
+				IsStream:        false,
+				BaseURL:         "https://custom-qwen-proxy.example.com",
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+					Region:            "us-west1",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://custom-qwen-proxy.example.com/v1/projects/test-project/locations/us-west1/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("qwen models without project ID should return error", func() {
+			meta := &meta.Meta{
+				ActualModelName: "qwen/qwen3-235b-a22b-instruct-2507-maas",
+				IsStream:        false,
+				Config:          model.ChannelConfig{
+					// Missing VertexAI project ID
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldNotBeNil)
+			So(url, ShouldEqual, "")
+			So(err.Error(), ShouldContainSubstring, "VertexAI project ID is required")
+		})
+	})
+}
+
+func TestQwenConvertRequest(t *testing.T) {
+	Convey("Qwen ConvertRequest", t, func() {
+		adaptor := &qwen.Adaptor{}
+
+		Convey("should convert max_completion_tokens to max_tokens", func() {
+			maxCompletionTokens := 1000
+			request := &relayModel.GeneralOpenAIRequest{
+				Model:               "qwen/qwen3-coder-480b-a35b-instruct-maas",
+				MaxTokens:           0, // Not set
+				MaxCompletionTokens: &maxCompletionTokens,
+				Messages: []relayModel.Message{
+					{Role: "user", Content: "Hello"},
+				},
+			}
+
+			result, err := adaptor.ConvertRequest(nil, 0, request)
+			So(err, ShouldBeNil)
+			So(result, ShouldNotBeNil)
+
+			convertedRequest := result.(*relayModel.GeneralOpenAIRequest)
+			So(convertedRequest.MaxTokens, ShouldEqual, 1000)
+			So(convertedRequest.MaxCompletionTokens, ShouldBeNil)
+		})
+
+		Convey("should preserve max_tokens if already set", func() {
+			maxCompletionTokens := 1000
+			request := &relayModel.GeneralOpenAIRequest{
+				Model:               "qwen/qwen3-coder-480b-a35b-instruct-maas",
+				MaxTokens:           500, // Already set
+				MaxCompletionTokens: &maxCompletionTokens,
+				Messages: []relayModel.Message{
+					{Role: "user", Content: "Hello"},
+				},
+			}
+
+			result, err := adaptor.ConvertRequest(nil, 0, request)
+			So(err, ShouldBeNil)
+			So(result, ShouldNotBeNil)
+
+			convertedRequest := result.(*relayModel.GeneralOpenAIRequest)
+			So(convertedRequest.MaxTokens, ShouldEqual, 500) // Should preserve original
+			So(convertedRequest.MaxCompletionTokens, ShouldBeNil)
+		})
+
+		Convey("should handle nil request", func() {
+			result, err := adaptor.ConvertRequest(nil, 0, nil)
+			So(err, ShouldNotBeNil)
+			So(result, ShouldBeNil)
+			So(err.Error(), ShouldContainSubstring, "request is nil")
+		})
+	})
+}
+
+func TestOpenAIRequestURL(t *testing.T) {
+	Convey("OpenAI GetRequestURL", t, func() {
+		adaptor := &Adaptor{}
+
+		Convey("openai/gpt-oss-20b-maas should use global endpoint", func() {
+			meta := &meta.Meta{
+				ActualModelName: "openai/gpt-oss-20b-maas",
+				IsStream:        false,
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("openai/gpt-oss-120b-maas should use global endpoint", func() {
+			meta := &meta.Meta{
+				ActualModelName: "openai/gpt-oss-120b-maas",
+				IsStream:        false,
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("openai models with custom BaseURL", func() {
+			meta := &meta.Meta{
+				ActualModelName: "openai/gpt-oss-20b-maas",
+				IsStream:        false,
+				BaseURL:         "https://custom-openai-proxy.example.com",
+				Config: model.ChannelConfig{
+					VertexAIProjectID: "test-project",
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldBeNil)
+			expectedURL := "https://custom-openai-proxy.example.com/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions"
+			So(url, ShouldEqual, expectedURL)
+		})
+
+		Convey("openai models without project ID should return error", func() {
+			meta := &meta.Meta{
+				ActualModelName: "openai/gpt-oss-20b-maas",
+				IsStream:        false,
+				Config:          model.ChannelConfig{
+					// Missing VertexAI project ID
+				},
+			}
+
+			url, err := adaptor.GetRequestURL(meta)
+			So(err, ShouldNotBeNil)
+			So(url, ShouldEqual, "")
+			So(err.Error(), ShouldContainSubstring, "VertexAI project ID is required")
+		})
+	})
+}
+
+func TestGetQwenEndpointConfig(t *testing.T) {
+	Convey("getQwenEndpointConfig", t, func() {
+		testCases := []struct {
+			model            string
+			expectedHost     string
+			expectedLocation string
+		}{
+			{
+				model:            "qwen/qwen3-next-80b-a3b-instruct-maas",
+				expectedHost:     "aiplatform.googleapis.com",
+				expectedLocation: "global",
+			},
+			{
+				model:            "qwen/qwen3-coder-480b-a35b-instruct-maas",
+				expectedHost:     "us-south1-aiplatform.googleapis.com",
+				expectedLocation: "us-central1",
+			},
+			{
+				model:            "qwen/qwen3-235b-a22b-instruct-2507-maas",
+				expectedHost:     "us-south1-aiplatform.googleapis.com",
+				expectedLocation: "us-central1",
+			},
+			{
+				model:            "qwen/unknown-model",
+				expectedHost:     "us-south1-aiplatform.googleapis.com",
+				expectedLocation: "us-central1",
+			},
+		}
+
+		for _, tc := range testCases {
+			Convey("model "+tc.model, func() {
+				host, location := getQwenEndpointConfig(tc.model)
+				So(host, ShouldEqual, tc.expectedHost)
+				So(location, ShouldEqual, tc.expectedLocation)
 			})
 		}
 	})

--- a/relay/adaptor/vertexai/deepseek/adaptor.go
+++ b/relay/adaptor/vertexai/deepseek/adaptor.go
@@ -57,11 +57,11 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Met
 	// Use OpenAI-compatible response handling since DeepSeek is OpenAI-compatible
 	return openai_compatible.HandleClaudeMessagesResponse(c, resp, meta, func(c *gin.Context, resp *http.Response, promptTokens int, modelName string) (*model.ErrorWithStatusCode, *model.Usage) {
 		if meta.IsStream {
-			// TODO: This may need to return "openai_compatible.StreamHandlerWithThinking".
 			// Note: Vertex AI uses Unicode-escaped thinking tags (e.g., \u003cthink\u003e...\u003c/think\u003e)
-			// instead of raw XML-style tags like <think></think>.
-			return openai_compatible.StreamHandler(c, resp, promptTokens, modelName)
+			// instead of raw XML-style tags like <think></think>. This implementation therefore uses
+			// "StreamHandlerWithThinking" to ensure consistent handling.
+			return openai_compatible.StreamHandlerWithThinking(c, resp, promptTokens, modelName)
 		}
-		return openai_compatible.Handler(c, resp, promptTokens, modelName)
+		return openai_compatible.HandlerWithThinking(c, resp, promptTokens, modelName)
 	})
 }

--- a/relay/adaptor/vertexai/deepseek/adaptor.go
+++ b/relay/adaptor/vertexai/deepseek/adaptor.go
@@ -1,0 +1,67 @@
+// Package deepseek provides an adaptor for the DeepSeek AI models in Vertex AI.
+package deepseek
+
+import (
+	"net/http"
+
+	"github.com/Laisky/errors/v2"
+	"github.com/gin-gonic/gin"
+
+	openai_compatible "github.com/songquanpeng/one-api/relay/adaptor/openai_compatible"
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+// Adaptor is an implementation of the DeepSeek AI adaptor for Vertex AI.
+type Adaptor struct{}
+
+// ConvertRequest converts an OpenAI request to a DeepSeek-compatible request.
+// DeepSeek is OpenAI-compatible but requires field mapping, particularly for token limits.
+// This function handles the conversion by:
+//
+//  1. Creating a copy of the original request to avoid modification
+//  2. Mapping max_completion_tokens to max_tokens if needed (DeepSeek only supports max_tokens)
+//  3. Clearing max_completion_tokens to avoid conflicts
+func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+	// DeepSeek is OpenAI-compatible but requires field mapping
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+
+	// Create a copy of the request to avoid modifying the original
+	deepseekRequest := *request
+
+	// DeepSeek doesn't support max_completion_tokens, only max_tokens
+	// If max_completion_tokens is set but max_tokens is not, use max_completion_tokens as max_tokens
+	if deepseekRequest.MaxCompletionTokens != nil && deepseekRequest.MaxTokens == 0 {
+		deepseekRequest.MaxTokens = *deepseekRequest.MaxCompletionTokens
+	}
+
+	// Clear max_completion_tokens to avoid conflicts
+	deepseekRequest.MaxCompletionTokens = nil
+
+	return &deepseekRequest, nil
+}
+
+// ConvertImageRequest handles image generation requests for DeepSeek.
+// Currently, DeepSeek does not support image generation, so this function always returns an error.
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, request *model.ImageRequest) (any, error) {
+	// DeepSeek doesn't support image generation currently
+	return nil, errors.New("Vertex AI: deepseek does not support image generation")
+}
+
+// DoResponse handles the response from DeepSeek API and converts it to a standard format.
+// Since DeepSeek is OpenAI-compatible, it uses the OpenAI-compatible response handlers.
+// For streaming responses, it uses the StreamHandler, otherwise the standard Handler.
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	// Use OpenAI-compatible response handling since DeepSeek is OpenAI-compatible
+	return openai_compatible.HandleClaudeMessagesResponse(c, resp, meta, func(c *gin.Context, resp *http.Response, promptTokens int, modelName string) (*model.ErrorWithStatusCode, *model.Usage) {
+		if meta.IsStream {
+			// TODO: This may need to return "openai_compatible.StreamHandlerWithThinking".
+			// Note: Vertex AI uses Unicode-escaped thinking tags (e.g., \u003cthink\u003e...\u003c/think\u003e)
+			// instead of raw XML-style tags like <think></think>.
+			return openai_compatible.StreamHandler(c, resp, promptTokens, modelName)
+		}
+		return openai_compatible.Handler(c, resp, promptTokens, modelName)
+	})
+}

--- a/relay/adaptor/vertexai/deepseek/constants.go
+++ b/relay/adaptor/vertexai/deepseek/constants.go
@@ -1,0 +1,24 @@
+// Package deepseek provides model pricing constants for DeepSeek AI models in Vertex AI.
+package deepseek
+
+import (
+	"github.com/songquanpeng/one-api/relay/adaptor"
+	"github.com/songquanpeng/one-api/relay/billing/ratio"
+)
+
+// ModelRatios contains DeepSeek models and their pricing ratios
+var ModelRatios = map[string]adaptor.ModelConfig{
+	// DeepSeek V3.1 - Input: $0.60 / million tokens, Output: $1.70 / million tokens
+	"deepseek-ai/deepseek-v3.1-maas": {
+		Ratio:           0.60 * ratio.MilliTokensUsd, // Input price: $0.60 per million tokens
+		CompletionRatio: 1.70 / 0.60,                 // Output/Input ratio: $1.70 / $0.60 = 2.833
+	},
+	// DeepSeek R1 - Input: $1.35 / million tokens, Output: $5.40 / million tokens
+	"deepseek-ai/deepseek-r1-0528-maas": {
+		Ratio:           1.35 * ratio.MilliTokensUsd, // Input price: $1.35 per million tokens
+		CompletionRatio: 5.40 / 1.35,                 // Output/Input ratio: $5.40 / $1.35 = 4.0
+	},
+}
+
+// ModelList derived from ModelRatios keys
+var ModelList = adaptor.GetModelListFromPricing(ModelRatios)

--- a/relay/adaptor/vertexai/openai/adaptor.go
+++ b/relay/adaptor/vertexai/openai/adaptor.go
@@ -1,0 +1,64 @@
+// Package openai provides an adaptor for OpenAI GPT-OSS models in Vertex AI.
+package openai
+
+import (
+	"net/http"
+
+	"github.com/Laisky/errors/v2"
+	"github.com/gin-gonic/gin"
+
+	openai_compatible "github.com/songquanpeng/one-api/relay/adaptor/openai_compatible"
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+// Adaptor is an implementation of the OpenAI GPT-OSS adaptor for Vertex AI.
+type Adaptor struct{}
+
+// ConvertRequest converts an OpenAI request to an OpenAI GPT-OSS compatible request.
+// OpenAI GPT-OSS models are fully OpenAI-compatible but require field mapping for token limits.
+// This function handles the conversion by:
+//
+//  1. Creating a copy of the original request to avoid modification
+//  2. Mapping max_completion_tokens to max_tokens if needed (GPT-OSS only supports max_tokens)
+//  3. Clearing max_completion_tokens to avoid conflicts
+func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+	// OpenAI GPT-OSS models are fully OpenAI-compatible
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+
+	// Create a copy of the request to avoid modifying the original
+	openaiRequest := *request
+
+	// OpenAI GPT-OSS doesn't support max_completion_tokens, only max_tokens
+	// If max_completion_tokens is set but max_tokens is not, use max_completion_tokens as max_tokens
+	if openaiRequest.MaxCompletionTokens != nil && openaiRequest.MaxTokens == 0 {
+		openaiRequest.MaxTokens = *openaiRequest.MaxCompletionTokens
+	}
+
+	// Clear max_completion_tokens to avoid conflicts
+	openaiRequest.MaxCompletionTokens = nil
+
+	return &openaiRequest, nil
+}
+
+// ConvertImageRequest handles image generation requests for OpenAI GPT-OSS models.
+// Currently, OpenAI GPT-OSS models do not support image generation, so this function always returns an error.
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, request *model.ImageRequest) (any, error) {
+	// OpenAI GPT-OSS doesn't support image generation currently
+	return nil, errors.New("Vertex AI: OpenAI GPT-OSS does not support image generation")
+}
+
+// DoResponse handles the response from OpenAI GPT-OSS API and converts it to a standard format.
+// Since GPT-OSS models are fully OpenAI-compatible, it uses the standard OpenAI-compatible response handlers.
+// For streaming responses, it uses the StreamHandler, otherwise the standard Handler.
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	// Use standard OpenAI-compatible response handling since GPT-OSS is OpenAI-compatible
+	if meta.IsStream {
+		err, usage = openai_compatible.StreamHandler(c, resp, meta.PromptTokens, meta.ActualModelName)
+	} else {
+		err, usage = openai_compatible.Handler(c, resp, meta.PromptTokens, meta.ActualModelName)
+	}
+	return usage, err
+}

--- a/relay/adaptor/vertexai/openai/constants.go
+++ b/relay/adaptor/vertexai/openai/constants.go
@@ -1,0 +1,22 @@
+// Package openai provides model pricing constants for OpenAI GPT-OSS models in Vertex AI.
+package openai
+
+import (
+	"github.com/songquanpeng/one-api/relay/adaptor"
+	"github.com/songquanpeng/one-api/relay/billing/ratio"
+)
+
+// ModelRatios contains pricing information for OpenAI GPT-OSS models
+var ModelRatios = map[string]adaptor.ModelConfig{
+	"openai/gpt-oss-20b-maas": {
+		Ratio:           0.15 * ratio.MilliTokensUsd, // $0.15 per million tokens input
+		CompletionRatio: 0.60 * ratio.MilliTokensUsd, // $0.60 per million tokens output
+	},
+	"openai/gpt-oss-120b-maas": {
+		Ratio:           0.075 * ratio.MilliTokensUsd, // $0.075 per million tokens input
+		CompletionRatio: 0.30 * ratio.MilliTokensUsd,  // $0.30 per million tokens output
+	},
+}
+
+// ModelList contains all OpenAI GPT-OSS models supported by VertexAI
+var ModelList = adaptor.GetModelListFromPricing(ModelRatios)

--- a/relay/adaptor/vertexai/qwen/adaptor.go
+++ b/relay/adaptor/vertexai/qwen/adaptor.go
@@ -1,0 +1,67 @@
+// Package qwen provides an adaptor for Qwen models in Vertex AI.
+package qwen
+
+import (
+	"net/http"
+
+	"github.com/Laisky/errors/v2"
+	"github.com/gin-gonic/gin"
+
+	openai_compatible "github.com/songquanpeng/one-api/relay/adaptor/openai_compatible"
+	"github.com/songquanpeng/one-api/relay/meta"
+	"github.com/songquanpeng/one-api/relay/model"
+)
+
+// Adaptor is an implementation of the Qwen adaptor for Vertex AI.
+type Adaptor struct{}
+
+// ConvertRequest converts an OpenAI request to a Qwen-compatible request.
+// Qwen models are fully OpenAI-compatible but require field mapping for token limits.
+//
+// This function handles the conversion by:
+//  1. Creating a copy of the original request to avoid modification
+//  2. Mapping max_completion_tokens to max_tokens if needed (Qwen only supports max_tokens)
+//  3. Clearing max_completion_tokens to avoid conflicts
+func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+	// Qwen models are fully OpenAI-compatible
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+
+	// Create a copy of the request to avoid modifying the original
+	qwenRequest := *request
+
+	// Qwen doesn't support max_completion_tokens, only max_tokens
+	// If max_completion_tokens is set but max_tokens is not, use max_completion_tokens as max_tokens
+	if qwenRequest.MaxCompletionTokens != nil && qwenRequest.MaxTokens == 0 {
+		qwenRequest.MaxTokens = *qwenRequest.MaxCompletionTokens
+	}
+
+	// Clear max_completion_tokens to avoid conflicts
+	qwenRequest.MaxCompletionTokens = nil
+
+	return &qwenRequest, nil
+}
+
+// ConvertImageRequest handles image generation requests for Qwen models.
+// Currently, Qwen models do not support image generation, so this function always returns an error.
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, request *model.ImageRequest) (any, error) {
+	// Qwen doesn't support image generation currently
+	return nil, errors.New("Vertex AI: Qwen does not support image generation")
+}
+
+// DoResponse handles the response from Qwen API and converts it to a standard format.
+// Since Qwen models are fully OpenAI-compatible, it uses the standard OpenAI-compatible response handlers.
+// For streaming responses, it uses the StreamHandler, otherwise the standard Handler.
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	// Use standard OpenAI-compatible response handling since Qwen is OpenAI-compatible
+	if meta.IsStream {
+		// TODO: This may need to return "openai_compatible.StreamHandlerWithThinking".
+		// Note: Vertex AI uses Unicode-escaped thinking tags (e.g., \u003cthink\u003e...\u003c/think\u003e)
+		// instead of raw XML-style tags like <think></think>.
+		err, usage = openai_compatible.StreamHandler(c, resp, meta.PromptTokens, meta.ActualModelName)
+	} else {
+		err, usage = openai_compatible.Handler(c, resp, meta.PromptTokens, meta.ActualModelName)
+	}
+	return usage, err
+}

--- a/relay/adaptor/vertexai/qwen/constants.go
+++ b/relay/adaptor/vertexai/qwen/constants.go
@@ -1,0 +1,26 @@
+// Package qwen provides model pricing constants for Qwen models in Vertex AI.
+package qwen
+
+import (
+	"github.com/songquanpeng/one-api/relay/adaptor"
+	"github.com/songquanpeng/one-api/relay/billing/ratio"
+)
+
+// ModelRatios contains pricing information for Qwen models
+var ModelRatios = map[string]adaptor.ModelConfig{
+	"qwen/qwen3-coder-480b-a35b-instruct-maas": {
+		Ratio:           1.00 * ratio.MilliTokensUsd, // $1.00 per million tokens input
+		CompletionRatio: 4.00 * ratio.MilliTokensUsd, // $4.00 per million tokens output
+	},
+	"qwen/qwen3-235b-a22b-instruct-2507-maas": {
+		Ratio:           0.25 * ratio.MilliTokensUsd, // $0.25 per million tokens input
+		CompletionRatio: 1.00 * ratio.MilliTokensUsd, // $1.00 per million tokens output
+	},
+	"qwen/qwen3-next-80b-a3b-instruct-maas": {
+		Ratio:           0.15 * ratio.MilliTokensUsd, // $0.15 per million tokens input
+		CompletionRatio: 1.20 * ratio.MilliTokensUsd, // $1.20 per million tokens output
+	},
+}
+
+// ModelList contains all Qwen models supported by VertexAI
+var ModelList = adaptor.GetModelListFromPricing(ModelRatios)

--- a/relay/adaptor/vertexai/registry.go
+++ b/relay/adaptor/vertexai/registry.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/songquanpeng/one-api/relay/adaptor/geminiOpenaiCompatible"
 	claude "github.com/songquanpeng/one-api/relay/adaptor/vertexai/claude"
+	"github.com/songquanpeng/one-api/relay/adaptor/vertexai/deepseek"
 	gemini "github.com/songquanpeng/one-api/relay/adaptor/vertexai/gemini"
 	"github.com/songquanpeng/one-api/relay/adaptor/vertexai/imagen"
+	"github.com/songquanpeng/one-api/relay/adaptor/vertexai/openai"
+	"github.com/songquanpeng/one-api/relay/adaptor/vertexai/qwen"
 	"github.com/songquanpeng/one-api/relay/adaptor/vertexai/veo"
 	"github.com/songquanpeng/one-api/relay/meta"
 	"github.com/songquanpeng/one-api/relay/model"
@@ -21,6 +24,9 @@ const (
 	VertexAIGemini
 	VertexAIImagen
 	VertexAIVeo
+	VertexAIDeepSeek
+	VertexAIOpenAI
+	VertexAIQwen
 )
 
 var modelMapping = map[string]VertexAIModelType{}
@@ -50,6 +56,24 @@ func init() {
 	for _, model := range veo.ModelList {
 		modelMapping[model] = VertexAIVeo
 	}
+
+	// register vertex deepseek models
+	modelList = append(modelList, deepseek.ModelList...)
+	for _, model := range deepseek.ModelList {
+		modelMapping[model] = VertexAIDeepSeek
+	}
+
+	// register vertex openai models
+	modelList = append(modelList, openai.ModelList...)
+	for _, model := range openai.ModelList {
+		modelMapping[model] = VertexAIOpenAI
+	}
+
+	// register vertex qwen models
+	modelList = append(modelList, qwen.ModelList...)
+	for _, model := range qwen.ModelList {
+		modelMapping[model] = VertexAIQwen
+	}
 }
 
 type innerAIAdapter interface {
@@ -69,6 +93,12 @@ func GetAdaptor(model string) innerAIAdapter {
 		return &imagen.Adaptor{}
 	case VertexAIVeo:
 		return &veo.Adaptor{}
+	case VertexAIDeepSeek:
+		return &deepseek.Adaptor{}
+	case VertexAIOpenAI:
+		return &openai.Adaptor{}
+	case VertexAIQwen:
+		return &qwen.Adaptor{}
 	default:
 		return nil
 	}

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -63,7 +63,7 @@ type GeneralOpenAIRequest struct {
 	TopLogprobs      *int     `json:"top_logprobs,omitempty"`
 	// MaxTokens is the maximum number of tokens to generate in the chat completion.
 	//
-	// Deprecated: Use MaxCompletionTokens instead.
+	// MaxTokens is not deprecated; most open-source models use max_tokens, not max_completion_tokens.
 	MaxTokens           int  `json:"max_tokens,omitempty"`
 	MaxCompletionTokens *int `json:"max_completion_tokens,omitempty"`
 	// N is how many chat completion choices to generate for each input message,


### PR DESCRIPTION
- [+] feat(vertexai): add support for DeepSeek, OpenAI, and Qwen models
- [+] fix(vertexai): ensure VertexAI project ID is configured for all models
- [+] fix(vertexai): handle custom base URL and region overrides for all models
- [+] fix(vertexai): ensure consistent handling of max_tokens and max_completion_tokens for all models
- [+] fix(vertexai): add tests for DeepSeek, OpenAI, and Qwen models

This PR is related to #209 and requires #208 to be merged first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vertex AI support for DeepSeek, OpenAI GPT-OSS, and Qwen model families with automatic endpoint routing by model type and Gemini fallback.
  * Streaming responses supported; image generation returns clear unsupported errors where applicable.
  * Custom base URL and region overrides for endpoint selection.

* **Refactor**
  * Centralized endpoint URL construction and routing for more predictable endpoint selection.

* **Documentation**
  * Clarified that max_tokens is supported (no longer marked deprecated).

* **Chores**
  * Updated model catalogs and pricing metadata for new models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->