### PR TITLE
feat: add STARTTLS support for email sending

### DIFF
--- a/common/message/email.go
+++ b/common/message/email.go
@@ -11,11 +11,37 @@ import (
 	"time"
 
 	"github.com/Laisky/errors/v2"
-	"github.com/Laisky/zap"
 
 	"github.com/songquanpeng/one-api/common/config"
-	"github.com/songquanpeng/one-api/common/logger"
 )
+
+// loginAuth implements the LOGIN authentication mechanism
+type loginAuth struct {
+	username, password string
+}
+
+// LoginAuth returns an Auth that implements the LOGIN authentication mechanism
+func LoginAuth(username, password string) smtp.Auth {
+	return &loginAuth{username, password}
+}
+
+func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	return "LOGIN", []byte{}, nil
+}
+
+func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if more {
+		switch string(fromServer) {
+		case "Username:", "username:":
+			return []byte(a.username), nil
+		case "Password:", "password:":
+			return []byte(a.password), nil
+		default:
+			return nil, errors.Errorf("unexpected server challenge: %s", string(fromServer))
+		}
+	}
+	return nil, nil
+}
 
 func shouldAuth() bool {
 	return config.SMTPAccount != "" || config.SMTPToken != ""
@@ -47,12 +73,13 @@ func SendEmail(subject string, receiver string, content string) error {
 	mail := fmt.Appendf(nil, "To: %s\r\n"+
 		"From: %s<%s>\r\n"+
 		"Subject: %s\r\n"+
-		"Message-ID: %s\r\n"+ // add Message-ID header to avoid being treated as spam, RFC 5322
+		"Message-ID: %s\r\n"+
 		"Date: %s\r\n"+
 		"Content-Type: text/html; charset=UTF-8\r\n\r\n%s\r\n",
 		receiver, config.SystemName, config.SMTPFrom, encodedSubject, messageId, time.Now().Format(time.RFC1123Z), content)
 
-	auth := smtp.PlainAuth("", config.SMTPAccount, config.SMTPToken, config.SMTPServer)
+	// Use LOGIN auth instead of PLAIN auth
+	auth := LoginAuth(config.SMTPAccount, config.SMTPToken)
 	addr := net.JoinHostPort(config.SMTPServer, fmt.Sprintf("%d", config.SMTPPort))
 
 	// Clean up recipient addresses
@@ -68,75 +95,109 @@ func SendEmail(subject string, receiver string, content string) error {
 		return errors.New("no valid recipient email addresses")
 	}
 
-	if config.SMTPPort == 465 || !shouldAuth() {
-		// need advanced client
-		var conn net.Conn
-		var err error
+	var conn net.Conn
+	var client *smtp.Client
+	var err error
 
-		// Add connection timeout
-		dialer := &net.Dialer{
-			Timeout: 30 * time.Second,
+	// Add connection timeout
+	dialer := &net.Dialer{
+		Timeout: 30 * time.Second,
+	}
+
+	// Try to establish connection based on port
+	// For port 465, try implicit TLS first, if fails, try plain connection with STARTTLS
+	if config.SMTPPort == 465 {
+		// First attempt: Try implicit TLS (traditional port 465 behavior)
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: !config.ForceEmailTLSVerify,
+			ServerName:         config.SMTPServer,
 		}
-
-		if config.SMTPPort == 465 {
-			tlsConfig := &tls.Config{
-				InsecureSkipVerify: !config.ForceEmailTLSVerify,
-				ServerName:         config.SMTPServer,
-			}
-			conn, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
-		} else {
+		conn, err = tls.DialWithDialer(dialer, "tcp", addr, tlsConfig)
+		if err != nil {
+			// If implicit TLS fails, try plain connection (some misconfigured servers)
 			conn, err = dialer.Dial("tcp", addr)
+			if err != nil {
+				return errors.Wrap(err, "failed to connect to SMTP server")
+			}
+			
+			client, err = smtp.NewClient(conn, config.SMTPServer)
+			if err != nil {
+				conn.Close()
+				return errors.Wrap(err, "failed to create SMTP client")
+			}
+			
+			// Try STARTTLS on port 465 if implicit TLS failed
+			if ok, _ := client.Extension("STARTTLS"); ok {
+				if err = client.StartTLS(tlsConfig); err != nil {
+					client.Close()
+					return errors.Wrap(err, "failed to start TLS on port 465")
+				}
+			}
+		} else {
+			// Implicit TLS connection succeeded
+			client, err = smtp.NewClient(conn, config.SMTPServer)
+			if err != nil {
+				conn.Close()
+				return errors.Wrap(err, "failed to create SMTP client with TLS")
+			}
 		}
-
+	} else {
+		// For other ports (25, 587, etc.): plain connection with STARTTLS
+		conn, err = dialer.Dial("tcp", addr)
 		if err != nil {
 			return errors.Wrap(err, "failed to connect to SMTP server")
 		}
 
-		client, err := smtp.NewClient(conn, config.SMTPServer)
+		client, err = smtp.NewClient(conn, config.SMTPServer)
 		if err != nil {
+			conn.Close()
 			return errors.Wrap(err, "failed to create SMTP client")
 		}
-		defer client.Close()
 
-		if shouldAuth() {
-			if err = client.Auth(auth); err != nil {
-				return errors.Wrap(err, "SMTP authentication failed")
+		// Try to use STARTTLS if supported
+		if ok, _ := client.Extension("STARTTLS"); ok {
+			tlsConfig := &tls.Config{
+				InsecureSkipVerify: !config.ForceEmailTLSVerify,
+				ServerName:         config.SMTPServer,
+			}
+			if err = client.StartTLS(tlsConfig); err != nil {
+				client.Close()
+				return errors.Wrap(err, "failed to start TLS")
 			}
 		}
-
-		if err = client.Mail(config.SMTPFrom); err != nil {
-			return errors.Wrap(err, "failed to set MAIL FROM")
-		}
-
-		for _, receiver := range receiverEmails {
-			if err = client.Rcpt(receiver); err != nil {
-				return errors.Wrapf(err, "failed to add recipient: %s", receiver)
-			}
-		}
-
-		w, err := client.Data()
-		if err != nil {
-			return errors.Wrap(err, "failed to create message data writer")
-		}
-
-		if _, err = w.Write(mail); err != nil {
-			return errors.Wrap(err, "failed to write email content")
-		}
-
-		if err = w.Close(); err != nil {
-			return errors.Wrap(err, "failed to close message data writer")
-		}
-
-		return nil
 	}
 
-	// Use the same sender address in the SMTP protocol as in the From header
-	err := smtp.SendMail(addr, auth, config.SMTPFrom, receiverEmails, mail)
-	if err != nil && strings.Contains(err.Error(), "short response") {
-		// Certain providers report an error, yet the email has been delivered successfully.
-		logger.Logger.Warn("short response from SMTP server, return nil instead of error", zap.Error(err))
-		return nil
+	defer client.Close()
+
+	// Authenticate if credentials are provided
+	if shouldAuth() {
+		if err = client.Auth(auth); err != nil {
+			return errors.Wrap(err, "SMTP authentication failed")
+		}
 	}
 
-	return errors.WithStack(err)
+	if err = client.Mail(config.SMTPFrom); err != nil {
+		return errors.Wrap(err, "failed to set MAIL FROM")
+	}
+
+	for _, receiver := range receiverEmails {
+		if err = client.Rcpt(receiver); err != nil {
+			return errors.Wrapf(err, "failed to add recipient: %s", receiver)
+		}
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return errors.Wrap(err, "failed to create message data writer")
+	}
+
+	if _, err = w.Write(mail); err != nil {
+		return errors.Wrap(err, "failed to write email content")
+	}
+
+	if err = w.Close(); err != nil {
+		return errors.Wrap(err, "failed to close message data writer")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add support STARTTLS

- Implement LOGIN authentication mechanism to support Microsoft Exchange and other SMTP servers that don't support PLAIN auth
- Add STARTTLS support for ports 25, 587, and other non-465 ports
- Improve port 465 handling with fallback: try implicit TLS first, then fall back to plain connection with STARTTLS if implicit TLS fails
- Add connection timeout (30 seconds) for better reliability
- Maintain backward compatibility with existing interface
- Clean up code by consolidating all ports to use the advanced SMTP client approach

This change enables the email service to work with a wider range of SMTP servers, particularly Microsoft Exchange servers which typically use STARTTLS on port 25 or 465.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email delivery reliability with enhanced SMTP connection handling and port-aware configuration support.
  * Strengthened email authentication security with upgraded authentication mechanism.
  * Added automatic fallback handling for TLS connections to ensure email delivery across different server configurations.
  * Enhanced error handling in email transmission workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->