### PR TITLE
Improve AWS Bedrock Adaptors

### DIFF
--- a/relay/adaptor/aws/cohere/main.go
+++ b/relay/adaptor/aws/cohere/main.go
@@ -171,10 +171,28 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
+	var finalUsageSent bool
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
+			// Send final usage chunk before [DONE] if we have usage data
+			//
+			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
+			// as I'm currently busy building an agent framework in Go.
+			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
+				usageResponse := &openai.ChatCompletionsStreamResponse{
+					Id:      id,
+					Object:  "chat.completion.chunk",
+					Created: createdTime,
+					Model:   c.GetString(ctxkey.RequestModel),
+					Choices: []openai.ChatCompletionsStreamResponseChoice{},
+					Usage:   &usage,
+				}
+				if jsonStr, err := json.Marshal(usageResponse); err == nil {
+					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+				}
+			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}

--- a/relay/adaptor/aws/cohere/main.go
+++ b/relay/adaptor/aws/cohere/main.go
@@ -171,28 +171,11 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
-	var finalUsageSent bool
+	var stopReason *string
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
-			// Send final usage chunk before [DONE] if we have usage data
-			//
-			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
-			// as I'm currently busy building an agent framework in Go.
-			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
-				usageResponse := &openai.ChatCompletionsStreamResponse{
-					Id:      id,
-					Object:  "chat.completion.chunk",
-					Created: createdTime,
-					Model:   c.GetString(ctxkey.RequestModel),
-					Choices: []openai.ChatCompletionsStreamResponseChoice{},
-					Usage:   &usage,
-				}
-				if jsonStr, err := json.Marshal(usageResponse); err == nil {
-					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
-				}
-			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}
@@ -245,31 +228,10 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 		case *types.ConverseStreamOutputMemberMessageStop:
 			// Handle message stop with OpenAI-compatible response structure
-			finishReason := convertStopReason(string(v.Value.StopReason))
-			response := &openai.ChatCompletionsStreamResponse{
-				Id:      id,
-				Object:  "chat.completion.chunk",
-				Created: createdTime,
-				Model:   c.GetString(ctxkey.RequestModel),
-				Choices: []openai.ChatCompletionsStreamResponseChoice{
-					{
-						Index:        0,
-						Delta:        relaymodel.Message{},
-						FinishReason: finishReason,
-					},
-				},
-			}
-
-			jsonStr, err := json.Marshal(response)
-			if err != nil {
-				lg.Error("error marshalling final stream response", zap.Error(err))
-				return false
-			}
-			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+			stopReason = convertStopReason(string(v.Value.StopReason))
 			return true
 
 		case *types.ConverseStreamOutputMemberMetadata:
-			// Handle metadata (usage)
 			if streamUsage := v.Value.Usage; streamUsage != nil {
 				if streamUsage.InputTokens != nil {
 					usage.PromptTokens = int(*streamUsage.InputTokens)
@@ -281,6 +243,28 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 					usage.TotalTokens = int(*streamUsage.TotalTokens)
 				}
 			}
+
+			response := &openai.ChatCompletionsStreamResponse{
+				Id:      id,
+				Object:  "chat.completion.chunk",
+				Created: createdTime,
+				Model:   c.GetString(ctxkey.RequestModel),
+				Choices: []openai.ChatCompletionsStreamResponseChoice{
+					{
+						Index:        0,
+						Delta:        relaymodel.Message{},
+						FinishReason: stopReason,
+					},
+				},
+				Usage: &usage,
+			}
+
+			jsonStr, err := json.Marshal(response)
+			if err != nil {
+				lg.Error("error marshalling final stream response", zap.Error(err))
+				return false
+			}
+			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
 			return true
 
 		default:

