### PR TITLE
[WIP]: Implement Official MCP Server For Documentation Related to this Repository

### DIFF
--- a/controller/mcp/documentation.go
+++ b/controller/mcp/documentation.go
@@ -1,0 +1,320 @@
+package mcp
+
+import "fmt"
+
+// Documentation generation functions (migrated from existing implementation)
+func generateChatCompletionsDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Chat Completions API
+
+## Endpoint
+POST %s/v1/chat/completions
+
+## Description
+Creates a model response for the given chat conversation. This is the main endpoint for conversational AI interactions.
+
+## Authentication
+Include your API key in the Authorization header:
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Hello!"}
+    ],
+    "temperature": 0.7,
+    "max_tokens": 150
+  }'
+`+"```"+`
+
+## Parameters
+- **model** (required): The model to use (e.g., gpt-4, gpt-3.5-turbo)
+- **messages** (required): Array of message objects with role and content
+- **temperature**: Controls randomness (0.0 to 2.0, default: 1.0)
+- **max_tokens**: Maximum tokens to generate
+- **stream**: Set to true for streaming responses
+
+## Response Format
+`+"```"+`json
+{
+  "id": "chatcmpl-123",
+  "object": "chat.completion",
+  "created": 1677652288,
+  "model": "gpt-4",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello! How can I help you today?"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 12,
+    "total_tokens": 21
+  }
+}
+`+"```", baseURL, baseURL)
+}
+
+func generateCompletionsDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Completions API
+
+## Endpoint
+POST %s/v1/completions
+
+## Description
+Creates a completion for the provided prompt and parameters.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "gpt-3.5-turbo-instruct",
+    "prompt": "Once upon a time",
+    "max_tokens": 50,
+    "temperature": 0.7
+  }'
+`+"```"+`
+
+## Key Parameters
+- **model** (required): Model identifier
+- **prompt** (required): Text prompt to complete
+- **max_tokens**: Maximum tokens to generate
+- **temperature**: Sampling temperature (0.0 to 2.0)`, baseURL, baseURL)
+}
+
+func generateEmbeddingsDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Embeddings API
+
+## Endpoint
+POST %s/v1/embeddings
+
+## Description
+Creates an embedding vector representing the input text.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "text-embedding-ada-002",
+    "input": "The food was delicious and the waiter..."
+  }'
+`+"```"+`
+
+## Parameters
+- **model** (required): Embedding model (e.g., text-embedding-ada-002)
+- **input** (required): Input text to embed`, baseURL, baseURL)
+}
+
+func generateImagesDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Image Generation API
+
+## Endpoint
+POST %s/v1/images/generations
+
+## Description
+Creates images from text prompts.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "dall-e-3",
+    "prompt": "A cute baby sea otter",
+    "n": 1,
+    "size": "1024x1024"
+  }'
+`+"```"+`
+
+## Parameters
+- **model** (required): Image generation model (dall-e-3, dall-e-2)
+- **prompt** (required): Text description of desired image
+- **n**: Number of images to generate (1-10)
+- **size**: Image size (256x256, 512x512, 1024x1024)`, baseURL, baseURL)
+}
+
+func generateAudioTranscriptionsDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Audio Transcriptions API
+
+## Endpoint
+POST %s/v1/audio/transcriptions
+
+## Description
+Transcribes audio into the input language.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/audio/transcriptions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F file="@audio.mp3" \
+  -F model="whisper-1"
+`+"```"+`
+
+## Parameters
+- **file** (required): Audio file (flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm)
+- **model** (required): Model identifier (whisper-1)
+- **language**: Language of input audio (ISO-639-1 format)`, baseURL, baseURL)
+}
+
+func generateAudioTranslationsDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Audio Translations API
+
+## Endpoint
+POST %s/v1/audio/translations
+
+## Description
+Translates audio into English.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/audio/translations \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F file="@audio.mp3" \
+  -F model="whisper-1"
+`+"```"+`
+
+## Parameters
+- **file** (required): Audio file to translate
+- **model** (required): Model identifier (whisper-1)`, baseURL, baseURL)
+}
+
+func generateAudioSpeechDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Audio Speech API
+
+## Endpoint
+POST %s/v1/audio/speech
+
+## Description
+Generates audio from input text.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "tts-1",
+    "input": "Hello world",
+    "voice": "alloy"
+  }'
+`+"```"+`
+
+## Parameters
+- **model** (required): TTS model (tts-1, tts-1-hd)
+- **input** (required): Text to generate audio for
+- **voice** (required): Voice option (alloy, echo, fable, onyx, nova, shimmer)`, baseURL, baseURL)
+}
+
+func generateModerationsDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Moderations API
+
+## Endpoint
+POST %s/v1/moderations
+
+## Description
+Classifies if text violates OpenAI's Usage Policies.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/moderations \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "input": "I want to kill them."
+  }'
+`+"```"+`
+
+## Parameters
+- **input** (required): Text to classify
+- **model**: Moderation model (text-moderation-stable, text-moderation-latest)`, baseURL, baseURL)
+}
+
+func generateModelsListDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Models List API
+
+## Endpoint
+GET %s/v1/models
+
+## Description
+Lists the currently available models and provides basic information about each.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/models \
+  -H "Authorization: Bearer YOUR_API_KEY"
+`+"```"+`
+
+## Response
+Returns a list of model objects containing id, object type, and other metadata.`, baseURL, baseURL)
+}
+
+func generateClaudeMessagesDocumentation(baseURL string) string {
+	return fmt.Sprintf(`# Claude Messages API
+
+## Endpoint
+POST %s/v1/messages
+
+## Description
+Creates messages using Claude API format.
+
+## Authentication
+Authorization: Bearer YOUR_API_KEY
+
+## Example Request
+`+"```"+`bash
+curl %s/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -d '{
+    "model": "claude-3-opus-20240229",
+    "max_tokens": 1000,
+    "messages": [
+      {"role": "user", "content": "Hello, Claude!"}
+    ]
+  }'
+`+"```"+`
+
+## Parameters
+- **model** (required): Claude model identifier
+- **messages** (required): Array of message objects
+- **max_tokens** (required): Maximum tokens to generate`, baseURL, baseURL)
+}

