### PR TITLE
Remove Duplicate resp.Body.Close()

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -243,7 +243,6 @@ func testChannel(ctx context.Context, channel *model.Channel, request *relaymode
 		// Return wrapped error; avoid duplicate logging here
 		return "", errors.Wrap(err, "failed to do request"), nil
 	}
-	defer resp.Body.Close()
 
 	// Handle nil response (e.g., AWS Bedrock uses SDK directly, not HTTP)
 	if resp != nil {


### PR DESCRIPTION
- [+] fix(channel-test.go): remove redundant defer statement

This PR Related #222 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability by preventing rare crashes when handling failed or missing network responses, reducing intermittent failures and improving reliability.

* **Tests**
  * Updated test logic to close response bodies only when present, avoiding nil pointer errors and increasing test robustness and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->