### PR TITLE
WIP: feat: Add ClaudeMessages relay support for volcengine doubao

### DIFF
--- a/relay/adaptor/doubao/main.go
+++ b/relay/adaptor/doubao/main.go
@@ -19,6 +19,12 @@ func GetRequestURL(meta *meta.Meta) (string, error) {
 		return fmt.Sprintf("%s/api/v3/chat/completions", meta.BaseURL), nil
 	case relaymode.Embeddings:
 		return fmt.Sprintf("%s/api/v3/embeddings", meta.BaseURL), nil
+	case relaymode.ClaudeMessages:
+		// 豆包支持 Claude Messages API 格式，转换为 ChatCompletions 处理
+		if strings.HasPrefix(meta.ActualModelName, "bot") {
+			return fmt.Sprintf("%s/api/v3/bots/chat/completions", meta.BaseURL), nil
+		}
+		return fmt.Sprintf("%s/api/v3/chat/completions", meta.BaseURL), nil
 	default:
 	}
 	return "", errors.Errorf("unsupported relay mode %d for doubao", meta.Mode)


### PR DESCRIPTION
TODOs:
- [ ] In OpenCode, request oneapi /v1/messages (using doubao provider)with tool calls failed with error 
```
Bad Request: {"error":{"message":"The parameter `tool_choice.type` specified in the request are not valid: expected 'function', but got `auto` instead. Request id: 0217676361346139b682021c37db203d3df9ca3c30e9969579fd8 (request id: 2026010602021435833600021693409)","type":"BadRequest","param":"tool_choice.type","code":"InvalidParameter"}}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Doubao adaptor with support for Claude Messages, enabling additional chat completion endpoints based on model configuration.

* **Bug Fixes**
  * Enhanced stream processing for thinking content handling—now intelligently filters and emits only non-empty thinking blocks with intelligent fallback to alternative content sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->