### PR TITLE
fix: enable Channel-level cache billing configuration support

### DIFF
--- a/docs/recent-10-commits-analysis.md
+++ b/docs/recent-10-commits-analysis.md
@@ -1,0 +1,318 @@
+# One-API 最近 10 个版本提交变更分析
+
+## 概述
+
+本文档分析了 `one-api-main-new-20260224` 仓库最近 10 个 git 提交，涵盖从 2026-02-25 到 2026-03-05 期间的代码变更，主要聚焦于修复的问题和改进的功能。
+
+---
+
+## 提交详情（按时间倒序）
+
+### 1. 提交 a7c3e7be - 增强 Claude 和 Gemini 使用量追踪与缓存令牌处理
+
+**提交时间**: 2026-03-05 04:17:51 +0000  
+**提交信息**: `fix(#317): enhance Claude and Gemini usage tracking with cache token handling and update pricing configurations`
+
+**修复的问题**:
+- Claude 和 Gemini 模型的使用量追踪不够完善
+- 缺少缓存令牌（cache token）的处理机制
+- 定价配置需要更新以支持新的计费场景
+
+**变更内容**:
+- 修改 `README.md` (2 行变更)
+- 新增 `docs/refs/claude_request.md` (45 行新增)
+- 修改 `relay/adaptor/anthropic/main.go` (50 行变更)
+- 新增 `relay/adaptor/anthropic/main_test.go` (70 行新增)
+- 修改 `relay/adaptor/geminiOpenaiCompatible/constants.go` (4 行变更)
+- 修改 `relay/adaptor/openai/response_api_ws_transport.go` (1 行新增)
+- 修改 `relay/adaptor/openai_compatible/claude_convert.go` (76 行变更)
+- 修改 `relay/adaptor/openai_compatible/claude_convert_test.go` (37 行变更)
+- 新增 `relay/controller/claude_messages.go` (22 行新增)
+- 修改 `relay/model/general.go` (13 行变更)
+- 修改 `relay/quota/quota.go` (45 行变更)
+- 新增 `relay/quota/quota_cache_test.go` (118 行新增)
+
+**影响范围**: 使用量追踪、缓存计费、Claude/Gemini 适配器、配额管理
+
+---
+
+### 2. 提交 271d1eb2 - 更新 Gemini 模型定价配置
+
+**提交时间**: 2026-03-04 17:33:49 +0000  
+**提交信息**: `fix: update pricing for gemini-3.1-flash-image-preview and add gemini-3.1-flash-lite-preview configuration`
+
+**修复的问题**:
+- `gemini-3.1-flash-image-preview` 模型定价需要更新
+- 缺少 `gemini-3.1-flash-lite-preview` 模型的配置支持
+
+**变更内容**:
+- 修改 `relay/adaptor/gemini/constants.go` (3 行变更)
+- 修改 `relay/adaptor/geminiOpenaiCompatible/constants.go` (15 行变更)
+
+**影响范围**: 计费系统、Gemini 适配器
+
+---
+
+### 3. 提交 c7d602a8 - 支持 Gemini 新模型定价
+
+**提交时间**: 2026-02-28 16:10:40 +0000  
+**提交信息**: `fix: add support for gemini-3.1-flash-image-preview pricing and corresponding tests`
+
+**修复的问题**:
+- 缺少对 `gemini-3.1-flash-image-preview` 模型的定价支持
+- 需要更新计费系统以支持新的 Gemini 多模态模型
+
+**变更内容**:
+- 修改 `README.md` (2 行变更)
+- 新增 `relay/adaptor/geminiOpenaiCompatible/constants.go` (28 行新增)
+- 新增 `relay/adaptor/geminiOpenaiCompatible/constants_test.go` (17 行新增)
+
+**影响范围**: 计费系统、Gemini 适配器
+
+---
+
+### 4. 提交 256cba25 - 增强上游客户端错误重试逻辑
+
+**提交时间**: 2026-02-26 03:55:41 +0000  
+**提交信息**: `fix: enhance retry logic for upstream client errors by classifying additional retryable error codes and adding corresponding tests`
+
+**修复的问题**:
+- 重试逻辑不够完善，未能正确分类可重试的错误码
+- 缺少对上游客户端错误的充分重试机制
+
+**变更内容**:
+- 修改 `controller/relay.go` (35 行变更，29 行新增，6 行删除)
+- 新增 `controller/retry_policy_test.go` 测试 (24 行新增)
+
+**影响范围**: 请求转发控制器、重试策略
+
+---
+
+### 4. 提交 6b204bf9 - 增强用户端错误处理
+
+**提交时间**: 2026-02-26 03:22:29 +0000  
+**提交信息**: `fix: enhance user-originated error handling for upstream malformed tool call arguments and add corresponding tests`
+
+**修复的问题**:
+- 上游工具调用参数格式错误时处理不当
+- 需要区分用户端错误和系统端错误，避免不必要的重试
+
+**变更内容**:
+- 修改 `controller/relay.go` (45 行变更，44 行新增，1 行删除)
+- 新增 `controller/retry_policy_test.go` 测试 (79 行新增)
+
+**影响范围**: 请求转发控制器、错误处理机制、重试策略
+
+---
+
+### 5. 提交 e432713b - 增强 Response API 输入诊断
+
+**提交时间**: 2026-02-26 00:30:28 +0000  
+**提交信息**: `fix: add diagnostics for malformed Response API input and corresponding tests`
+
+**修复的问题**:
+- Response API 输入格式错误时缺乏有效的诊断信息
+- 难以定位和调试输入参数问题
+
+**变更内容**:
+- 新增 `relay/adaptor/openai/adaptor_request_logging.go` (61 行新增)
+- 新增 `relay/adaptor/openai/adaptor_request_logging_test.go` (55 行新增)
+- 修改 `relay/adaptor/openai/response_model.go` (5 行变更)
+- 新增 `relay/adaptor/openai/response_model_test.go` (38 行新增)
+
+**影响范围**: OpenAI 适配器、请求日志记录、响应模型验证
+
+---
+
+### 6. 提交 f0c8aae8 - 确保非流式请求使用 HTTP 传输
+
+**提交时间**: 2026-02-25 20:32:52 +0000  
+**提交信息**: `fix: ensure non-stream requests use HTTP transport and add fallback handling for websocket close errors`
+
+**修复的问题**:
+- 非流式请求可能错误地使用 WebSocket 传输
+- WebSocket 连接关闭时缺少降级处理机制
+
+**变更内容**:
+- 修改 `relay/adaptor/openai/response_api_ws_transport.go` (17 行新增)
+- 修改 `relay/adaptor/openai/response_api_ws_transport_test.go` (68 行变更)
+
+**影响范围**: WebSocket 传输层、HTTP 降级处理
+
+---
+
+### 7. 提交 2862bcf0 - 增强重试逻辑和 WebSocket 连接限制测试
+
+**提交时间**: 2026-02-25 19:42:00 +0000  
+**提交信息**: `fix: enhance retry logic for upstream client errors and add tests for websocket connection limits`
+
+**修复的问题**:
+- 重试逻辑需要进一步优化以处理上游客户端错误
+- 缺少 WebSocket 连接限制相关的测试
+
+**变更内容**:
+- 修改 `controller/relay.go` (51 行变更)
+- 修改 `controller/retry_policy_test.go` (39 行新增)
+- 修改 `relay/adaptor/openai/response_api_ws_transport.go` (104 行变更)
+- 修改 `relay/adaptor/openai/response_api_ws_transport_test.go` (41 行新增)
+
+**影响范围**: 请求转发控制器、重试策略、WebSocket 传输层
+
+---
+
+### 8. 提交 43db1c4e - 实现 WebSocket 连接限制错误处理
+
+**提交时间**: 2026-02-25 17:20:55 +0000  
+**提交信息**: `fix: implement WebSocket connection limit error handling and fallback to HTTP`
+
+**修复的问题**:
+- WebSocket 连接数达到限制时缺少错误处理
+- 需要实现自动降级到 HTTP 传输的机制
+
+**变更内容**:
+- 修改 `relay/adaptor/openai/response_api_ws_transport.go` (88 行新增)
+- 新增 `relay/adaptor/openai/response_api_ws_transport_test.go` (158 行新增)
+
+**影响范围**: WebSocket 传输层、连接管理、HTTP 降级
+
+---
+
+### 9. 提交 03e2c917 - 优化 CI Docker 镜像缓存
+
+**提交时间**: 2026-02-25 15:15:57 +0000  
+**提交信息**: `ci: add build_latest_cache job to optimize Docker image caching in CI`
+
+**修复的问题**:
+- CI/CD 流程中 Docker 镜像构建效率低
+- 缺少缓存机制导致每次构建时间过长
+
+**变更内容**:
+- 修改 `.github/workflows/ci.yml` (24 行新增)
+
+**影响范围**: CI/CD 流程、Docker 构建
+
+---
+
+### 9. 提交 e7a294a5 - 增强 WebSocket 传输正常关闭处理
+
+**提交时间**: 2026-02-25 14:57:08 +0000  
+**提交信息**: `fix: enhance WebSocket transport with normal closure handling and fallback to HTTP`
+
+**修复的问题**:
+- WebSocket 正常关闭时处理不当
+- 缺少到 HTTP 的自动降级机制
+
+**变更内容**:
+- 修改 `relay/adaptor/openai/adaptor_response.go` (13 行变更)
+- 修改 `relay/adaptor/openai/response_api_ws_transport.go` (66 行变更)
+- 新增 `relay/adaptor/openai/response_api_ws_transport_test.go` (157 行新增)
+
+**影响范围**: WebSocket 传输层、适配器响应处理、HTTP 降级
+
+---
+
+### 10. 提交 cb8caf12 - 更新计费管理文档
+
+**提交时间**: 2026-02-24 22:30:06 +0000  
+**提交信息**: `docs: update Billing Administration Guide with detailed sections on scope, pricing resolution, and operational workflows`
+
+**修复的问题**:
+- 计费管理文档不够详细
+- 缺少计费范围、价格解析和操作流程的详细说明
+
+**变更内容**:
+- 修改 `docs/manuals/billing.md` (653 行变更，555 行新增，98 行删除)
+
+**影响范围**: 文档系统、计费管理指南
+
+---
+
+## 变更趋势分析
+
+### 按类型分类
+
+| 变更类型 | 数量 | 占比 |
+|---------|------|------|
+| 功能修复 (fix) | 8 | 80% |
+| 文档更新 (docs) | 1 | 10% |
+| CI/CD 优化 (ci) | 1 | 10% |
+
+### 主要修复方向
+
+1. **WebSocket 传输层优化** (4 个提交)
+   - 实现 WebSocket 连接限制错误处理
+   - 增强正常关闭处理机制
+   - 实现 HTTP 降级策略
+   - 确保非流式请求使用 HTTP 传输
+
+2. **错误处理和重试机制** (3 个提交)
+   - 增强上游客户端错误重试逻辑
+   - 增强用户端错误处理
+   - 区分可重试和不可重试错误
+
+3. **计费和文档** (2 个提交)
+   - 支持新模型定价
+   - 更新计费管理文档
+
+4. **诊断和日志** (1 个提交)
+   - 增强 Response API 输入诊断
+
+5. **CI/CD 优化** (1 个提交)
+   - 优化 Docker 镜像缓存
+
+### 修改频率最高的文件
+
+| 文件路径 | 修改次数 |
+|---------|---------|
+| `relay/adaptor/openai/response_api_ws_transport.go` | 6 |
+| `relay/quota/quota.go` | 2 |
+| `relay/adaptor/anthropic/main.go` | 2 |
+| `relay/adaptor/openai_compatible/claude_convert.go` | 2 |
+| `controller/relay.go` | 3 |
+| `controller/retry_policy_test.go` | 3 |
+| `relay/adaptor/openai/response_api_ws_transport_test.go` | 4 |
+
+---
+
+## 关键改进点
+
+### 1. 缓存计费和使用量追踪（新增重点）
+
+通过 a7c3e7be 提交，系统性地增强了 Claude 和 Gemini 模型的使用量追踪能力：
+- 实现缓存令牌（cache token）处理机制
+- 完善使用量统计和配额计算
+- 新增配额缓存测试（118 行测试代码）
+- 更新定价配置以支持新的计费场景
+
+### 2. WebSocket 传输稳定性
+
+通过连续 4 个提交（43db1c4e → 2862bcf0 → f0c8aae8 → a7c3e7be），系统性地解决了 WebSocket 传输层的多个问题：
+- 连接限制处理
+- 正常关闭处理
+- HTTP 降级机制
+- 非流式请求传输协议选择
+
+### 3. 错误分类和重试策略
+
+通过 3 个提交（6b204bf9 → 256cba25 → 2862bcf0）完善了错误处理机制：
+- 区分用户端错误和系统端错误
+- 细化可重试错误码分类
+- 避免对不可重试错误的无效重试
+
+### 4. 可观测性提升
+
+通过 e432713b 提交增强了请求日志记录和诊断能力，便于问题排查。
+
+---
+
+## 总结
+
+最近 10 个提交主要集中在以下几个方面：
+
+1. **缓存计费优化**: 新增 Claude 和 Gemini 缓存令牌处理机制，完善使用量追踪和配额管理
+2. **稳定性提升**: 通过优化 WebSocket 传输和错误处理机制，显著提升了系统的稳定性和容错能力
+3. **可维护性增强**: 增加了大量测试用例（包括配额缓存测试、Claude 转换测试等）和日志记录，便于后续维护和问题定位
+4. **功能完善**: 支持新模型定价（Gemini 3.1 系列），更新文档，提升用户体验
+5. **构建效率**: 优化 CI/CD 流程，提升开发效率
+
+这些变更体现了团队对系统稳定性、计费准确性、可维护性和用户体验的持续关注和改进。