--- a/controller/mcp/documentation_test.go
+++ b/controller/mcp/documentation_test.go
@@ -1,0 +1,297 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateChatCompletionsDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateChatCompletionsDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Chat Completions API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/chat/completions")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"model": "gpt-4"`)
+	assert.Contains(t, doc, `"messages"`)
+	assert.Contains(t, doc, `"temperature"`)
+	assert.Contains(t, doc, `"max_tokens"`)
+	assert.Contains(t, doc, `**stream**`)
+
+	// Test response format structure
+	assert.Contains(t, doc, `"id": "chatcmpl-123"`)
+	assert.Contains(t, doc, `"object": "chat.completion"`)
+	assert.Contains(t, doc, `"choices"`)
+	assert.Contains(t, doc, `"usage"`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Chat completions documentation length: %d characters", len(doc))
+}
+
+func TestGenerateCompletionsDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateCompletionsDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Completions API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/completions")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"model": "gpt-3.5-turbo-instruct"`)
+	assert.Contains(t, doc, `"prompt"`)
+	assert.Contains(t, doc, `"max_tokens"`)
+	assert.Contains(t, doc, `"temperature"`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Completions documentation length: %d characters", len(doc))
+}
+
+func TestGenerateEmbeddingsDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateEmbeddingsDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Embeddings API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/embeddings")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"model": "text-embedding-ada-002"`)
+	assert.Contains(t, doc, `"input"`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Embeddings documentation length: %d characters", len(doc))
+}
+
+func TestGenerateImagesDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateImagesDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Image Generation API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/images/generations")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"model": "dall-e-3"`)
+	assert.Contains(t, doc, `"prompt"`)
+	assert.Contains(t, doc, `"n"`)
+	assert.Contains(t, doc, `"size"`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Images documentation length: %d characters", len(doc))
+}
+
+func TestGenerateAudioTranscriptionsDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateAudioTranscriptionsDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Audio Transcriptions API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/audio/transcriptions")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"whisper-1"`)
+	assert.Contains(t, doc, `file=`)
+	assert.Contains(t, doc, `model=`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Audio transcriptions documentation length: %d characters", len(doc))
+}
+
+func TestGenerateAudioTranslationsDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateAudioTranslationsDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Audio Translations API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/audio/translations")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"whisper-1"`)
+	assert.Contains(t, doc, `file=`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Audio translations documentation length: %d characters", len(doc))
+}
+
+func TestGenerateAudioSpeechDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateAudioSpeechDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Audio Speech API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/audio/speech")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"model": "tts-1"`)
+	assert.Contains(t, doc, `"input"`)
+	assert.Contains(t, doc, `"voice"`)
+	assert.Contains(t, doc, `"alloy"`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Audio speech documentation length: %d characters", len(doc))
+}
+
+func TestGenerateModerationsDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateModerationsDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Moderations API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/moderations")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"input"`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Moderations documentation length: %d characters", len(doc))
+}
+
+func TestGenerateModelsListDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateModelsListDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Models List API")
+	assert.Contains(t, doc, "GET https://api.example.com/v1/models")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Models list documentation length: %d characters", len(doc))
+}
+
+func TestGenerateClaudeMessagesDocumentation(t *testing.T) {
+	baseURL := "https://api.example.com"
+	doc := generateClaudeMessagesDocumentation(baseURL)
+
+	// Test that documentation contains expected elements
+	assert.Contains(t, doc, "# Claude Messages API")
+	assert.Contains(t, doc, "POST https://api.example.com/v1/messages")
+	assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY")
+	assert.Contains(t, doc, `"model": "claude-3-opus-20240229"`)
+	assert.Contains(t, doc, `"messages"`)
+	assert.Contains(t, doc, `"max_tokens"`)
+
+	// Test that baseURL is properly substituted
+	assert.Contains(t, doc, baseURL)
+
+	t.Logf("Claude messages documentation length: %d characters", len(doc))
+}
+
+func TestDocumentationWithDifferentBaseURLs(t *testing.T) {
+	testCases := []struct {
+		name    string
+		baseURL string
+	}{
+		{"localhost", "http://localhost:3000"},
+		{"https", "https://api.example.com"},
+		{"http", "http://api.example.com"},
+		{"with_port", "https://api.example.com:8080"},
+		{"with_path", "https://api.example.com/api"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := generateChatCompletionsDocumentation(tc.baseURL)
+
+			// Verify the base URL appears correctly in the documentation
+			assert.Contains(t, doc, tc.baseURL)
+
+			// Verify the full endpoint URL is constructed correctly
+			expectedEndpoint := tc.baseURL + "/v1/chat/completions"
+			assert.Contains(t, doc, expectedEndpoint)
+
+			t.Logf("✓ Documentation correctly uses baseURL: %s", tc.baseURL)
+		})
+	}
+}
+
+func TestDocumentationStructure(t *testing.T) {
+	baseURL := "https://api.example.com"
+
+	testCases := []struct {
+		name     string
+		genFunc  func(string) string
+		endpoint string
+	}{
+		{"chat_completions", generateChatCompletionsDocumentation, "/v1/chat/completions"},
+		{"completions", generateCompletionsDocumentation, "/v1/completions"},
+		{"embeddings", generateEmbeddingsDocumentation, "/v1/embeddings"},
+		{"images", generateImagesDocumentation, "/v1/images/generations"},
+		{"audio_transcriptions", generateAudioTranscriptionsDocumentation, "/v1/audio/transcriptions"},
+		{"audio_translations", generateAudioTranslationsDocumentation, "/v1/audio/translations"},
+		{"audio_speech", generateAudioSpeechDocumentation, "/v1/audio/speech"},
+		{"moderations", generateModerationsDocumentation, "/v1/moderations"},
+		{"models_list", generateModelsListDocumentation, "/v1/models"},
+		{"claude_messages", generateClaudeMessagesDocumentation, "/v1/messages"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := tc.genFunc(baseURL)
+
+			// Test common documentation structure
+			assert.Contains(t, doc, "# ", "Should have header")
+			assert.Contains(t, doc, "## Endpoint", "Should have endpoint section")
+			assert.Contains(t, doc, "## Description", "Should have description section")
+			assert.Contains(t, doc, "## Authentication", "Should have authentication section")
+			assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY", "Should have auth header")
+			assert.Contains(t, doc, tc.endpoint, "Should contain correct endpoint")
+
+			// Verify documentation is not empty
+			assert.Greater(t, len(doc), 100, "Documentation should be substantial")
+
+			// Verify no template placeholders remain
+			assert.NotContains(t, doc, "%s", "Should not contain format placeholders")
+
+			t.Logf("✓ %s documentation structure is valid", tc.name)
+		})
+	}
+}
+
+func TestDocumentationConsistency(t *testing.T) {
+	baseURL := "https://api.example.com"
+
+	docs := []string{
+		generateChatCompletionsDocumentation(baseURL),
+		generateCompletionsDocumentation(baseURL),
+		generateEmbeddingsDocumentation(baseURL),
+		generateImagesDocumentation(baseURL),
+		generateAudioTranscriptionsDocumentation(baseURL),
+		generateAudioTranslationsDocumentation(baseURL),
+		generateAudioSpeechDocumentation(baseURL),
+		generateModerationsDocumentation(baseURL),
+		generateModelsListDocumentation(baseURL),
+		generateClaudeMessagesDocumentation(baseURL),
+	}
+
+	// Test that all documentations follow consistent patterns
+	for i, doc := range docs {
+		// All should contain authentication section
+		assert.Contains(t, doc, "Authorization: Bearer YOUR_API_KEY",
+			"Documentation %d should have consistent auth format", i)
+
+		// All should use consistent markdown formatting
+		assert.True(t, strings.Contains(doc, "# ") && strings.Contains(doc, "## "),
+			"Documentation %d should use consistent markdown headers", i)
+
+		// All should contain the base URL
+		assert.Contains(t, doc, baseURL,
+			"Documentation %d should contain the base URL", i)
+	}
+
+	t.Logf("✓ All %d documentation functions follow consistent patterns", len(docs))
+}