--- a/relay/adaptor/aws/deepseek/main.go
+++ b/relay/adaptor/aws/deepseek/main.go
@@ -186,10 +186,28 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
+	var finalUsageSent bool
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
+			// Send final usage chunk before [DONE] if we have usage data
+			//
+			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
+			// as I'm currently busy building an agent framework in Go.
+			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
+				usageResponse := &openai.ChatCompletionsStreamResponse{
+					Id:      id,
+					Object:  "chat.completion.chunk",
+					Created: createdTime,
+					Model:   c.GetString(ctxkey.RequestModel),
+					Choices: []openai.ChatCompletionsStreamResponseChoice{},
+					Usage:   &usage,
+				}
+				if jsonStr, err := json.Marshal(usageResponse); err == nil {
+					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+				}
+			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}

--- a/relay/adaptor/aws/deepseek/main.go
+++ b/relay/adaptor/aws/deepseek/main.go
@@ -186,28 +186,11 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
-	var finalUsageSent bool
+	var stopReason *string
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
-			// Send final usage chunk before [DONE] if we have usage data
-			//
-			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
-			// as I'm currently busy building an agent framework in Go.
-			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
-				usageResponse := &openai.ChatCompletionsStreamResponse{
-					Id:      id,
-					Object:  "chat.completion.chunk",
-					Created: createdTime,
-					Model:   c.GetString(ctxkey.RequestModel),
-					Choices: []openai.ChatCompletionsStreamResponseChoice{},
-					Usage:   &usage,
-				}
-				if jsonStr, err := json.Marshal(usageResponse); err == nil {
-					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
-				}
-			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}
@@ -289,31 +272,10 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 		case *types.ConverseStreamOutputMemberMessageStop:
 			// Handle message stop with OpenAI-compatible response structure
-			finishReason := convertStopReason(string(v.Value.StopReason))
-			response := &openai.ChatCompletionsStreamResponse{
-				Id:      id,
-				Object:  "chat.completion.chunk",
-				Created: createdTime,
-				Model:   c.GetString(ctxkey.RequestModel),
-				Choices: []openai.ChatCompletionsStreamResponseChoice{
-					{
-						Index:        0,
-						Delta:        relaymodel.Message{},
-						FinishReason: finishReason,
-					},
-				},
-			}
-
-			jsonStr, err := json.Marshal(response)
-			if err != nil {
-				lg.Error("error marshalling final stream response", zap.Error(err))
-				return false
-			}
-			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+			stopReason = convertStopReason(string(v.Value.StopReason))
 			return true
 
 		case *types.ConverseStreamOutputMemberMetadata:
-			// Handle metadata (usage)
 			if streamUsage := v.Value.Usage; streamUsage != nil {
 				if streamUsage.InputTokens != nil {
 					usage.PromptTokens = int(*streamUsage.InputTokens)
@@ -325,6 +287,28 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 					usage.TotalTokens = int(*streamUsage.TotalTokens)
 				}
 			}
+
+			response := &openai.ChatCompletionsStreamResponse{
+				Id:      id,
+				Object:  "chat.completion.chunk",
+				Created: createdTime,
+				Model:   c.GetString(ctxkey.RequestModel),
+				Choices: []openai.ChatCompletionsStreamResponseChoice{
+					{
+						Index:        0,
+						Delta:        relaymodel.Message{},
+						FinishReason: stopReason,
+					},
+				},
+				Usage: &usage,
+			}
+
+			jsonStr, err := json.Marshal(response)
+			if err != nil {
+				lg.Error("error marshalling final stream response", zap.Error(err))
+				return false
+			}
+			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
 			return true
 
 		default:

--- a/relay/adaptor/aws/llama3/main.go
+++ b/relay/adaptor/aws/llama3/main.go
@@ -417,10 +417,28 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
+	var finalUsageSent bool
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
+			// Send final usage chunk before [DONE] if we have usage data
+			//
+			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
+			// as I'm currently busy building an agent framework in Go.
+			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
+				usageResponse := &openai.ChatCompletionsStreamResponse{
+					Id:      id,
+					Object:  "chat.completion.chunk",
+					Created: createdTime,
+					Model:   c.GetString(ctxkey.RequestModel),
+					Choices: []openai.ChatCompletionsStreamResponseChoice{},
+					Usage:   &usage,
+				}
+				if jsonStr, err := json.Marshal(usageResponse); err == nil {
+					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+				}
+			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}