--- a/model/channel.go
+++ b/model/channel.go
@@ -111,12 +111,25 @@ type ModelConfig struct {
 // ModelConfigLocal represents the local definition of ModelConfig to avoid import cycles
 // This should match the structure in relay/adaptor/interface.go
 type ModelConfigLocal struct {
-	Ratio           float64            `json:"ratio"`
-	CompletionRatio float64            `json:"completion_ratio,omitempty"`
-	MaxTokens       int32              `json:"max_tokens,omitempty"`
-	Video           *VideoPricingLocal `json:"video,omitempty"`
-	Audio           *AudioPricingLocal `json:"audio,omitempty"`
-	Image           *ImagePricingLocal `json:"image,omitempty"`
+	Ratio             float64               `json:"ratio"`
+	CompletionRatio   float64               `json:"completion_ratio,omitempty"`
+	CachedInputRatio  float64               `json:"cached_input_ratio,omitempty"`
+	CacheWrite5mRatio float64               `json:"cache_write_5m_ratio,omitempty"`
+	CacheWrite1hRatio float64               `json:"cache_write_1h_ratio,omitempty"`
+	Tiers             []ModelRatioTierLocal `json:"tiers,omitempty"`
+	MaxTokens         int32                 `json:"max_tokens,omitempty"`
+	Video             *VideoPricingLocal    `json:"video,omitempty"`
+	Audio             *AudioPricingLocal    `json:"audio,omitempty"`
+	Image             *ImagePricingLocal    `json:"image,omitempty"`
+}
+
+type ModelRatioTierLocal struct {
+	Ratio               float64 `json:"ratio"`
+	CompletionRatio     float64 `json:"completion_ratio,omitempty"`
+	CachedInputRatio    float64 `json:"cached_input_ratio,omitempty"`
+	CacheWrite5mRatio   float64 `json:"cache_write_5m_ratio,omitempty"`
+	CacheWrite1hRatio   float64 `json:"cache_write_1h_ratio,omitempty"`
+	InputTokenThreshold int     `json:"input_token_threshold"`
 }
 
 // VideoPricingLocal represents channel-scoped video pricing metadata stored alongside model configs.
@@ -264,9 +277,15 @@ func normalizeModelConfigLocal(cfg ModelConfigLocal) (ModelConfigLocal, error) {
 	}
 
 	normalized := ModelConfigLocal{
-		Ratio:           cfg.Ratio,
-		CompletionRatio: cfg.CompletionRatio,
-		MaxTokens:       cfg.MaxTokens,
+		Ratio:             cfg.Ratio,
+		CompletionRatio:   cfg.CompletionRatio,
+		CachedInputRatio:  cfg.CachedInputRatio,
+		CacheWrite5mRatio: cfg.CacheWrite5mRatio,
+		CacheWrite1hRatio: cfg.CacheWrite1hRatio,
+		MaxTokens:         cfg.MaxTokens,
+	}
+	if len(cfg.Tiers) > 0 {
+		normalized.Tiers = append([]ModelRatioTierLocal(nil), cfg.Tiers...)
 	}
 	if video != nil {
 		normalized.Video = video
@@ -716,6 +735,29 @@ func (channel *Channel) validateModelPriceConfigs(configs map[string]ModelConfig
 		if config.CompletionRatio < 0 {
 			return errors.Errorf("negative completion ratio for model %s: %f", modelName, config.CompletionRatio)
 		}
+		if config.CacheWrite5mRatio < 0 {
+			return errors.Errorf("negative cache_write_5m_ratio for model %s: %f", modelName, config.CacheWrite5mRatio)
+		}
+		if config.CacheWrite1hRatio < 0 {
+			return errors.Errorf("negative cache_write_1h_ratio for model %s: %f", modelName, config.CacheWrite1hRatio)
+		}
+		for _, tier := range config.Tiers {
+			if tier.InputTokenThreshold < 0 {
+				return errors.Errorf("negative input_token_threshold for model %s tier: %d", modelName, tier.InputTokenThreshold)
+			}
+			if tier.Ratio < 0 {
+				return errors.Errorf("negative tier ratio for model %s: %f", modelName, tier.Ratio)
+			}
+			if tier.CompletionRatio < 0 {
+				return errors.Errorf("negative tier completion ratio for model %s: %f", modelName, tier.CompletionRatio)
+			}
+			if tier.CacheWrite5mRatio < 0 {
+				return errors.Errorf("negative tier cache_write_5m_ratio for model %s: %f", modelName, tier.CacheWrite5mRatio)
+			}
+			if tier.CacheWrite1hRatio < 0 {
+				return errors.Errorf("negative tier cache_write_1h_ratio for model %s: %f", modelName, tier.CacheWrite1hRatio)
+			}
+		}
 
 		// Validate MaxTokens
 		if config.MaxTokens < 0 {
@@ -736,7 +778,16 @@ func (channel *Channel) validateModelPriceConfigs(configs map[string]ModelConfig
 		}
 
 		// Validate that at least one field has meaningful data
-		if config.Ratio == 0 && config.CompletionRatio == 0 && config.MaxTokens == 0 && !hasVideoData && !hasAudioData && !hasImageData {
+		if config.Ratio == 0 &&
+			config.CompletionRatio == 0 &&
+			config.CachedInputRatio == 0 &&
+			config.CacheWrite5mRatio == 0 &&
+			config.CacheWrite1hRatio == 0 &&
+			len(config.Tiers) == 0 &&
+			config.MaxTokens == 0 &&
+			!hasVideoData &&
+			!hasAudioData &&
+			!hasImageData {
 			return errors.Errorf("model %s has no meaningful configuration data", modelName)
 		}
 	}

--- a/model/channel_test.go
+++ b/model/channel_test.go
@@ -313,6 +313,44 @@ func TestChannel_GetModelPriceConfigs(t *testing.T) {
 	}
 }
 
+func TestChannel_GetModelPriceConfigs_PreservesCacheAndTierFields(t *testing.T) {
+	t.Parallel()
+	channel := &Channel{
+		Id: 1,
+		ModelConfigs: stringPtr(`{
+			"claude-4.6-sonnet": {
+				"ratio": 1.543,
+				"completion_ratio": 7.715,
+				"cached_input_ratio": 1.543,
+				"cache_write_5m_ratio": 1.543,
+				"cache_write_1h_ratio": 1.543,
+				"tiers": [
+					{
+						"input_token_threshold": 200000,
+						"ratio": 3.086,
+						"completion_ratio": 11.571,
+						"cached_input_ratio": 3.086,
+						"cache_write_5m_ratio": 3.086,
+						"cache_write_1h_ratio": 3.086
+					}
+				]
+			}
+		}`),
+	}
+
+	configs := channel.GetModelPriceConfigs()
+	require.Contains(t, configs, "claude-4.6-sonnet")
+
+	data, err := json.Marshal(configs["claude-4.6-sonnet"])
+	require.NoError(t, err)
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Contains(t, decoded, "cached_input_ratio")
+	require.Contains(t, decoded, "cache_write_5m_ratio")
+	require.Contains(t, decoded, "cache_write_1h_ratio")
+	require.Contains(t, decoded, "tiers")
+}
+
 func TestChannel_GetModelPriceConfig(t *testing.T) {
 	channel := &Channel{
 		Id:           1,

--- a/relay/controller/claude_messages.go
+++ b/relay/controller/claude_messages.go
@@ -58,6 +58,7 @@ func RelayClaudeMessagesHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 
 	// get channel model ratio
 	channelModelRatio, channelCompletionRatio := getChannelRatios(c)
+	channelModelConfigs := getChannelModelConfigs(c)
 
 	// get model ratio using three-layer pricing system
 	pricingAdaptor := resolvePricingAdaptor(meta)
@@ -474,7 +475,7 @@ postConsume:
 		var quota int64
 
 		go func() {
-			quota = postConsumeClaudeMessagesQuotaWithTraceID(ctx, requestId, traceId, usage, meta, claudeRequest, ratio, preConsumedQuota, mcpIncrementalCharged, modelRatio, groupRatio, channelCompletionRatio)
+			quota = postConsumeClaudeMessagesQuotaWithTraceID(ctx, requestId, traceId, usage, meta, claudeRequest, ratio, preConsumedQuota, mcpIncrementalCharged, modelRatio, groupRatio, channelModelConfigs, channelCompletionRatio)
 
 			// Reconcile request cost with final quota (override provisional value)
 			if quota != 0 {

--- a/relay/controller/claude_messages_billing.go
+++ b/relay/controller/claude_messages_billing.go
@@ -71,7 +71,7 @@ func preConsumeClaudeMessagesQuota(c *gin.Context, request *ClaudeMessagesReques
 // postConsumeClaudeMessagesQuotaWithTraceID calculates and applies final quota consumption for Claude Messages API with explicit trace ID.
 // Parameters: ctx/requestId/traceId identify the request, usage/meta/request carry usage metadata, ratio/preConsumedQuota/incrementalCharged/modelRatio/groupRatio/channelCompletionRatio drive billing.
 // Returns: the final quota charged for the request.
-func postConsumeClaudeMessagesQuotaWithTraceID(ctx context.Context, requestId string, traceId string, usage *relaymodel.Usage, meta *metalib.Meta, request *ClaudeMessagesRequest, ratio float64, preConsumedQuota int64, incrementalCharged int64, modelRatio float64, groupRatio float64, channelCompletionRatio map[string]float64) int64 {
+func postConsumeClaudeMessagesQuotaWithTraceID(ctx context.Context, requestId string, traceId string, usage *relaymodel.Usage, meta *metalib.Meta, request *ClaudeMessagesRequest, ratio float64, preConsumedQuota int64, incrementalCharged int64, modelRatio float64, groupRatio float64, channelModelConfigs map[string]model.ModelConfigLocal, channelCompletionRatio map[string]float64) int64 {
 	if usage == nil {
 		// Context may be detached; log with context if available
 		gmw.GetLogger(ctx).Warn("usage is nil for Claude Messages API")
@@ -84,6 +84,7 @@ func postConsumeClaudeMessagesQuotaWithTraceID(ctx context.Context, requestId st
 		ModelName:              request.Model,
 		ModelRatio:             modelRatio,
 		GroupRatio:             groupRatio,
+		ChannelModelConfigs:    channelModelConfigs,
 		ChannelCompletionRatio: channelCompletionRatio,
 		PricingAdaptor:         pricingAdaptor,
 	})

--- a/relay/controller/helper.go
+++ b/relay/controller/helper.go
@@ -162,6 +162,7 @@ func postConsumeQuota(ctx context.Context,
 	modelRatio float64,
 	groupRatio float64,
 	systemPromptReset bool,
+	channelModelConfigs map[string]model.ModelConfigLocal,
 	channelCompletionRatio map[string]float64) (quota int64) {
 	if usage == nil {
 		gmw.GetLogger(ctx).Error("usage is nil, which is unexpected")
@@ -174,6 +175,7 @@ func postConsumeQuota(ctx context.Context,
 		ModelName:              textRequest.Model,
 		ModelRatio:             modelRatio,
 		GroupRatio:             groupRatio,
+		ChannelModelConfigs:    channelModelConfigs,
 		ChannelCompletionRatio: channelCompletionRatio,
 		PricingAdaptor:         pricingAdaptor,
 	})
@@ -252,6 +254,7 @@ func postConsumeQuotaWithTraceID(ctx context.Context, traceId string,
 	modelRatio float64,
 	groupRatio float64,
 	systemPromptReset bool,
+	channelModelConfigs map[string]model.ModelConfigLocal,
 	channelCompletionRatio map[string]float64) (quota int64) {
 	if usage == nil {
 		gmw.GetLogger(ctx).Error("usage is nil, which is unexpected")
@@ -264,6 +267,7 @@ func postConsumeQuotaWithTraceID(ctx context.Context, traceId string,
 		ModelName:              textRequest.Model,
 		ModelRatio:             modelRatio,
 		GroupRatio:             groupRatio,
+		ChannelModelConfigs:    channelModelConfigs,
 		ChannelCompletionRatio: channelCompletionRatio,
 		PricingAdaptor:         pricingAdaptor,
 	})

--- a/relay/controller/mcp_helpers.go
+++ b/relay/controller/mcp_helpers.go
@@ -181,7 +181,7 @@ func updateMCPRequestCostProvisional(c *gin.Context, meta *metalib.Meta, quota i
 // updateMCPRequestCostEstimate updates request cost based on accumulated usage after each round.
 // Parameters: c is the Gin context, meta provides request metadata, usage is the accumulated usage, modelName/modelRatio/groupRatio/channelCompletionRatio/pricingAdaptor drive pricing.
 // Returns: none.
-func updateMCPRequestCostEstimate(c *gin.Context, meta *metalib.Meta, usage *relaymodel.Usage, modelName string, modelRatio float64, groupRatio float64, channelCompletionRatio map[string]float64, pricingAdaptor adaptor.Adaptor) {
+func updateMCPRequestCostEstimate(c *gin.Context, meta *metalib.Meta, usage *relaymodel.Usage, modelName string, modelRatio float64, groupRatio float64, channelModelConfigs map[string]model.ModelConfigLocal, channelCompletionRatio map[string]float64, pricingAdaptor adaptor.Adaptor) {
 	if c == nil || meta == nil || usage == nil {
 		return
 	}
@@ -195,6 +195,7 @@ func updateMCPRequestCostEstimate(c *gin.Context, meta *metalib.Meta, usage *rel
 		ModelName:              modelName,
 		ModelRatio:             modelRatio,
 		GroupRatio:             groupRatio,
+		ChannelModelConfigs:    channelModelConfigs,
 		ChannelCompletionRatio: channelCompletionRatio,
 		PricingAdaptor:         pricingAdaptor,
 	})

--- a/relay/controller/mcp_orchestrator.go
+++ b/relay/controller/mcp_orchestrator.go
@@ -358,6 +358,7 @@ func executeChatMCPToolLoop(c *gin.Context, meta *metalib.Meta, request *relaymo
 	}
 
 	channelModelRatio, channelCompletionRatio := getChannelRatios(c)
+	channelModelConfigs := getChannelModelConfigs(c)
 	pricingAdaptor := resolvePricingAdaptor(meta)
 	modelRatio := pricing.GetModelRatioWithThreeLayers(request.Model, channelModelRatio, pricingAdaptor)
 	groupRatio := c.GetFloat64(ctxkey.ChannelRatio)
@@ -389,7 +390,7 @@ func executeChatMCPToolLoop(c *gin.Context, meta *metalib.Meta, request *relaymo
 			return nil, accumulated, summary, incrementalCharged, respErr
 		}
 		accumulated = mergeUsage(accumulated, usage)
-		updateMCPRequestCostEstimate(c, meta, accumulated, request.Model, modelRatio, groupRatio, channelCompletionRatio, pricingAdaptor)
+		updateMCPRequestCostEstimate(c, meta, accumulated, request.Model, modelRatio, groupRatio, channelModelConfigs, channelCompletionRatio, pricingAdaptor)
 
 		choice, ok := firstChoice(response)
 		if !ok || len(choice.Message.ToolCalls) == 0 {
@@ -440,7 +441,7 @@ func executeChatMCPToolLoop(c *gin.Context, meta *metalib.Meta, request *relaymo
 			return nil, accumulated, summary, incrementalCharged, openai.ErrorWrapper(execErr, "mcp_tool_call_failed", 500)
 		}
 		accumulated = applyMCPToolCostDelta(accumulated, previousCost, summary)
-		updateMCPRequestCostEstimate(c, meta, accumulated, request.Model, modelRatio, groupRatio, channelCompletionRatio, pricingAdaptor)
+		updateMCPRequestCostEstimate(c, meta, accumulated, request.Model, modelRatio, groupRatio, channelModelConfigs, channelCompletionRatio, pricingAdaptor)
 		if len(results) == 0 {
 			return response, accumulated, summary, incrementalCharged, nil
 		}

--- a/relay/controller/response.go
+++ b/relay/controller/response.go
@@ -119,6 +119,7 @@ func RelayResponseAPIHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 
 	// get channel model ratio
 	channelModelRatio, channelCompletionRatio := getChannelRatios(c)
+	channelModelConfigs := getChannelModelConfigs(c)
 
 	// get model ratio using three-layer pricing system
 	pricingAdaptor := resolvePricingAdaptor(meta)
@@ -253,7 +254,7 @@ func RelayResponseAPIHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 		go func() {
 			// Attach IDs into context using a lightweight wrapper struct in meta if needed; for now,
 			// we keep postConsumeResponseAPIQuota signature and rely on it to read IDs from outer scope.
-			quota = postConsumeResponseAPIQuota(ctx, usage, meta, responseAPIRequest, preConsumedQuota, modelRatio, groupRatio, channelCompletionRatio)
+			quota = postConsumeResponseAPIQuota(ctx, usage, meta, responseAPIRequest, preConsumedQuota, modelRatio, groupRatio, channelModelConfigs, channelCompletionRatio)
 
 			// Reconcile request cost with final quota (override provisional pre-consumed value)
 			if requestId == "" {

--- a/relay/controller/response_billing.go
+++ b/relay/controller/response_billing.go
@@ -92,6 +92,7 @@ func postConsumeResponseAPIQuota(ctx context.Context,
 	preConsumedQuota int64,
 	modelRatio float64,
 	groupRatio float64,
+	channelModelConfigs map[string]model.ModelConfigLocal,
 	channelCompletionRatio map[string]float64) (quota int64) {
 
 	if usage == nil {
@@ -106,6 +107,7 @@ func postConsumeResponseAPIQuota(ctx context.Context,
 		ModelName:              responseAPIRequest.Model,
 		ModelRatio:             modelRatio,
 		GroupRatio:             groupRatio,
+		ChannelModelConfigs:    channelModelConfigs,
 		ChannelCompletionRatio: channelCompletionRatio,
 		PricingAdaptor:         pricingAdaptor,
 	})

--- a/relay/controller/response_fallback.go
+++ b/relay/controller/response_fallback.go
@@ -141,6 +141,7 @@ func relayResponseAPIThroughChat(c *gin.Context, meta *metalib.Meta, responseAPI
 	}
 
 	channelModelRatio, channelCompletionRatio := getChannelRatios(c)
+	channelModelConfigs := getChannelModelConfigs(c)
 	pricingAdaptor := resolvePricingAdaptor(meta)
 	modelRatio := pricing.GetModelRatioWithThreeLayers(chatRequest.Model, channelModelRatio, pricingAdaptor)
 	completionRatio := pricing.GetCompletionRatioWithThreeLayers(chatRequest.Model, channelCompletionRatio, pricingAdaptor)
@@ -266,7 +267,7 @@ func relayResponseAPIThroughChat(c *gin.Context, meta *metalib.Meta, responseAPI
 			var quota int64
 
 			go func() {
-				quota = postConsumeQuota(ctx, usage, meta, chatRequest, ratio, preConsumedQuota, incrementalCharged, modelRatio, groupRatio, false, channelCompletionRatio)
+				quota = postConsumeQuota(ctx, usage, meta, chatRequest, ratio, preConsumedQuota, incrementalCharged, modelRatio, groupRatio, false, channelModelConfigs, channelCompletionRatio)
 				if requestId != "" {
 					if err := model.UpdateUserRequestCostQuotaByRequestID(quotaId, requestId, quota); err != nil {
 						lg.Error("update user request cost failed", zap.Error(err), zap.String("request_id", requestId))
@@ -449,7 +450,7 @@ func relayResponseAPIThroughChat(c *gin.Context, meta *metalib.Meta, responseAPI
 		var quota int64
 
 		go func() {
-			quota = postConsumeQuota(ctx, usage, meta, chatRequest, ratio, preConsumedQuota, 0, modelRatio, groupRatio, false, channelCompletionRatio)
+			quota = postConsumeQuota(ctx, usage, meta, chatRequest, ratio, preConsumedQuota, 0, modelRatio, groupRatio, false, channelModelConfigs, channelCompletionRatio)
 			if requestId != "" {
 				if err := model.UpdateUserRequestCostQuotaByRequestID(quotaId, requestId, quota); err != nil {
 					lg.Error("update user request cost failed", zap.Error(err), zap.String("request_id", requestId))

--- a/relay/controller/response_utils.go
+++ b/relay/controller/response_utils.go
@@ -31,6 +31,11 @@ func getChannelRatios(c *gin.Context) (map[string]float64, map[string]float64) {
 	return modelRatios, completionRatios
 }
 
+func getChannelModelConfigs(c *gin.Context) map[string]model.ModelConfigLocal {
+	channel := c.MustGet(ctxkey.ChannelModel).(*model.Channel)
+	return channel.GetModelPriceConfigs()
+}
+
 // getAndValidateResponseAPIRequest gets and validates Response API request
 func getAndValidateResponseAPIRequest(c *gin.Context) (*openai.ResponseAPIRequest, error) {
 	responseAPIRequest := &openai.ResponseAPIRequest{}

--- a/relay/controller/text.go
+++ b/relay/controller/text.go
@@ -66,12 +66,14 @@ func RelayTextHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 	// get channel-specific pricing if available
 	var channelRecord *model.Channel
 	var channelModelRatio map[string]float64
+	var channelModelConfigs map[string]model.ModelConfigLocal
 	var channelCompletionRatio map[string]float64
 	if channelModel, ok := c.Get(ctxkey.ChannelModel); ok {
 		if channel, ok := channelModel.(*model.Channel); ok {
 			channelRecord = channel
 			// Get from unified ModelConfigs only (after migration)
 			channelModelRatio = channel.GetModelRatioFromConfigs()
+			channelModelConfigs = channel.GetModelPriceConfigs()
 			channelCompletionRatio = channel.GetCompletionRatioFromConfigs()
 		}
 	}
@@ -129,6 +131,7 @@ func RelayTextHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 			ModelRatio:             modelRatio,
 			GroupRatio:             groupRatio,
 			PreConsumedQuota:       preConsumedQuota,
+			ChannelModelConfigs:    channelModelConfigs,
 			ChannelCompletionRatio: channelCompletionRatio,
 			PricingAdaptor:         pricingAdaptor,
 			FlushInterval:          time.Duration(config.StreamingBillingIntervalSec) * time.Second,
@@ -224,7 +227,7 @@ func RelayTextHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 			var quota int64
 
 			go func() {
-				quota = postConsumeQuota(ctx, usage, meta, textRequest, ratio, preConsumedQuota, incrementalCharged, modelRatio, groupRatio, systemPromptReset, channelCompletionRatio)
+				quota = postConsumeQuota(ctx, usage, meta, textRequest, ratio, preConsumedQuota, incrementalCharged, modelRatio, groupRatio, systemPromptReset, channelModelConfigs, channelCompletionRatio)
 				if requestId != "" {
 					if err := model.UpdateUserRequestCostQuotaByRequestID(quotaId, requestId, quota); err != nil {
 						lg.Error("update user request cost failed", zap.Error(err), zap.String("request_id", requestId))
@@ -412,7 +415,7 @@ func RelayTextHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 
 		requestId := c.GetString(ctxkey.RequestId)
 		go func() {
-			quota = postConsumeQuota(ctx, usage, meta, textRequest, ratio, preConsumedQuota, incrementalCharged, modelRatio, groupRatio, systemPromptReset, channelCompletionRatio)
+			quota = postConsumeQuota(ctx, usage, meta, textRequest, ratio, preConsumedQuota, incrementalCharged, modelRatio, groupRatio, systemPromptReset, channelModelConfigs, channelCompletionRatio)
 
 			// Reconcile request cost with final quota (override provisional pre-consumed value)
 			if requestId == "" {

--- a/relay/controller/token_billing_cache_test.go
+++ b/relay/controller/token_billing_cache_test.go
@@ -68,7 +68,7 @@ func TestPostConsumeQuota_OutputPricingIndependentOfCache(t *testing.T) {
 
 	// Case A: No cache
 	usageNoCache := &relaymodel.Usage{PromptTokens: promptTokens, CompletionTokens: completionTokens}
-	quotaNoCache := postConsumeQuota(context.Background(), usageNoCache, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil)
+	quotaNoCache := postConsumeQuota(context.Background(), usageNoCache, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil, nil)
 
 	// Case B: Some cached prompt tokens (e.g., 60%)
 	cachedPrompt := int(float64(promptTokens) * 0.6)
@@ -79,7 +79,7 @@ func TestPostConsumeQuota_OutputPricingIndependentOfCache(t *testing.T) {
 			CachedTokens: cachedPrompt,
 		},
 	}
-	quotaCached := postConsumeQuota(context.Background(), usageCached, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil)
+	quotaCached := postConsumeQuota(context.Background(), usageCached, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil, nil)
 
 	// Expected delta arises only from input pricing change on cached tokens
 	// Base prompt tokens: promptTokens. With caching, cachedPrompt tokens charged at cachedInputPrice instead of normalInputPrice.
@@ -122,11 +122,11 @@ func TestPostConsumeQuota_CacheWriteDoesNotAffectOutput(t *testing.T) {
 
 	// Base: no cache writes
 	usageBase := &relaymodel.Usage{PromptTokens: promptTokens, CompletionTokens: completionTokens}
-	base := postConsumeQuota(context.Background(), usageBase, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil)
+	base := postConsumeQuota(context.Background(), usageBase, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil, nil)
 
 	// With write tokens
 	usageWrite := &relaymodel.Usage{PromptTokens: promptTokens, CompletionTokens: completionTokens, CacheWrite5mTokens: write5m}
-	withWrite := postConsumeQuota(context.Background(), usageWrite, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil)
+	withWrite := postConsumeQuota(context.Background(), usageWrite, meta, req, 0, 0, 0, modelRatio, groupRatio, false, nil, nil)
 
 	// Expected delta is purely input-side: write tokens shift from normalInputPrice to write5mPrice
 	expectedDelta := int64(math.Ceil(float64(write5m) * (write5mPrice - normalInputPrice)))
@@ -157,7 +157,7 @@ func TestPostConsumeResponseAPIQuota_UsesCachedInputPricing(t *testing.T) {
 
 	// Base usage
 	usageBase := &relaymodel.Usage{PromptTokens: promptTokens, CompletionTokens: completionTokens}
-	base := postConsumeResponseAPIQuota(context.Background(), usageBase, meta, respReq, 0, modelRatio, groupRatio, nil)
+	base := postConsumeResponseAPIQuota(context.Background(), usageBase, meta, respReq, 0, modelRatio, groupRatio, nil, nil)
 	baseResult := quotautil.Compute(quotautil.ComputeInput{
 		Usage:          usageBase,
 		ModelName:      modelName,
@@ -171,7 +171,7 @@ func TestPostConsumeResponseAPIQuota_UsesCachedInputPricing(t *testing.T) {
 	// With cached prompt details present - expect delta only from input pricing change
 	cachedPrompt := int(float64(promptTokens) * 0.6)
 	usageCached := &relaymodel.Usage{PromptTokens: promptTokens, CompletionTokens: completionTokens, PromptTokensDetails: &relaymodel.UsagePromptTokensDetails{CachedTokens: cachedPrompt}}
-	withCache := postConsumeResponseAPIQuota(context.Background(), usageCached, meta, respReq, 0, modelRatio, groupRatio, nil)
+	withCache := postConsumeResponseAPIQuota(context.Background(), usageCached, meta, respReq, 0, modelRatio, groupRatio, nil, nil)
 	cachedResult := quotautil.Compute(quotautil.ComputeInput{
 		Usage:          usageCached,
 		ModelName:      modelName,

--- a/relay/pricing/global.go
+++ b/relay/pricing/global.go
@@ -438,36 +438,37 @@ type EffectivePricing struct {
 // - If tiers exist, finds the tier whose InputTokenThreshold <= inputTokens and is the highest such threshold.
 // - Optional tier fields inherit from base if zero. Negative cached ratios mean free.
 func ResolveEffectivePricing(modelName string, inputTokens int, adaptor adaptor.Adaptor) EffectivePricing {
-	eff := EffectivePricing{}
 	if adaptor == nil {
-		// Fallback to defaults if adaptor missing
 		baseIn := 2.5 * 0.000001
 		baseComp := 1.0
-		eff.InputRatio = baseIn
-		eff.OutputRatio = baseIn * baseComp
-		eff.CachedInputRatio = 0
-		eff.CacheWrite5mRatio = 0
-		eff.CacheWrite1hRatio = 0
-		eff.AppliedTierThreshold = 0
-		return eff
+		return EffectivePricing{
+			InputRatio:            baseIn,
+			OutputRatio:           baseIn * baseComp,
+			CachedInputRatio:      0,
+			CacheWrite5mRatio:     0,
+			CacheWrite1hRatio:     0,
+			AppliedTierThreshold:  0,
+		}
 	}
 
-	pricing := adaptor.GetDefaultModelPricing()
-	base, ok := pricing[modelName]
-	if !ok {
-		// Use adaptor fallbacks
-		baseRatio := adaptor.GetModelRatio(modelName)
-		baseComp := adaptor.GetCompletionRatio(modelName)
-		eff.InputRatio = baseRatio
-		eff.OutputRatio = baseRatio * baseComp
-		eff.CachedInputRatio = base.CachedInputRatio // will be zero, as base not exists
-		eff.CacheWrite5mRatio = base.CacheWrite5mRatio
-		eff.CacheWrite1hRatio = base.CacheWrite1hRatio
-		eff.AppliedTierThreshold = 0
-		return eff
+	modelPricing := adaptor.GetDefaultModelPricing()
+	if base, ok := modelPricing[modelName]; ok {
+		return ResolveEffectivePricingFromConfig(inputTokens, base)
 	}
 
-	// Start with base
+	baseRatio := adaptor.GetModelRatio(modelName)
+	baseComp := adaptor.GetCompletionRatio(modelName)
+	return EffectivePricing{
+		InputRatio:            baseRatio,
+		OutputRatio:           baseRatio * baseComp,
+		CachedInputRatio:      0,
+		CacheWrite5mRatio:     0,
+		CacheWrite1hRatio:     0,
+		AppliedTierThreshold:  0,
+	}
+}
+
+func ResolveEffectivePricingFromConfig(inputTokens int, base adaptor.ModelConfig) EffectivePricing {
 	in := base.Ratio
 	comp := base.CompletionRatio
 	cachedIn := base.CachedInputRatio
@@ -475,39 +476,36 @@ func ResolveEffectivePricing(modelName string, inputTokens int, adaptor adaptor.
 	cw1 := base.CacheWrite1hRatio
 	appliedThreshold := 0
 
-	// Find applicable tier (tiers are sorted ascending by threshold)
 	if len(base.Tiers) > 0 {
 		for _, t := range base.Tiers {
-			if inputTokens >= t.InputTokenThreshold {
-				// Apply overrides from this tier
-				if t.Ratio != 0 {
-					in = t.Ratio
-				}
-				if t.CompletionRatio != 0 {
-					comp = t.CompletionRatio
-				}
-				if t.CachedInputRatio != 0 {
-					cachedIn = t.CachedInputRatio
-				}
-				if t.CacheWrite5mRatio != 0 {
-					cw5 = t.CacheWrite5mRatio
-				}
-				if t.CacheWrite1hRatio != 0 {
-					cw1 = t.CacheWrite1hRatio
-				}
-				appliedThreshold = t.InputTokenThreshold
-			} else {
+			if inputTokens < t.InputTokenThreshold {
 				break
 			}
+			if t.Ratio != 0 {
+				in = t.Ratio
+			}
+			if t.CompletionRatio != 0 {
+				comp = t.CompletionRatio
+			}
+			if t.CachedInputRatio != 0 {
+				cachedIn = t.CachedInputRatio
+			}
+			if t.CacheWrite5mRatio != 0 {
+				cw5 = t.CacheWrite5mRatio
+			}
+			if t.CacheWrite1hRatio != 0 {
+				cw1 = t.CacheWrite1hRatio
+			}
+			appliedThreshold = t.InputTokenThreshold
 		}
 	}
 
-	eff.InputRatio = in
-	// Allow completion ratio to be zero if explicitly configured (means free completion tokens)
-	eff.OutputRatio = in * comp
-	eff.CachedInputRatio = cachedIn
-	eff.CacheWrite5mRatio = cw5
-	eff.CacheWrite1hRatio = cw1
-	eff.AppliedTierThreshold = appliedThreshold
-	return eff
+	return EffectivePricing{
+		InputRatio:            in,
+		OutputRatio:           in * comp,
+		CachedInputRatio:      cachedIn,
+		CacheWrite5mRatio:     cw5,
+		CacheWrite1hRatio:     cw1,
+		AppliedTierThreshold:  appliedThreshold,
+	}
 }

--- a/relay/pricing/resolver.go
+++ b/relay/pricing/resolver.go
@@ -108,9 +108,25 @@ func ResolveImagePricing(modelName string, channelConfigs map[string]model.Model
 
 func convertLocalModelConfig(local model.ModelConfigLocal) adaptor.ModelConfig {
 	cfg := adaptor.ModelConfig{
-		Ratio:           local.Ratio,
-		CompletionRatio: local.CompletionRatio,
-		MaxTokens:       local.MaxTokens,
+		Ratio:             local.Ratio,
+		CompletionRatio:   local.CompletionRatio,
+		CachedInputRatio:  local.CachedInputRatio,
+		CacheWrite5mRatio: local.CacheWrite5mRatio,
+		CacheWrite1hRatio: local.CacheWrite1hRatio,
+		MaxTokens:         local.MaxTokens,
+	}
+	if len(local.Tiers) > 0 {
+		cfg.Tiers = make([]adaptor.ModelRatioTier, 0, len(local.Tiers))
+		for _, t := range local.Tiers {
+			cfg.Tiers = append(cfg.Tiers, adaptor.ModelRatioTier{
+				Ratio:               t.Ratio,
+				CompletionRatio:     t.CompletionRatio,
+				CachedInputRatio:    t.CachedInputRatio,
+				CacheWrite5mRatio:   t.CacheWrite5mRatio,
+				CacheWrite1hRatio:   t.CacheWrite1hRatio,
+				InputTokenThreshold: t.InputTokenThreshold,
+			})
+		}
 	}
 	if local.Video != nil {
 		cfg.Video = convertLocalVideo(local.Video)

--- a/relay/pricing/resolver_test.go
+++ b/relay/pricing/resolver_test.go
@@ -1,6 +1,7 @@
 package pricing
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,4 +93,41 @@ func TestGetVideoPricingWithThreeLayers_ChannelConfigMissingVideoFallback(t *tes
 	require.NotNil(t, cfg, "expected provider video pricing fallback")
 	require.InDelta(t, 0.10, cfg.PerSecondUsd, 0.0000001, "expected provider per-second pricing fallback")
 	require.Equal(t, "1280x720", cfg.BaseResolution, "expected provider base resolution fallback")
+}
+
+func TestResolveModelConfig_ChannelOverridePreservesCacheAndTiers(t *testing.T) {
+	const modelName = "claude-4.6-sonnet"
+	var channelConfigs map[string]model.ModelConfigLocal
+	err := json.Unmarshal([]byte(`{
+		"claude-4.6-sonnet": {
+			"ratio": 1.543,
+			"completion_ratio": 7.715,
+			"cached_input_ratio": 1.543,
+			"cache_write_5m_ratio": 1.543,
+			"cache_write_1h_ratio": 1.543,
+			"tiers": [
+				{
+					"input_token_threshold": 200000,
+					"ratio": 3.086,
+					"completion_ratio": 11.571,
+					"cached_input_ratio": 3.086,
+					"cache_write_5m_ratio": 3.086,
+					"cache_write_1h_ratio": 3.086
+				}
+			]
+		}
+	}`), &channelConfigs)
+	require.NoError(t, err)
+
+	cfg, ok := ResolveModelConfig(modelName, channelConfigs, nil)
+	require.True(t, ok)
+	require.InDelta(t, 1.543, cfg.CachedInputRatio, 0.0000001)
+	require.InDelta(t, 1.543, cfg.CacheWrite5mRatio, 0.0000001)
+	require.InDelta(t, 1.543, cfg.CacheWrite1hRatio, 0.0000001)
+	require.Len(t, cfg.Tiers, 1)
+	require.Equal(t, 200000, cfg.Tiers[0].InputTokenThreshold)
+	require.InDelta(t, 3.086, cfg.Tiers[0].Ratio, 0.0000001)
+	require.InDelta(t, 3.086, cfg.Tiers[0].CachedInputRatio, 0.0000001)
+	require.InDelta(t, 3.086, cfg.Tiers[0].CacheWrite5mRatio, 0.0000001)
+	require.InDelta(t, 3.086, cfg.Tiers[0].CacheWrite1hRatio, 0.0000001)
 }

--- a/relay/quota/quota.go
+++ b/relay/quota/quota.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"strings"
 
+	modelcfg "github.com/songquanpeng/one-api/model"
 	"github.com/songquanpeng/one-api/relay/adaptor"
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/pricing"
@@ -16,6 +17,7 @@ type ComputeInput struct {
 	ModelName              string
 	ModelRatio             float64
 	GroupRatio             float64
+	ChannelModelConfigs    map[string]modelcfg.ModelConfigLocal
 	ChannelCompletionRatio map[string]float64
 	PricingAdaptor         adaptor.Adaptor
 }
@@ -48,12 +50,26 @@ func Compute(input ComputeInput) ComputeResult {
 	completionRatioResolved := pricing.GetCompletionRatioWithThreeLayers(input.ModelName, input.ChannelCompletionRatio, pricingAdaptor)
 
 	eff := pricing.ResolveEffectivePricing(input.ModelName, promptTokens, pricingAdaptor)
+	resolvedModelCfg, hasResolvedModelCfg := pricing.ResolveModelConfig(input.ModelName, input.ChannelModelConfigs, pricingAdaptor)
+	if hasResolvedModelCfg {
+		eff = pricing.ResolveEffectivePricingFromConfig(promptTokens, resolvedModelCfg)
+	}
 
 	usedModelRatio := input.ModelRatio
 	usedCompletionRatio := completionRatioResolved
-	if pricingAdaptor != nil {
-		defaultPricing := pricingAdaptor.GetDefaultModelPricing()
-		if _, ok := defaultPricing[input.ModelName]; ok {
+	if hasResolvedModelCfg {
+		if math.Abs(input.ModelRatio-resolvedModelCfg.Ratio) < 1e-12 {
+			usedModelRatio = eff.InputRatio
+			baseComp := eff.OutputRatio
+			if eff.InputRatio != 0 {
+				baseComp = eff.OutputRatio / eff.InputRatio
+			} else {
+				baseComp = 1.0
+			}
+			usedCompletionRatio = baseComp
+		}
+	} else if pricingAdaptor != nil {
+		if _, ok := pricingAdaptor.GetDefaultModelPricing()[input.ModelName]; ok {
 			adaptorBase := pricingAdaptor.GetModelRatio(input.ModelName)
 			if math.Abs(input.ModelRatio-adaptorBase) < 1e-12 {
 				usedModelRatio = eff.InputRatio

--- a/relay/streaming/tracker.go
+++ b/relay/streaming/tracker.go
@@ -30,6 +30,7 @@ type QuotaTrackerParams struct {
 	ModelRatio             float64
 	GroupRatio             float64
 	PreConsumedQuota       int64
+	ChannelModelConfigs    map[string]model.ModelConfigLocal
 	ChannelCompletionRatio map[string]float64
 	PricingAdaptor         adaptor.Adaptor
 	FlushInterval          time.Duration
@@ -223,6 +224,7 @@ func (t *QuotaTracker) computeTargetQuotaLocked() int64 {
 		ModelName:              t.params.ModelName,
 		ModelRatio:             t.params.ModelRatio,
 		GroupRatio:             t.params.GroupRatio,
+		ChannelModelConfigs:    t.params.ChannelModelConfigs,
 		ChannelCompletionRatio: t.params.ChannelCompletionRatio,
 		PricingAdaptor:         t.params.PricingAdaptor,
 	})


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where cache billing configurations set at the Channel level were not being persisted or applied during quota calculation, resulting in incorrect billing for cached token usage.

## Problem

Users could configure cache billing ratios (`cached_input_ratio`, `cache_write_5m_ratio`, `cache_write_1h_ratio`) and tiered pricing in the Channel settings, but these configurations were:
1. **Not persisted** - `ModelConfigLocal` struct lacked cache billing fields
2. **Not applied** - Pricing logic ignored Channel-level cache configurations
3. **Causing billing errors** - Example: 63,277 cache write tokens were not billed

**Example Issue:**
- Channel config: `cached_input_ratio: 1.543`, `cache_write_5m_ratio: 1.543`
- Actual usage: 63,277 cache write tokens (5m)
- Billed quota: 97 (only base tokens, cache tokens free)
- **Expected**: Cache tokens should be billed according to Channel configuration

## Root Cause

1. `ModelConfigLocal` struct in `model/channel.go` was missing cache billing fields
2. `convertLocalModelConfig` didn't map cache ratios to `adaptor.ModelConfig`
3. Quota calculation didn't support Channel-level cache pricing overrides

## Solution

### Code Changes

1. **Extended `ModelConfigLocal`** (`model/channel.go`)
   - Added `cached_input_ratio`, `cache_write_5m_ratio`, `cache_write_1h_ratio`
   - Added `tiers` support for tiered pricing

2. **Updated `ModelRatioTierLocal`** (`model/channel.go`)
   - Added cache billing fields for tier configurations

3. **Fixed mapping logic** (`relay/pricing/resolver.go`)
   - `convertLocalModelConfig` now maps all cache billing fields

4. **Enhanced pricing resolution** (`relay/pricing/global.go`)
   - `ResolveEffectivePricingFromConfig` supports full config with tiers

5. **Integrated Channel configs into quota calculation** (`relay/quota/quota.go`)
   - `Compute` function now uses `ChannelModelConfigs` for cache billing

6. **Propagated Channel configs** (`relay/controller/*`, `relay/streaming/tracker.go`)
   - All controllers pass `ChannelModelConfigs` to quota calculation

### Pricing Priority (After Fix)

1. **Channel-level override** (highest priority)
2. Provider default pricing
3. Global pricing fallback
4. Default value (2.5 USD per million tokens)

## Test Coverage

All tests pass ✅:

- `TestResolveModelConfig_ChannelOverridePreservesCacheAndTiers` - Validates cache field parsing
- `TestChannel_GetModelPriceConfigs_PreservesCacheAndTierFields` - Validates struct persistence
- `TestComputeCachedInputPricing` - Validates cache input billing
- `TestComputeClaudePromptExcludesCacheBuckets` - Validates Claude Messages path
- `TestComputeLegacyPromptIncludesCacheBuckets` - Validates legacy path
- `TestPostConsumeQuota_OutputPricingIndependentOfCache` - Validates text path
- `TestPostConsumeQuota_CacheWriteDoesNotAffectOutput` - Validates cache write billing
- `TestPostConsumeResponseAPIQuota_UsesCachedInputPricing` - Validates Response API path

## Impact

- **Files changed**: 19
- **Lines added**: 582
- **Lines removed**: 85

After this fix, Channel-level cache billing configurations will be correctly:
1. ✅ Persisted to database
2. ✅ Parsed and passed to pricing logic
3. ✅ Applied during quota calculation

## Related Issues

Fixes issue where Channel `model_configs` does not persist tier/cache ratio fields (previously documented in `docs/manuals/billing.md` line 579-581).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced pricing: adds cache-aware ratios and per-model tiered pricing for finer cost calculations.
  * Billing/quota now respects per-channel model configurations for more accurate usage and cost tracking.

* **Documentation**
  * Added a recent-commits analysis doc summarizing recent changes and impact.

* **Chores**
  * Updated Docker build to support GOPROXY propagation.
  * Minor updates to build/verify scripts' user messages.

* **Tests**
  * Added/updated tests to cover new pricing and serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->