### PR TITLE
fix(vertexai): correct publisher name in claude model url

### DIFF
--- a/relay/adaptor/vertexai/adaptor.go
+++ b/relay/adaptor/vertexai/adaptor.go
@@ -400,7 +400,7 @@ func (a *Adaptor) buildClaudeURL(meta *meta.Meta) (string, error) {
 	// Claude models use rawPredict
 	baseHost, location := a.getDefaultHostAndLocation(meta)
 
-	return fmt.Sprintf("https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s:rawPredict",
+	return fmt.Sprintf("https://%s/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:rawPredict",
 		baseHost, meta.Config.VertexAIProjectID, location, meta.ActualModelName), nil
 }
 


### PR DESCRIPTION
vertex has changed 3rd party like claude from google to anthropic
<img width="736" height="122" alt="image" src="https://github.com/user-attachments/assets/3cc30726-c5cc-43a2-adf7-797599b4ba2d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Claude model routing to use the correct Anthropic publisher endpoint, ensuring proper model access and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->