### PR TITLE
feat(ali): support Qwen-Image full series (sync + async)

### DIFF
--- a/relay/adaptor/ali/adaptor.go
+++ b/relay/adaptor/ali/adaptor.go
@@ -19,6 +19,20 @@ import (
 
 // https://help.aliyun.com/zh/dashscope/developer-reference/api-details
 
+// qwenImageSyncModels lists models that use the synchronous multimodal-generation endpoint.
+// Ref: https://help.aliyun.com/zh/model-studio/qwen-image-api
+var qwenImageSyncModels = map[string]bool{
+	"qwen-image-2.0-pro": true,
+	"qwen-image-2.0":     true,
+	"qwen-image-max":     true,
+}
+
+// isQwenImageSyncModel returns true for qwen-image-2.0 series models
+// that use the synchronous multimodal-generation/generation endpoint.
+func isQwenImageSyncModel(modelName string) bool {
+	return qwenImageSyncModels[modelName]
+}
+
 type Adaptor struct {
 	meta *meta.Meta
 }
@@ -33,7 +47,13 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 	case relaymode.Embeddings:
 		fullRequestURL = fmt.Sprintf("%s/api/v1/services/embeddings/text-embedding/text-embedding", meta.BaseURL)
 	case relaymode.ImagesGenerations:
-		fullRequestURL = fmt.Sprintf("%s/api/v1/services/aigc/text2image/image-synthesis", meta.BaseURL)
+		if isQwenImageSyncModel(meta.ActualModelName) {
+			// qwen-image-2.0 series uses synchronous multimodal-generation endpoint
+			fullRequestURL = fmt.Sprintf("%s/api/v1/services/aigc/multimodal-generation/generation", meta.BaseURL)
+		} else {
+			// Legacy models (qwen-image-plus, wanx-v1, etc.) use async text2image endpoint
+			fullRequestURL = fmt.Sprintf("%s/api/v1/services/aigc/text2image/image-synthesis", meta.BaseURL)
+		}
 	default:
 		fullRequestURL = fmt.Sprintf("%s/api/v1/services/aigc/text-generation/generation", meta.BaseURL)
 	}
@@ -49,7 +69,9 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, meta *me
 	}
 	req.Header.Set("Authorization", "Bearer "+meta.APIKey)
 