--- a/relay/adaptor/aws/llama3/main.go
+++ b/relay/adaptor/aws/llama3/main.go
@@ -417,28 +417,11 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
-	var finalUsageSent bool
+	var stopReason *string
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
-			// Send final usage chunk before [DONE] if we have usage data
-			//
-			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
-			// as I'm currently busy building an agent framework in Go.
-			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
-				usageResponse := &openai.ChatCompletionsStreamResponse{
-					Id:      id,
-					Object:  "chat.completion.chunk",
-					Created: createdTime,
-					Model:   c.GetString(ctxkey.RequestModel),
-					Choices: []openai.ChatCompletionsStreamResponseChoice{},
-					Usage:   &usage,
-				}
-				if jsonStr, err := json.Marshal(usageResponse); err == nil {
-					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
-				}
-			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}
@@ -491,31 +474,10 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 		case *types.ConverseStreamOutputMemberMessageStop:
 			// Handle message stop with OpenAI-compatible response structure
-			finishReason := convertStopReason(string(v.Value.StopReason))
-			response := &openai.ChatCompletionsStreamResponse{
-				Id:      id,
-				Object:  "chat.completion.chunk",
-				Created: createdTime,
-				Model:   c.GetString(ctxkey.RequestModel),
-				Choices: []openai.ChatCompletionsStreamResponseChoice{
-					{
-						Index:        0,
-						Delta:        relaymodel.Message{},
-						FinishReason: finishReason,
-					},
-				},
-			}
-
-			jsonStr, err := json.Marshal(response)
-			if err != nil {
-				lg.Error("error marshalling final stream response", zap.Error(err))
-				return false
-			}
-			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+			stopReason = convertStopReason(string(v.Value.StopReason))
 			return true
 
 		case *types.ConverseStreamOutputMemberMetadata:
-			// Handle metadata (usage)
 			if streamUsage := v.Value.Usage; streamUsage != nil {
 				if streamUsage.InputTokens != nil {
 					usage.PromptTokens = int(*streamUsage.InputTokens)
@@ -527,6 +489,28 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 					usage.TotalTokens = int(*streamUsage.TotalTokens)
 				}
 			}
+
+			response := &openai.ChatCompletionsStreamResponse{
+				Id:      id,
+				Object:  "chat.completion.chunk",
+				Created: createdTime,
+				Model:   c.GetString(ctxkey.RequestModel),
+				Choices: []openai.ChatCompletionsStreamResponseChoice{
+					{
+						Index:        0,
+						Delta:        relaymodel.Message{},
+						FinishReason: stopReason,
+					},
+				},
+				Usage: &usage,
+			}
+
+			jsonStr, err := json.Marshal(response)
+			if err != nil {
+				lg.Error("error marshalling final stream response", zap.Error(err))
+				return false
+			}
+			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
 			return true
 
 		default:

--- a/relay/adaptor/aws/mistral/main.go
+++ b/relay/adaptor/aws/mistral/main.go
@@ -385,28 +385,10 @@ func handleStreamWithInvokeModel(c *gin.Context, awsCli *bedrockruntime.Client, 
 
 	var usage relaymodel.Usage
 	var id string
-	var finalUsageSent bool
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
-			// Send final usage chunk before [DONE] if we have usage data
-			//
-			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
-			// as I'm currently busy building an agent framework in Go.
-			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
-				usageResponse := &openai.ChatCompletionsStreamResponse{
-					Id:      id,
-					Object:  "chat.completion.chunk",
-					Created: createdTime,
-					Model:   c.GetString(ctxkey.RequestModel),
-					Choices: []openai.ChatCompletionsStreamResponseChoice{},
-					Usage:   &usage,
-				}
-				if jsonStr, err := json.Marshal(usageResponse); err == nil {
-					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
-				}
-			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}