--- a/controller/mcp/handlers.go
+++ b/controller/mcp/handlers.go
@@ -1,0 +1,215 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// addRelayAPITools adds all the relay API tools to the MCP server
+func (s *Server) addRelayAPITools() {
+	// Chat Completions tool
+	type ChatCompletionsArgs struct {
+		Model       string           `json:"model" jsonschema_description:"ID of the model to use" jsonschema_required:"true"`
+		Messages    []map[string]any `json:"messages" jsonschema_description:"Array of message objects" jsonschema_required:"true"`
+		Temperature *float64         `json:"temperature,omitempty" jsonschema_description:"Sampling temperature between 0 and 2"`
+		MaxTokens   *int             `json:"max_tokens,omitempty" jsonschema_description:"Maximum number of tokens to generate"`
+		Stream      *bool            `json:"stream,omitempty" jsonschema_description:"Whether to stream responses"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "chat_completions",
+		Description: "Create a chat completion using OpenAI-compatible API. Supports streaming and non-streaming responses.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args ChatCompletionsArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateChatCompletionsDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Completions tool
+	type CompletionsArgs struct {
+		Model       string   `json:"model" jsonschema_description:"ID of the model to use" jsonschema_required:"true"`
+		Prompt      string   `json:"prompt" jsonschema_description:"The prompt to generate completions for" jsonschema_required:"true"`
+		MaxTokens   *int     `json:"max_tokens,omitempty" jsonschema_description:"Maximum number of tokens to generate"`
+		Temperature *float64 `json:"temperature,omitempty" jsonschema_description:"Sampling temperature"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "completions",
+		Description: "Create a text completion using OpenAI-compatible API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args CompletionsArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateCompletionsDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Embeddings tool
+	type EmbeddingsArgs struct {
+		Model string `json:"model" jsonschema_description:"ID of the model to use" jsonschema_required:"true"`
+		Input string `json:"input" jsonschema_description:"Input text to embed" jsonschema_required:"true"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "embeddings",
+		Description: "Create embeddings for input text using OpenAI-compatible API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args EmbeddingsArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateEmbeddingsDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Images Generation tool
+	type ImagesArgs struct {
+		Model  string `json:"model" jsonschema_description:"ID of the model to use" jsonschema_required:"true"`
+		Prompt string `json:"prompt" jsonschema_description:"Text description of desired image" jsonschema_required:"true"`
+		N      *int   `json:"n,omitempty" jsonschema_description:"Number of images to generate"`
+		Size   string `json:"size,omitempty" jsonschema_description:"Size of generated images"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "images_generations",
+		Description: "Create images from text prompts using OpenAI-compatible API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args ImagesArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateImagesDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Audio Transcriptions tool
+	type AudioTranscriptionsArgs struct {
+		Model    string  `json:"model" jsonschema_description:"ID of the model to use" jsonschema_required:"true"`
+		File     string  `json:"file" jsonschema_description:"Audio file to transcribe" jsonschema_required:"true"`
+		Language *string `json:"language,omitempty" jsonschema_description:"Language of input audio"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "audio_transcriptions",
+		Description: "Transcribe audio into text using OpenAI-compatible API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args AudioTranscriptionsArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateAudioTranscriptionsDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Audio Translations tool
+	type AudioTranslationsArgs struct {
+		Model string `json:"model" jsonschema_description:"ID of the model to use" jsonschema_required:"true"`
+		File  string `json:"file" jsonschema_description:"Audio file to translate" jsonschema_required:"true"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "audio_translations",
+		Description: "Translate audio into English text using OpenAI-compatible API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args AudioTranslationsArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateAudioTranslationsDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Audio Speech tool
+	type AudioSpeechArgs struct {
+		Model string `json:"model" jsonschema_description:"ID of the model to use" jsonschema_required:"true"`
+		Input string `json:"input" jsonschema_description:"Text to generate audio for" jsonschema_required:"true"`
+		Voice string `json:"voice" jsonschema_description:"Voice to use" jsonschema_required:"true"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "audio_speech",
+		Description: "Generate speech from text using OpenAI-compatible API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args AudioSpeechArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateAudioSpeechDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Moderations tool
+	type ModerationsArgs struct {
+		Input string  `json:"input" jsonschema_description:"Text to classify" jsonschema_required:"true"`
+		Model *string `json:"model,omitempty" jsonschema_description:"Moderation model to use"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "moderations",
+		Description: "Check if text violates OpenAI's usage policies using moderation API.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args ModerationsArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateModerationsDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Models List tool
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "models_list",
+		Description: "List available models through the One-API relay.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateModelsListDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+
+	// Claude Messages tool
+	type ClaudeMessagesArgs struct {
+		Model     string           `json:"model" jsonschema_description:"ID of Claude model to use" jsonschema_required:"true"`
+		Messages  []map[string]any `json:"messages" jsonschema_description:"Array of message objects" jsonschema_required:"true"`
+		MaxTokens int              `json:"max_tokens" jsonschema_description:"Maximum tokens to generate" jsonschema_required:"true"`
+	}
+
+	mcp.AddTool(s.server, &mcp.Tool{
+		Name:        "claude_messages",
+		Description: "Create messages using Claude API format.",
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args ClaudeMessagesArgs) (*mcp.CallToolResult, any, error) {
+		baseURL := getBaseURL()
+		doc := generateClaudeMessagesDocumentation(baseURL)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: doc},
+			},
+		}, nil, nil
+	})
+}

--- a/controller/mcp/handlers_http_test.go
+++ b/controller/mcp/handlers_http_test.go
@@ -1,0 +1,358 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/songquanpeng/one-api/common/config"
+)
+
+func TestHandler(t *testing.T) {
+	// Set test mode for gin
+	gin.SetMode(gin.TestMode)
+
+	// Create test router
+	router := gin.New()
+	router.GET("/mcp", Handler)
+	router.POST("/mcp", Handler)
+
+	testCases := []struct {
+		name           string
+		method         string
+		expectedStatus int
+	}{
+		{
+			name:           "GET_request",
+			method:         "GET",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "POST_request",
+			method:         "POST",
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create request
+			req, err := http.NewRequest(tc.method, "/mcp", nil)
+			assert.NoError(t, err, "Should create request without error")
+
+			// Create response recorder
+			w := httptest.NewRecorder()
+
+			// Perform request
+			router.ServeHTTP(w, req)
+
+			// Check status code
+			assert.Equal(t, tc.expectedStatus, w.Code, "Should return correct status code")
+
+			// Parse response
+			var response map[string]any
+			err = json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err, "Should parse JSON response successfully")
+
+			// Check response structure
+			assert.Contains(t, response, "message", "Response should contain message field")
+			assert.Contains(t, response, "info", "Response should contain info field")
+			assert.Contains(t, response, "tools", "Response should contain tools field")
+			assert.Contains(t, response, "note", "Response should contain note field")
+
+			// Check message content
+			message, ok := response["message"].(string)
+			assert.True(t, ok, "Message should be a string")
+			assert.Contains(t, message, "One-API Official MCP", "Message should mention One-API MCP")
+
+			t.Logf("✓ %s request handled correctly", tc.method)
+		})
+	}
+}
+
+func TestHandlerResponseContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/mcp", Handler)
+
+	// Create request
+	req, _ := http.NewRequest("GET", "/mcp", nil)
+	w := httptest.NewRecorder()
+
+	// Perform request
+	router.ServeHTTP(w, req)
+
+	// Parse response
+	var response map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	// Test specific response content
+	expectedFields := map[string]string{
+		"message": "One-API Official MCP for Documentation is available",
+		"info":    "This is an One-API Official MCP server implementation using the official Go SDK",
+		"tools":   "Use an MCP client to connect and access available tools",
+		"note":    "Direct HTTP access is limited - use MCP protocol for full functionality",
+	}
+
+	for field, expectedValue := range expectedFields {
+		actualValue, exists := response[field]
+		assert.True(t, exists, "Response should contain field: %s", field)
+		assert.Equal(t, expectedValue, actualValue, "Field %s should have correct value", field)
+	}
+
+	t.Logf("✓ Handler response contains all expected content")
+}
+
+func TestHandlerWithDifferentContentTypes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/mcp", Handler)
+
+	contentTypes := []string{
+		"application/json",
+		"text/plain",
+		"application/xml",
+		"",
+	}
+
+	for _, contentType := range contentTypes {
+		t.Run("content_type_"+contentType, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", "/mcp", nil)
+			if contentType != "" {
+				req.Header.Set("Content-Type", contentType)
+			}
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			// Should handle all content types the same way (returns info message)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			var response map[string]any
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err, "Should parse JSON response regardless of request content type")
+
+			assert.Contains(t, response, "message", "Should contain message field")
+
+			t.Logf("✓ Handler works with content-type: %s", contentType)
+		})
+	}
+}
+
+func TestHandlerWithDifferentHTTPMethods(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	
+	// Register handler for various methods
+	router.GET("/mcp", Handler)
+	router.POST("/mcp", Handler)
+	router.PUT("/mcp", Handler)
+	router.DELETE("/mcp", Handler)
+
+	methods := []string{"GET", "POST", "PUT", "DELETE"}
+
+	for _, method := range methods {
+		t.Run("method_"+method, func(t *testing.T) {
+			req, _ := http.NewRequest(method, "/mcp", nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			// All methods should return the same response
+			assert.Equal(t, http.StatusOK, w.Code, "Method %s should return 200", method)
+
+			var response map[string]any
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err, "Should parse JSON for method %s", method)
+
+			assert.Contains(t, response, "message", "Should contain message for method %s", method)
+
+			t.Logf("✓ Handler works with HTTP method: %s", method)
+		})
+	}
+}
+
+func TestHandlerJSONResponseFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/mcp", Handler)
+
+	req, _ := http.NewRequest("GET", "/mcp", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Check content type
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	// Check that response is valid JSON
+	var response map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err, "Response should be valid JSON")
+
+	// Check JSON structure types
+	assert.IsType(t, "", response["message"], "message should be string")
+	assert.IsType(t, "", response["info"], "info should be string")
+	assert.IsType(t, "", response["tools"], "tools should be string")
+	assert.IsType(t, "", response["note"], "note should be string")
+
+	t.Logf("✓ Handler returns properly formatted JSON")
+}
+
+func TestHandlerConcurrentRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/mcp", Handler)
+
+	const numRequests = 50
+	results := make(chan int, numRequests)
+
+	// Send concurrent requests
+	for i := 0; i < numRequests; i++ {
+		go func() {
+			req, _ := http.NewRequest("GET", "/mcp", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			results <- w.Code
+		}()
+	}
+
+	// Collect results
+	successCount := 0
+	for i := 0; i < numRequests; i++ {
+		statusCode := <-results
+		if statusCode == http.StatusOK {
+			successCount++
+		}
+	}
+
+	assert.Equal(t, numRequests, successCount, "All concurrent requests should succeed")
+	t.Logf("✓ Handler handles %d concurrent requests successfully", numRequests)
+}
+
+func TestHandlerWithConfigChanges(t *testing.T) {
+	// Save original config
+	originalServerAddress := config.ServerAddress
+
+	testCases := []struct {
+		name          string
+		serverAddress string
+	}{
+		{"with_custom_server", "https://custom.example.com"},
+		{"with_localhost", "http://localhost:8080"},
+		{"with_empty_config", ""},
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/mcp", Handler)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set test config
+			config.ServerAddress = tc.serverAddress
+
+			req, _ := http.NewRequest("GET", "/mcp", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code, "Should work with any config")
+
+			var response map[string]any
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err, "Should parse response with config: %s", tc.serverAddress)
+
+			assert.Contains(t, response, "message", "Should contain message")
+
+			t.Logf("✓ Handler works with ServerAddress: %s", tc.serverAddress)
+		})
+	}
+
+	// Restore original config
+	config.ServerAddress = originalServerAddress
+}
+
+// Benchmark the handler performance
+func BenchmarkHandler(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/mcp", Handler)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req, _ := http.NewRequest("GET", "/mcp", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+	}
+}
+
+// Test middleware compatibility
+func TestHandlerWithMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Add some test middleware
+	router.Use(func(c *gin.Context) {
+		c.Header("X-Test-Header", "test-value")
+		c.Next()
+	})
+
+	router.GET("/mcp", Handler)
+
+	req, _ := http.NewRequest("GET", "/mcp", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Check that middleware executed
+	assert.Equal(t, "test-value", w.Header().Get("X-Test-Header"))
+
+	// Check that handler still works
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Contains(t, response, "message")
+
+	t.Logf("✓ Handler works correctly with middleware")
+}
+
+// Test error handling in handler
+func TestHandlerErrorScenarios(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/mcp", Handler)
+
+	// Test with malformed requests (though our handler doesn't parse request body)
+	req, _ := http.NewRequest("GET", "/mcp", nil)
+	req.Header.Set("Content-Length", "invalid")
+	
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Handler should still work since it doesn't depend on request parsing
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	t.Logf("✓ Handler is resilient to malformed requests")
+}
+
+func TestHandlerResponseSize(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/mcp", Handler)
+
+	req, _ := http.NewRequest("GET", "/mcp", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	responseSize := len(w.Body.Bytes())
+	
+	// Response should be reasonably sized (not too small, not too large)
+	assert.Greater(t, responseSize, 50, "Response should contain meaningful content")
+	assert.Less(t, responseSize, 5000, "Response should not be excessively large")
+
+	t.Logf("✓ Handler response size is appropriate: %d bytes", responseSize)
+}

--- a/controller/mcp/server.go
+++ b/controller/mcp/server.go
@@ -1,0 +1,54 @@
+package mcp
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/songquanpeng/one-api/common/config"
+)
+
+// Server wraps the official MCP SDK server
+type Server struct {
+	server *mcp.Server
+}
+
+// NewServer creates a new MCP server using the official SDK
+func NewServer() *Server {
+	// Create the MCP server with implementation info
+	server := mcp.NewServer(&mcp.Implementation{
+		Name:    "one-api-official-mcp",
+		Version: "1.0.0",
+	}, nil)
+
+	Server := &Server{
+		server: server,
+	}
+
+	// Add tools for each One-API relay endpoint
+	Server.addRelayAPITools()
+
+	return Server
+}
+
+// getBaseURL returns the base URL for API documentation
+func getBaseURL() string {
+	if config.ServerAddress != "" {
+		return config.ServerAddress
+	}
+	return "https://your-one-api-host" // fallback
+}
+
+// Handler handles MCP requests through HTTP (bridge between HTTP and MCP SDK)
+func Handler(c *gin.Context) {
+	// For now, we'll provide information about how to connect to the MCP server
+	// In a full implementation, this would need to set up the appropriate transport
+	// and handle the MCP protocol properly
+
+	response := map[string]any{
+		"message": "One-API Official MCP for Documentation is available",
+		"info":    "This is an One-API Official MCP server implementation using the official Go SDK",
+		"tools":   "Use an MCP client to connect and access available tools",
+		"note":    "Direct HTTP access is limited - use MCP protocol for full functionality",
+	}
+
+	c.JSON(200, response)
+}