-	if meta.Mode == relaymode.ImagesGenerations {
+	if meta.Mode == relaymode.ImagesGenerations && !isQwenImageSyncModel(meta.ActualModelName) {
+		// Only set async header for legacy image models (qwen-image-plus, wanx-v1, etc.)
+		// qwen-image-2.0 series uses synchronous calls
 		req.Header.Set("X-DashScope-Async", "enable")
 	}
 	if a.meta.Config.Plugin != "" {
@@ -75,6 +97,10 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 func (a *Adaptor) ConvertImageRequest(_ *gin.Context, request *model.ImageRequest) (any, error) {
 	if request == nil {
 		return nil, errors.New("request is nil")
+	}
+
+	if isQwenImageSyncModel(request.Model) {
+		return ConvertQwenImageSyncRequest(*request), nil
 	}
 
 	aliRequest := ConvertImageRequest(*request)
@@ -235,7 +261,11 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Met
 		case relaymode.Embeddings:
 			err, usage = EmbeddingHandler(c, resp)
 		case relaymode.ImagesGenerations:
-			err, usage = ImageHandler(c, resp)
+			if isQwenImageSyncModel(meta.ActualModelName) {
+				err, usage = QwenImageSyncHandler(c, resp)
+			} else {
+				err, usage = ImageHandler(c, resp)
+			}
 		default:
 			err, usage = Handler(c, resp)
 		}

--- a/relay/adaptor/ali/constants.go
+++ b/relay/adaptor/ali/constants.go
@@ -150,7 +150,109 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 	"text-embedding-async-v2": {Ratio: 0.5 * ratio.MilliTokensRmb, CompletionRatio: 1},
 	"text-embedding-async-v1": {Ratio: 0.5 * ratio.MilliTokensRmb, CompletionRatio: 1},
 
-	// Image Generation Models
+	// Qwen-Image Models (synchronous multimodal-generation endpoint)
+	// Pricing: https://help.aliyun.com/zh/model-studio/qwen-image-api
+	// qwen-image-2.0-pro: 0.06 RMB/image (1024x1024)
+	"qwen-image-2.0-pro": {
+		Ratio:           60 * ratio.MilliTokensRmb,
+		CompletionRatio: 1,
+		Image: &adaptor.ImagePricingConfig{
+			DefaultSize:      "1024x1024",
+			DefaultQuality:   "standard",
+			PromptTokenLimit: 800,
+			MinImages:        1,
+			MaxImages:        6,
+			SizeMultipliers: map[string]float64{
+				"512x512":   0.25,
+				"512x1024":  0.5,
+				"1024x512":  0.5,
+				"1024x1024": 1,
+				"1024x2048": 2,
+				"2048x1024": 2,
+				"2048x2048": 4,
+			},
+		},
+	},
+	// qwen-image-2.0: 0.02 RMB/image (1024x1024)
+	"qwen-image-2.0": {
+		Ratio:           20 * ratio.MilliTokensRmb,
+		CompletionRatio: 1,
+		Image: &adaptor.ImagePricingConfig{
+			DefaultSize:      "1024x1024",
+			DefaultQuality:   "standard",
+			PromptTokenLimit: 800,
+			MinImages:        1,
+			MaxImages:        6,
+			SizeMultipliers: map[string]float64{
+				"512x512":   0.25,
+				"512x1024":  0.5,
+				"1024x512":  0.5,
+				"1024x1024": 1,
+				"1024x2048": 2,
+				"2048x1024": 2,
+				"2048x2048": 4,
+			},
+		},
+	},
+	// qwen-image-max: 0.16 RMB/image
+	"qwen-image-max": {
+		Ratio:           160 * ratio.MilliTokensRmb,
+		CompletionRatio: 1,
+		Image: &adaptor.ImagePricingConfig{
+			DefaultSize:      "1024x1024",
+			DefaultQuality:   "standard",
+			PromptTokenLimit: 800,
+			MinImages:        1,
+			MaxImages:        1,
+			SizeMultipliers: map[string]float64{
+				"1664x928":  1,
+				"1472x1104": 1,
+				"1328x1328": 1,
+				"1104x1472": 1,
+				"928x1664":  1,
+			},
+		},
+	},
+	// qwen-image-plus (async): 0.04 RMB/image
+	"qwen-image-plus": {
+		Ratio:           40 * ratio.MilliTokensRmb,
+		CompletionRatio: 1,
+		Image: &adaptor.ImagePricingConfig{
+			DefaultSize:      "1024x1024",
+			DefaultQuality:   "standard",
+			PromptTokenLimit: 500,
+			MinImages:        1,
+			MaxImages:        1,
+			SizeMultipliers: map[string]float64{
+				"1664x928":  1,
+				"1472x1104": 1,
+				"1328x1328": 1,
+				"1104x1472": 1,
+				"928x1664":  1,
+			},
+		},
+	},
+	// qwen-image (async): 0.04 RMB/image
+	"qwen-image": {
+		Ratio:           40 * ratio.MilliTokensRmb,
+		CompletionRatio: 1,
+		Image: &adaptor.ImagePricingConfig{
+			DefaultSize:      "1024x1024",
+			DefaultQuality:   "standard",
+			PromptTokenLimit: 500,
+			MinImages:        1,
+			MaxImages:        1,
+			SizeMultipliers: map[string]float64{
+				"1664x928":  1,
+				"1472x1104": 1,
+				"1328x1328": 1,
+				"1104x1472": 1,
+				"928x1664":  1,
+			},
+		},
+	},
+
+	// Legacy Image Generation Models
 	"ali-stable-diffusion-xl": {
 		Ratio:           8 * ratio.MilliTokensRmb,
 		CompletionRatio: 1,

--- a/relay/adaptor/ali/image.go
+++ b/relay/adaptor/ali/image.go
@@ -172,6 +172,66 @@ func responseAli2OpenAIImage(response *TaskResponse, responseFormat string) *ope
 	return &imageResponse
 }
 
+// QwenImageSyncHandler handles responses from the qwen-image-2.0 synchronous endpoint.
+func QwenImageSyncHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCode, *model.Usage) {
+	responseFormat := c.GetString("response_format")
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return openai.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	_ = resp.Body.Close()
+
+	var qwenResp QwenImageSyncResponse
+	if err := json.Unmarshal(responseBody, &qwenResp); err != nil {
+		return openai.ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+
+	if qwenResp.Code != "" {
+		return &model.ErrorWithStatusCode{
+			Error: model.Error{
+				Message:  qwenResp.Message,
+				Type:     model.ErrorTypeAli,
+				Code:     qwenResp.Code,
+				RawError: errors.New(qwenResp.Message),
+			},
+			StatusCode: resp.StatusCode,
+		}, nil
+	}
+
+	imageResponse := openai.ImageResponse{
+		Created: helper.GetTimestamp(),
+	}
+	for _, choice := range qwenResp.Output.Choices {
+		for _, content := range choice.Message.Content {
+			if content.Image == "" {
+				continue
+			}
+			imgData := openai.ImageData{
+				Url: content.Image,
+			}
+			if responseFormat == "b64_json" {
+				raw, dlErr := getImageData(content.Image)
+				if dlErr != nil {
+					continue
+				}
+				imgData.B64Json = Base64Encode(raw)
+				imgData.Url = ""
+			}
+			imageResponse.Data = append(imageResponse.Data, imgData)
+		}
+	}
+
+	jsonResponse, err := json.Marshal(imageResponse)
+	if err != nil {
+		return openai.ErrorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(resp.StatusCode)
+	_, _ = c.Writer.Write(jsonResponse)
+	return nil, nil
+}
+
 func getImageData(url string) ([]byte, error) {
 	response, err := http.Get(url)
 	if err != nil {

--- a/relay/adaptor/ali/main.go
+++ b/relay/adaptor/ali/main.go
@@ -89,6 +89,39 @@ func ConvertImageRequest(request model.ImageRequest) *ImageRequest {
 	return &imageRequest
 }
 
+// ConvertQwenImageSyncRequest converts an OpenAI image request to the
+// qwen-image-2.0 synchronous multimodal-generation format.
+func ConvertQwenImageSyncRequest(request model.ImageRequest) *QwenImageSyncRequest {
+	size := strings.Replace(request.Size, "x", "*", -1)
+	if size == "" {
+		size = "1024*1024"
+	}
+	n := request.N
+	if n == 0 {
+		n = 1
+	}
+	watermark := false
+
+	return &QwenImageSyncRequest{
+		Model: request.Model,
+		Input: QwenImageSyncInput{
+			Messages: []QwenImageSyncMessage{
+				{
+					Role: "user",
+					Content: []QwenImageSyncContentPart{
+						{Text: request.Prompt},
+					},
+				},
+			},
+		},
+		Parameters: QwenImageSyncParameters{
+			Size:      size,
+			N:         n,
+			Watermark: &watermark,
+		},
+	}
+}
+
 func EmbeddingHandler(c *gin.Context, resp *http.Response) (*model.ErrorWithStatusCode, *model.Usage) {
 	var aliResponse EmbeddingResponse
 	err := json.NewDecoder(resp.Body).Decode(&aliResponse)

--- a/relay/adaptor/ali/main_test.go
+++ b/relay/adaptor/ali/main_test.go
@@ -36,3 +36,82 @@ func TestConvertRequestLeavesNilTopPUnchanged(t *testing.T) {
 	converted := ConvertRequest(req)
 	require.Nil(t, converted.Parameters.TopP, "expected TopP to remain nil when not provided")
 }
+
+func TestIsQwenImageSyncModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"qwen-image-2.0-pro", true},
+		{"qwen-image-2.0", true},
+		{"qwen-image-max", true},
+		{"qwen-image-plus", false},
+		{"qwen-image", false},
+		{"wanx-v1", false},
+		{"ali-stable-diffusion-xl", false},
+		{"qwen-max", false},
+	}
+	for _, tc := range tests {
+		require.Equal(t, tc.want, isQwenImageSyncModel(tc.model), "model: %s", tc.model)
+	}
+}
+
+func TestConvertQwenImageSyncRequest(t *testing.T) {
+	t.Parallel()
+
+	req := model.ImageRequest{
+		Model:  "qwen-image-2.0-pro",
+		Prompt: "a cat on the moon",
+		Size:   "1024x1024",
+		N:      2,
+	}
+
+	result := ConvertQwenImageSyncRequest(req)
+
+	require.Equal(t, "qwen-image-2.0-pro", result.Model)
+	require.Len(t, result.Input.Messages, 1)
+	require.Equal(t, "user", result.Input.Messages[0].Role)
+	require.Len(t, result.Input.Messages[0].Content, 1)
+	require.Equal(t, "a cat on the moon", result.Input.Messages[0].Content[0].Text)
+	require.Equal(t, "1024*1024", result.Parameters.Size)
+	require.Equal(t, 2, result.Parameters.N)
+	require.NotNil(t, result.Parameters.Watermark)
+	require.False(t, *result.Parameters.Watermark)
+}
+
+func TestConvertQwenImageSyncRequestDefaults(t *testing.T) {
+	t.Parallel()
+
+	req := model.ImageRequest{
+		Model:  "qwen-image-2.0",
+		Prompt: "hello",
+	}
+
+	result := ConvertQwenImageSyncRequest(req)
+
+	require.Equal(t, "1024*1024", result.Parameters.Size)
+	require.Equal(t, 1, result.Parameters.N)
+}
+
+func TestConvertImageRequestLegacy(t *testing.T) {
+	t.Parallel()
+
+	format := "url"
+	req := model.ImageRequest{
+		Model:          "wanx-v1",
+		Prompt:         "sunset",
+		Size:           "1024x1024",
+		N:              1,
+		ResponseFormat: &format,
+	}
+
+	result := ConvertImageRequest(req)
+
+	require.Equal(t, "wanx-v1", result.Model)
+	require.Equal(t, "sunset", result.Input.Prompt)
+	require.Equal(t, "1024*1024", result.Parameters.Size)
+	require.Equal(t, 1, result.Parameters.N)
+	require.Equal(t, "url", result.ResponseFormat)
+}

--- a/relay/adaptor/ali/model.go
+++ b/relay/adaptor/ali/model.go
@@ -152,3 +152,59 @@ type ChatResponse struct {
 	Usage  Usage  `json:"usage"`
 	Error
 }
+
+// QwenImageSyncRequest is the request format for qwen-image-2.0 series models
+// using the synchronous multimodal-generation/generation endpoint.
+// Ref: https://help.aliyun.com/zh/model-studio/qwen-image-api
+type QwenImageSyncRequest struct {
+	Model      string                      `json:"model"`
+	Input      QwenImageSyncInput          `json:"input"`
+	Parameters QwenImageSyncParameters     `json:"parameters,omitempty"`
+}
+
+type QwenImageSyncInput struct {
+	Messages []QwenImageSyncMessage `json:"messages"`
+}
+
+type QwenImageSyncMessage struct {
+	Role    string                       `json:"role"`
+	Content []QwenImageSyncContentPart   `json:"content"`
+}
+
+type QwenImageSyncContentPart struct {
+	Text string `json:"text,omitempty"`
+}
+
+type QwenImageSyncParameters struct {
+	Size           string `json:"size,omitempty"`
+	N              int    `json:"n,omitempty"`
+	PromptExtend   *bool  `json:"prompt_extend,omitempty"`
+	Watermark      *bool  `json:"watermark,omitempty"`
+	Seed           int    `json:"seed,omitempty"`
+	NegativePrompt string `json:"negative_prompt,omitempty"`
+}
+
+// QwenImageSyncResponse is the response from qwen-image-2.0 series synchronous endpoint.
+type QwenImageSyncResponse struct {
+	RequestId string `json:"request_id,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Output    struct {
+		Choices []QwenImageSyncChoice `json:"choices,omitempty"`
+	} `json:"output"`
+	Usage struct {
+		ImageCount int `json:"image_count,omitempty"`
+	} `json:"usage"`
+}
+
+type QwenImageSyncChoice struct {
+	Message QwenImageSyncChoiceMessage `json:"message"`
+}
+
+type QwenImageSyncChoiceMessage struct {
+	Content []QwenImageSyncResponseContent `json:"content"`
+}
+
+type QwenImageSyncResponseContent struct {
+	Image string `json:"image,omitempty"`
+}


### PR DESCRIPTION
Add support for qwen-image-2.0-pro/2.0/max (synchronous multimodal-generation endpoint) alongside existing async text2image models (qwen-image-plus/qwen-image).

- Route sync models to /api/v1/services/aigc/multimodal-generation/generation
- Skip X-DashScope-Async header for sync models
- Convert OpenAI image request to DashScope messages format for sync models
- Add QwenImageSyncHandler for synchronous response parsing
- Register pricing for all 5 Qwen-Image models
- Add unit tests for model detection, request conversion, and legacy compat

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for new Qwen image generation models (qwen-image-2.0-pro, qwen-image-2.0, qwen-image-max, qwen-image-plus, qwen-image) with improved synchronous handling and optimized response processing. Legacy Qwen image models continue to be supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->