--- a/relay/adaptor/aws/mistral/main.go
+++ b/relay/adaptor/aws/mistral/main.go
@@ -384,10 +384,28 @@ func handleStreamWithInvokeModel(c *gin.Context, awsCli *bedrockruntime.Client, 
 
 	var usage relaymodel.Usage
 	var id string
+	var finalUsageSent bool
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
+			// Send final usage chunk before [DONE] if we have usage data
+			//
+			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
+			// as I'm currently busy building an agent framework in Go.
+			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
+				usageResponse := &openai.ChatCompletionsStreamResponse{
+					Id:      id,
+					Object:  "chat.completion.chunk",
+					Created: createdTime,
+					Model:   c.GetString(ctxkey.RequestModel),
+					Choices: []openai.ChatCompletionsStreamResponseChoice{},
+					Usage:   &usage,
+				}
+				if jsonStr, err := json.Marshal(usageResponse); err == nil {
+					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+				}
+			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}

--- a/relay/adaptor/aws/openai/main.go
+++ b/relay/adaptor/aws/openai/main.go
@@ -178,28 +178,11 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
-	var finalUsageSent bool
+	var stopReason *string
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
-			// Send final usage chunk before [DONE] if we have usage data
-			//
-			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
-			// as I'm currently busy building an agent framework in Go.
-			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
-				usageResponse := &openai.ChatCompletionsStreamResponse{
-					Id:      id,
-					Object:  "chat.completion.chunk",
-					Created: createdTime,
-					Model:   c.GetString(ctxkey.RequestModel),
-					Choices: []openai.ChatCompletionsStreamResponseChoice{},
-					Usage:   &usage,
-				}
-				if jsonStr, err := json.Marshal(usageResponse); err == nil {
-					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
-				}
-			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}
@@ -238,12 +221,12 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 						}
 					}
 				case *types.ContentBlockDeltaMemberReasoningContent:
-					// Handle reasoning content delta - unified within ContentBlockDelta for OpenAI OSS
+					// Handle reasoning content delta - OpenAI OSS models support reasoning like DeepSeek
 					if deltaValue.Value != nil {
 						switch reasoningDelta := deltaValue.Value.(type) {
 						case *types.ReasoningContentBlockDeltaMemberText:
 							if reasoningText := reasoningDelta.Value; reasoningText != "" {
-								// Create OpenAI-compatible streaming response with reasoning content
+								// Create OpenAI-compatible streaming response with reasoning content as separate field
 								response = &openai.ChatCompletionsStreamResponse{
 									Id:      id,
 									Object:  "chat.completion.chunk",
@@ -277,32 +260,10 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 			return true
 
 		case *types.ConverseStreamOutputMemberMessageStop:
-			// Handle message stop with OpenAI-compatible response structure
-			finishReason := convertStopReason(string(v.Value.StopReason))
-			response := &openai.ChatCompletionsStreamResponse{
-				Id:      id,
-				Object:  "chat.completion.chunk",
-				Created: createdTime,
-				Model:   c.GetString(ctxkey.RequestModel),
-				Choices: []openai.ChatCompletionsStreamResponseChoice{
-					{
-						Index:        0,
-						Delta:        relaymodel.Message{},
-						FinishReason: finishReason,
-					},
-				},
-			}
-
-			jsonStr, err := json.Marshal(response)
-			if err != nil {
-				lg.Error("error marshalling final stream response", zap.Error(err))
-				return false
-			}
-			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+			stopReason = convertStopReason(string(v.Value.StopReason))
 			return true
 
 		case *types.ConverseStreamOutputMemberMetadata:
-			// Handle metadata (usage)
 			if streamUsage := v.Value.Usage; streamUsage != nil {
 				if streamUsage.InputTokens != nil {
 					usage.PromptTokens = int(*streamUsage.InputTokens)
@@ -314,10 +275,31 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 					usage.TotalTokens = int(*streamUsage.TotalTokens)
 				}
 			}
+
+			response := &openai.ChatCompletionsStreamResponse{
+				Id:      id,
+				Object:  "chat.completion.chunk",
+				Created: createdTime,
+				Model:   c.GetString(ctxkey.RequestModel),
+				Choices: []openai.ChatCompletionsStreamResponseChoice{
+					{
+						Index:        0,
+						Delta:        relaymodel.Message{},
+						FinishReason: stopReason,
+					},
+				},
+				Usage: &usage,
+			}
+
+			jsonStr, err := json.Marshal(response)
+			if err != nil {
+				lg.Error("error marshalling final stream response", zap.Error(err))
+				return false
+			}
+			c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
 			return true
 
 		default:
-			// Handle other event types
 			return true
 		}
 	})

--- a/relay/adaptor/aws/openai/main.go
+++ b/relay/adaptor/aws/openai/main.go
@@ -178,10 +178,28 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 
 	var usage relaymodel.Usage
 	var id string
+	var finalUsageSent bool
 
 	c.Stream(func(w io.Writer) bool {
 		event, ok := <-stream.Events()
 		if !ok {
+			// Send final usage chunk before [DONE] if we have usage data
+			//
+			// TODO (H0llyW00dzZ): This should be correct. If it's not, it will be improved later when I have more time,
+			// as I'm currently busy building an agent framework in Go.
+			if !finalUsageSent && (usage.PromptTokens > 0 || usage.CompletionTokens > 0 || usage.TotalTokens > 0) {
+				usageResponse := &openai.ChatCompletionsStreamResponse{
+					Id:      id,
+					Object:  "chat.completion.chunk",
+					Created: createdTime,
+					Model:   c.GetString(ctxkey.RequestModel),
+					Choices: []openai.ChatCompletionsStreamResponseChoice{},
+					Usage:   &usage,
+				}
+				if jsonStr, err := json.Marshal(usageResponse); err == nil {
+					c.Render(-1, common.CustomEvent{Data: "data: " + string(jsonStr)})
+				}
+			}
 			c.Render(-1, common.CustomEvent{Data: "data: [DONE]"})
 			return false
 		}

--- a/relay/adaptor/aws/openai/main.go
+++ b/relay/adaptor/aws/openai/main.go
@@ -260,6 +260,7 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 			return true
 
 		case *types.ConverseStreamOutputMemberMessageStop:
+			// Handle message stop with OpenAI-compatible response structure
 			stopReason = convertStopReason(string(v.Value.StopReason))
 			return true
 

--- a/relay/adaptor/aws/openai/main.go
+++ b/relay/adaptor/aws/openai/main.go
@@ -300,6 +300,7 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 			return true
 
 		default:
+			// Handle other event types
 			return true
 		}
 	})

