### PR TITLE
⚡ Bolt: optimize global pricing lookup performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 
 **Learning:** The channel cache in One API is already indexed by model name. Re-checking `SupportsModel` in a loop during every request is O(N) redundant work that involves string splitting and allocations. TRIPLE redundancy exists between the cache lookup, the cache selection functions, and the distributor middleware.
 **Action:** Remove redundant `SupportsModel` checks in the cached path. Ensure `InitChannelCache` and `SupportsModel` use consistent trimming if needed, but for now, focus on removing the redundant checks in the hot path.
+
+## 2026-02-06 - [Avoid Map Cloning in Hot Path]
+**Learning:** Functions like `GetGlobalModelPricing()` that clone large maps and all their entries (thousands of models) introduce massive CPU and memory overhead when called on every request. This is a common performance anti-pattern in Go where safety (returning a copy) conflicts with performance in high-throughput paths.
+**Action:** Always prefer targeted lookup functions (e.g., `GetGlobalModelConfig(name)`) over full collection retrieval in the request hot path. If such functions don't exist, create them or use a more efficient caching mechanism like `atomic.Pointer`.

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -417,7 +417,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		imagePriceUsd = resolvedConfig.Image.PricePerImageUsd
 	}
 	if imagePriceUsd == 0 {
-		if pm, ok := pricing.GetGlobalModelPricing()[imageModel]; ok && pm.Image != nil {
+		if pm, ok := pricing.GetGlobalModelConfig(imageModel); ok && pm.Image != nil {
 			imagePriceUsd = pm.Image.PricePerImageUsd
 		}
 	}

--- a/relay/pricing/global.go
+++ b/relay/pricing/global.go
@@ -300,10 +300,8 @@ func GetModelRatioWithThreeLayers(modelName string, channelOverrides map[string]
 
 	// Layer 3: Global model pricing (merged from selected adapters)
 	// Respect explicit zero pricing by checking existence, not value.
-	if globalPricing := GetGlobalModelPricing(); globalPricing != nil {
-		if cfg, exists := globalPricing[modelName]; exists {
-			return cfg.Ratio
-		}
+	if cfg, exists := GetGlobalModelConfig(modelName); exists {
+		return cfg.Ratio
 	}
 
 	// Layer 4: Final fallback - reasonable default
@@ -331,10 +329,8 @@ func GetCompletionRatioWithThreeLayers(modelName string, channelOverrides map[st
 
 	// Layer 3: Global model pricing (merged from selected adapters)
 	// Respect explicit zero pricing by checking existence, not value.
-	if globalPricing := GetGlobalModelPricing(); globalPricing != nil {
-		if cfg, exists := globalPricing[modelName]; exists {
-			return cfg.CompletionRatio
-		}
+	if cfg, exists := GetGlobalModelConfig(modelName); exists {
+		return cfg.CompletionRatio
 	}
 
 	// Layer 4: Final fallback - reasonable default
@@ -356,11 +352,9 @@ func GetVideoPricingWithThreeLayers(modelName string, channelOverride *adaptor.V
 		}
 	}
 
-	if global := GetGlobalModelPricing(); global != nil {
-		if cfg, exists := global[modelName]; exists {
-			if cfg.Video != nil && cfg.Video.HasData() {
-				return cfg.Video.Clone()
-			}
+	if cfg, exists := GetGlobalModelConfig(modelName); exists {
+		if cfg.Video != nil && cfg.Video.HasData() {
+			return cfg.Video
 		}
 	}
 


### PR DESCRIPTION
### 💡 What:
- Modified `relay/pricing/global.go` to use `GetGlobalModelConfig` in `GetModelRatioWithThreeLayers`, `GetCompletionRatioWithThreeLayers`, and `GetVideoPricingWithThreeLayers`.
- Modified `relay/controller/image.go` to use `GetGlobalModelConfig` for image pricing resolution.

### 🎯 Why:
`GetGlobalModelPricing()` clones the entire global pricing map and all its entries (potentially thousands of models) on every call. In a high-throughput gateway, this causes massive CPU and memory allocation overhead for every request, as it was being called twice or more per request.

### 📊 Impact:
- Reduces memory allocations and CPU usage by avoiding redundant map cloning.
- If N is the number of models, reduces complexity from O(N) with cloning to O(1) with single entry cloning.

### 🔬 Measurement:
Verified via `go test` and `go vet`. Performance improvement is architectural and avoids a known O(N) bottleneck in a hot path.

---
*PR created automatically by Jules for task [5915013610921063642](https://jules.google.com/task/5915013610921063642) started by @Laisky*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Performance Improvements**
* Optimized pricing configuration data retrieval mechanisms to significantly reduce computational overhead and improve response times for all pricing calculations.
* Enhanced pricing data access efficiency by streamlining lookup patterns for improved overall system responsiveness and performance.

**Documentation**
* Added performance optimization best practices and guidelines to prevent inefficiencies in critical system execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->