--- a/controller/mcp/server_test.go
+++ b/controller/mcp/server_test.go
@@ -1,0 +1,264 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/songquanpeng/one-api/common/config"
+)
+
+func TestNewServer(t *testing.T) {
+	server := NewServer()
+
+	// Test server creation
+	assert.NotNil(t, server, "Server should not be nil")
+	assert.NotNil(t, server.server, "Internal MCP server should not be nil")
+
+	// Test that server is properly initialized
+	assert.IsType(t, &Server{}, server, "Should return correct server type")
+
+	t.Logf("✓ MCP server created successfully")
+}
+
+func TestServerImplementationInfo(t *testing.T) {
+	server := NewServer()
+
+	// Since we can't directly access the implementation info from the SDK,
+	// we test that the server was created without errors
+	assert.NotNil(t, server.server, "Server should be initialized with implementation info")
+
+	t.Logf("✓ Server implementation info configured")
+}
+
+func TestGetBaseURL(t *testing.T) {
+	// Save original config value
+	originalServerAddress := config.ServerAddress
+
+	testCases := []struct {
+		name           string
+		serverAddress  string
+		expectedResult string
+	}{
+		{
+			name:           "with_server_address_set",
+			serverAddress:  "https://api.example.com",
+			expectedResult: "https://api.example.com",
+		},
+		{
+			name:           "with_localhost",
+			serverAddress:  "http://localhost:3000",
+			expectedResult: "http://localhost:3000",
+		},
+		{
+			name:           "with_empty_server_address",
+			serverAddress:  "",
+			expectedResult: "https://your-one-api-host",
+		},
+		{
+			name:           "with_port_number",
+			serverAddress:  "https://api.example.com:8080",
+			expectedResult: "https://api.example.com:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set test config
+			config.ServerAddress = tc.serverAddress
+
+			// Test getBaseURL
+			result := getBaseURL()
+
+			// Verify result
+			assert.Equal(t, tc.expectedResult, result)
+
+			t.Logf("✓ getBaseURL() with ServerAddress='%s' returns '%s'", tc.serverAddress, result)
+		})
+	}
+
+	// Restore original config
+	config.ServerAddress = originalServerAddress
+}
+
+func TestGetBaseURLEnvironmentVariable(t *testing.T) {
+	// Save original values
+	originalServerAddress := config.ServerAddress
+	originalEnv := os.Getenv("SERVER_ADDRESS")
+
+	// Test with environment variable (if the config reads from env)
+	testURL := "https://env.example.com"
+	os.Setenv("SERVER_ADDRESS", testURL)
+	
+	// Reset config to empty to test fallback
+	config.ServerAddress = ""
+	
+	result := getBaseURL()
+	expected := "https://your-one-api-host" // Should use fallback since config.ServerAddress is empty
+
+	assert.Equal(t, expected, result)
+
+	// Restore original values
+	config.ServerAddress = originalServerAddress
+	if originalEnv != "" {
+		os.Setenv("SERVER_ADDRESS", originalEnv)
+	} else {
+		os.Unsetenv("SERVER_ADDRESS")
+	}
+
+	t.Logf("✓ getBaseURL() fallback mechanism works correctly")
+}
+
+// Test helper function to check if tools are registered
+func TestServerToolsRegistration(t *testing.T) {
+	server := NewServer()
+
+	// Since we can't directly access the tools from the MCP SDK,
+	// we test that the server was created and tools registration completed without errors
+	assert.NotNil(t, server.server, "Server should have tools registered")
+
+	// The addRelayAPITools() function should have been called during NewServer()
+	// We can't directly verify the tools are registered due to SDK limitations,
+	// but we can ensure the function completes successfully
+	
+	t.Logf("✓ Server tools registration completed")
+}
+
+// Test that we can call addRelayAPITools multiple times without issues
+func TestAddRelayAPIToolsIdempotent(t *testing.T) {
+	server := NewServer()
+
+	// Call addRelayAPITools again - should not cause issues
+	assert.NotPanics(t, func() {
+		server.addRelayAPITools()
+	}, "addRelayAPITools should be safe to call multiple times")
+
+	t.Logf("✓ addRelayAPITools is idempotent")
+}
+
+// Mock test for tool functionality - tests that tools can be called
+func TestServerToolsCanBeCalled(t *testing.T) {
+	server := NewServer()
+
+	// Test context
+	ctx := context.Background()
+
+	// We can't easily test the individual tools without more complex mocking
+	// of the MCP SDK, but we can verify the server is properly set up
+	assert.NotNil(t, server.server, "Server should be ready to handle tool calls")
+
+	// The tool argument types are defined within the addRelayAPITools function
+	// and are not accessible from outside that scope. This is intentional
+	// encapsulation. We verify that the server was created successfully
+	// and the addRelayAPITools function completed without errors.
+
+	_ = ctx // Use ctx to avoid unused variable warning
+
+	t.Logf("✓ Server is properly set up to handle tool calls")
+}
+
+// Benchmark test for server creation
+func BenchmarkNewServer(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		server := NewServer()
+		_ = server // Avoid unused variable warning
+	}
+}
+
+// Benchmark test for getBaseURL
+func BenchmarkGetBaseURL(b *testing.B) {
+	config.ServerAddress = "https://api.example.com"
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		url := getBaseURL()
+		_ = url // Avoid unused variable warning
+	}
+}
+
+// Test server configuration edge cases
+func TestServerEdgeCases(t *testing.T) {
+	testCases := []struct {
+		name          string
+		setupFunc     func()
+		expectedPanic bool
+	}{
+		{
+			name: "normal_creation",
+			setupFunc: func() {
+				config.ServerAddress = "https://api.example.com"
+			},
+			expectedPanic: false,
+		},
+		{
+			name: "empty_config",
+			setupFunc: func() {
+				config.ServerAddress = ""
+			},
+			expectedPanic: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setupFunc()
+
+			if tc.expectedPanic {
+				assert.Panics(t, func() {
+					NewServer()
+				}, "Should panic in edge case: %s", tc.name)
+			} else {
+				assert.NotPanics(t, func() {
+					server := NewServer()
+					assert.NotNil(t, server, "Server should be created successfully")
+				}, "Should not panic in edge case: %s", tc.name)
+			}
+
+			t.Logf("✓ Edge case '%s' handled correctly", tc.name)
+		})
+	}
+}
+
+// Test that the server struct is properly encapsulated
+func TestServerEncapsulation(t *testing.T) {
+	server := NewServer()
+
+	// Test that we can access the server field (it's public for testing)
+	assert.NotNil(t, server.server, "server field should be accessible")
+
+	// Test type assertions
+	assert.IsType(t, &Server{}, server)
+	assert.IsType(t, &mcp.Server{}, server.server)
+
+	t.Logf("✓ Server encapsulation is correct")
+}
+
+// Test concurrent server creation (thread safety)
+func TestConcurrentServerCreation(t *testing.T) {
+	const goroutines = 10
+	servers := make([]*Server, goroutines)
+	done := make(chan int, goroutines)
+
+	// Create servers concurrently
+	for i := 0; i < goroutines; i++ {
+		go func(index int) {
+			servers[index] = NewServer()
+			done <- index
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+
+	// Verify all servers were created successfully
+	for i, server := range servers {
+		assert.NotNil(t, server, "Server %d should be created", i)
+		assert.NotNil(t, server.server, "Server %d internal server should be created", i)
+	}
+
+	t.Logf("✓ Concurrent server creation works correctly (%d servers)", goroutines)
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jinzhu/copier v0.4.0
 	github.com/joho/godotenv v1.5.1
+	github.com/modelcontextprotocol/go-sdk v0.8.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkoukk/tiktoken-go v0.1.7
 	github.com/prometheus/client_golang v1.23.0
@@ -87,6 +88,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932 // indirect
+	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
@@ -122,6 +124,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	github.com/xlzd/gotp v0.1.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.dedis.ch/kyber/v3 v3.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/google/go-cpy v0.0.0-20211218193943-a9c933c06932/go.mod h1:cC6EdPbj/1
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -355,6 +357,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/modelcontextprotocol/go-sdk v0.8.0 h1:jdsBtGzBLY287WKSIjYovOXAqtJkP+HtFQFKrZd4a6c=
+github.com/modelcontextprotocol/go-sdk v0.8.0/go.mod h1:nYtYQroQ2KQiM0/SbyEPUWQ6xs4B95gJjEalc9AQyOs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -461,6 +465,8 @@ github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/xlzd/gotp v0.1.0 h1:37blvlKCh38s+fkem+fFh7sMnceltoIEBYTVXyoa5Po=
 github.com/xlzd/gotp v0.1.0/go.mod h1:ndLJ3JKzi3xLmUProq4LLxCuECL93dG9WASNLpHz8qg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/router/api.go
+++ b/router/api.go
@@ -3,6 +3,7 @@ package router
 import (
 	"github.com/songquanpeng/one-api/controller"
 	"github.com/songquanpeng/one-api/controller/auth"
+	"github.com/songquanpeng/one-api/controller/mcp"
 	"github.com/songquanpeng/one-api/middleware"
 
 	"github.com/gin-contrib/gzip"
@@ -156,5 +157,13 @@ func SetApiRouter(router *gin.Engine) {
 		{
 			groupRoute.GET("/", controller.GetGroups)
 		}
+	}
+
+	// MCP (Model Context Protocol) server routes using official SDK
+	mcpRoute := apiRouter.Group("/mcp")
+	mcpRoute.Use(middleware.TokenAuth()) // Require API token authentication
+	{
+		mcpRoute.GET("/", mcp.Handler)
+		mcpRoute.POST("/", mcp.Handler)
 	}
 }


### PR DESCRIPTION
- [+] docs(mcp): add documentation generation functions for all One-API endpoints
- [+] feat(mcp): implement MCP server using official SDK, add tools for each One-API endpoint
- [+] test(mcp): add comprehensive tests for documentation generation, server creation, and tools

This PR related #211 