--- a/relay/adaptor/aws/writer/main.go
+++ b/relay/adaptor/aws/writer/main.go
@@ -363,6 +363,7 @@ func StreamHandler(c *gin.Context, awsCli *bedrockruntime.Client) (*relaymodel.E
 				switch deltaValue := v.Value.Delta.(type) {
 				case *types.ContentBlockDeltaMemberText:
 					if textDelta := deltaValue.Value; textDelta != "" {
+						// Create OpenAI-compatible streaming response with simple string content
 						response := &openai.ChatCompletionsStreamResponse{
 							Id:      id,
 							Object:  "chat.completion.chunk",


### PR DESCRIPTION
- [+] fix(relay/adaptor/aws/cohere/main.go): send final usage chunk before [DONE]
- [+] fix(relay/adaptor/aws/deepseek/main.go): send final usage chunk before [DONE]
- [+] fix(relay/adaptor/aws/llama3/main.go): send final usage chunk before [DONE]
- [+] fix(relay/adaptor/aws/mistral/main.go): send final usage chunk before [DONE]
- [+] fix(relay/adaptor/aws/openai/main.go): send final usage chunk before [DONE]
- [+] fix(relay/adaptor/aws/writer/main.go): send final usage chunk before [DONE]

This PR Related #218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streaming responses now emit a final chunk (before the DONE sentinel) that includes accumulated usage metrics (prompt, completion, total tokens) and a preserved finish reason across AWS-backed providers (Cohere, DeepSeek, Llama 3, Mistral, OpenAI-compatible, Writer).

- **Bug Fixes**
  - More consistent and accurate end-of-stream finish reasons in streamed responses; reasoning content is represented more clearly in OpenAI-compatible streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->