### PR TITLE
feat: add Grafana dashboard with Prometheus metrics improvements

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -751,6 +751,13 @@ var (
 	// Default: true
 	EnablePrometheusMetrics = env.Bool("ENABLE_PROMETHEUS_METRICS", true)
 
+	// MetricsToken is the Bearer token required to access the /metrics endpoint.
+	// When empty (default), the endpoint returns 403 until configured.
+	//
+	// Environment variable: METRICS_TOKEN
+	// Default: "" (metrics endpoint blocked)
+	MetricsToken = env.String("METRICS_TOKEN", "")
+
 	// MetricQueueSize configures the buffered queue that aggregates success/failure
 	// events before processing. Larger queues handle burst traffic better.
 	//

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -756,7 +756,7 @@ var (
 	//
 	// Environment variable: METRICS_TOKEN
 	// Default: "" (metrics endpoint blocked)
-	MetricsToken = env.String("METRICS_TOKEN", "")
+	MetricsToken = strings.TrimSpace(env.String("METRICS_TOKEN", ""))
 
 	// MetricQueueSize configures the buffered queue that aggregates success/failure
 	// events before processing. Larger queues handle burst traffic better.

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,16 @@
+services:
+  oneapi:
+    build:
+      context: .
+      dockerfile: Dockerfile.local
+    container_name: oneapi-local
+    ports:
+      - "3000:3000"
+    environment:
+      - GIN_MODE=debug
+      - SESSION_SECRET=test-secret
+      - INITIAL_ROOT_TOKEN=sk-local-test-token
+      - ENABLE_PROMETHEUS_METRICS=true
+      - METRICS_TOKEN=test-metrics-token
+    volumes:
+      - ./data/local:/data

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -515,7 +515,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",channel_type=~\"$channel_type\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model)",
+              "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",channel_type=~\"$channel_type\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (model)",
               "legendFormat": "{{model}}",
               "refId": "A"
             }
@@ -563,7 +563,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\",success=\"true\"}[$__rate_interval])) by (model) / sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model)",
+              "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\",success=\"true\"}[$__rate_interval])) by (model) / sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (model)",
               "legendFormat": "{{model}}",
               "refId": "A"
             }
@@ -630,17 +630,17 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (le, model))",
+              "expr": "histogram_quantile(0.5, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (le, model))",
               "legendFormat": "{{model}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (le, model))",
+              "expr": "histogram_quantile(0.95, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (le, model))",
               "legendFormat": "{{model}} P95",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (le, model))",
+              "expr": "histogram_quantile(0.99, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (le, model))",
               "legendFormat": "{{model}} P99",
               "refId": "C"
             }
@@ -687,7 +687,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(one_api_relay_tokens_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model, token_type)",
+              "expr": "sum(rate(one_api_relay_tokens_total{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (model, token_type)",
               "legendFormat": "{{model}}-{{token_type}}",
               "refId": "A"
             }
@@ -738,13 +738,13 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model) / 500000",
+              "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (model) / 500000",
               "legendFormat": "{{model}} (USD)",
               "refId": "A",
               "hide": false
             },
             {
-              "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model) / 500000 * $exchange_rate",
+              "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\",user_id=~\"$username\"}[$__rate_interval])) by (model) / 500000 * $exchange_rate",
               "legendFormat": "{{model}} (CNY)",
               "refId": "B",
               "hide": false

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -1,0 +1,3017 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "barchart",
+      "name": "Bar chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "总览 Overview",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "系统运行时间",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "time() - one_api_system_start_time_seconds",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "总请求速率",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(one_api_http_requests_total[$__rate_interval]))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Relay 成功率",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(one_api_relay_requests_total{success=\"true\"}[$__rate_interval])) / sum(rate(one_api_relay_requests_total[$__rate_interval]))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.95
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "活跃用户数",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "one_api_site_active_users",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "全站 Quota 使用率",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "one_api_site_used_quota / one_api_site_total_quota",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.6
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "认证失败率",
+      "description": "预留：当前无数据",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(one_api_token_auth_attempts_total{success=\"false\"}[$__rate_interval])) / sum(rate(one_api_token_auth_attempts_total[$__rate_interval]))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "noValue": "暂无数据",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "none"
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "HTTP 请求速率（按状态码）",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(one_api_http_requests_total[$__rate_interval])) by (status_code)",
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "错误总览",
+      "description": "预留：当前无数据",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(one_api_errors_total[$__rate_interval])) by (component)",
+          "legendFormat": "{{component}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "unit": "short",
+          "noValue": "暂无数据"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Relay 请求",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "panels": [
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "Relay QPS",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",channel_type=~\"$channel_type\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model)",
+              "legendFormat": "{{model}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "last"
+              ]
+            }
+          }
+        },
+        {
+          "id": 12,
+          "type": "timeseries",
+          "title": "Relay 成功率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\",success=\"true\"}[$__rate_interval])) by (model) / sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model)",
+              "legendFormat": "{{model}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.95
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.99
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "min",
+                "last"
+              ]
+            }
+          }
+        },
+        {
+          "id": 13,
+          "type": "timeseries",
+          "title": "Relay 延迟 P50/P95/P99",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (le, model))",
+              "legendFormat": "{{model}} P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (le, model))",
+              "legendFormat": "{{model}} P95",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (le, model))",
+              "legendFormat": "{{model}} P99",
+              "refId": "C"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 5
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 14,
+          "type": "timeseries",
+          "title": "Token 消耗速率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 30
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_relay_tokens_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model, token_type)",
+              "legendFormat": "{{model}}-{{token_type}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "unit": "short",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 15,
+          "type": "timeseries",
+          "title": "Quota 消耗速率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 30
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model) / 500000",
+              "legendFormat": "{{model}} (USD)",
+              "refId": "A",
+              "hide": false
+            },
+            {
+              "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\",username=~\"$username\"}[$__rate_interval])) by (model) / 500000 * $exchange_rate",
+              "legendFormat": "{{model}} (CNY)",
+              "refId": "B",
+              "hide": false
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "currencyUSD",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          },
+          "transformations": []
+        },
+        {
+          "id": 16,
+          "type": "piechart",
+          "title": "请求分布（按渠道类型）",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 38
+          },
+          "targets": [
+            {
+              "expr": "sum(one_api_relay_requests_total{channel_id=~\"$channel_id\"}) by (channel_type)",
+              "legendFormat": "{{channel_type}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "donut"
+          }
+        },
+        {
+          "id": 17,
+          "type": "piechart",
+          "title": "请求分布（按 API 格式）",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 38
+          },
+          "targets": [
+            {
+              "expr": "sum(one_api_relay_requests_total{channel_id=~\"$channel_id\"}) by (api_format)",
+              "legendFormat": "{{api_format}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "donut"
+          }
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "row",
+      "title": "渠道健康",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "panels": [
+        {
+          "id": 19,
+          "type": "table",
+          "title": "渠道状态表",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 47
+          },
+          "targets": [
+            {
+              "expr": "one_api_channel_status",
+              "refId": "A",
+              "instant": true,
+              "format": "table"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "noValue": "暂无数据"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-background"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": -1
+                        },
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "green",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true
+          },
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true
+                },
+                "renameByName": {
+                  "channel_id": "渠道 ID",
+                  "channel_name": "渠道名称",
+                  "channel_type": "渠道类型",
+                  "Value": "状态"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "type": "timeseries",
+          "title": "渠道在途请求",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 55
+          },
+          "targets": [
+            {
+              "expr": "one_api_channel_requests_in_flight{channel_id=~\"$channel_id\"}",
+              "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "last"
+              ]
+            }
+          }
+        },
+        {
+          "id": 21,
+          "type": "timeseries",
+          "title": "渠道响应时间",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 55
+          },
+          "targets": [
+            {
+              "expr": "one_api_channel_response_time_ms{channel_id=~\"$channel_id\"}",
+              "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ms",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 22,
+          "type": "timeseries",
+          "title": "渠道成功率",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 63
+          },
+          "targets": [
+            {
+              "expr": "one_api_channel_success_rate{channel_id=~\"$channel_id\"}",
+              "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "min"
+              ]
+            }
+          }
+        },
+        {
+          "id": 23,
+          "type": "stat",
+          "title": "渠道余额",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 63
+          },
+          "targets": [
+            {
+              "expr": "one_api_channel_balance_usd{channel_id=~\"$channel_id\"}",
+              "legendFormat": "ch{{channel_id}} (USD)",
+              "refId": "A"
+            },
+            {
+              "expr": "one_api_channel_balance_usd{channel_id=~\"$channel_id\"} * $exchange_rate",
+              "legendFormat": "ch{{channel_id}} (CNY)",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "currencyUSD",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto"
+          }
+        },
+        {
+          "id": 24,
+          "type": "barchart",
+          "title": "渠道请求量 Top10",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 71
+          },
+          "targets": [
+            {
+              "expr": "topk(10, sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\"}[$__rate_interval])) by (channel_id, channel_type))",
+              "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "orientation": "horizontal",
+            "showValue": "always",
+            "stacking": "none",
+            "legend": {
+              "displayMode": "list",
+              "placement": "right"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "type": "row",
+      "title": "用户与 Quota",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      },
+      "panels": [
+        {
+          "id": 26,
+          "type": "gauge",
+          "title": "全站 Quota 使用率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 0,
+            "y": 80
+          },
+          "targets": [
+            {
+              "expr": "one_api_site_used_quota / one_api_site_total_quota",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.6
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.8
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "showThresholdMarkers": true,
+            "showThresholdLabels": false
+          }
+        },
+        {
+          "id": 27,
+          "type": "stat",
+          "title": "全站已用额度",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 6,
+            "y": 80
+          },
+          "targets": [
+            {
+              "expr": "one_api_site_used_quota / 500000",
+              "legendFormat": "USD",
+              "refId": "A",
+              "instant": true
+            },
+            {
+              "expr": "one_api_site_used_quota / 500000 * $exchange_rate",
+              "legendFormat": "CNY",
+              "refId": "B",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "currencyUSD",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none"
+          }
+        },
+        {
+          "id": 28,
+          "type": "stat",
+          "title": "全站总额度",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 12,
+            "y": 80
+          },
+          "targets": [
+            {
+              "expr": "one_api_site_total_quota / 500000",
+              "legendFormat": "USD",
+              "refId": "A",
+              "instant": true
+            },
+            {
+              "expr": "one_api_site_total_quota / 500000 * $exchange_rate",
+              "legendFormat": "CNY",
+              "refId": "B",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "currencyUSD",
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none"
+          }
+        },
+        {
+          "id": 29,
+          "type": "piechart",
+          "title": "用户分组分布",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 6,
+            "x": 18,
+            "y": 80
+          },
+          "targets": [
+            {
+              "expr": "sum(one_api_user_requests_total) by (group)",
+              "legendFormat": "{{group}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "values": [
+                "value",
+                "percent"
+              ]
+            },
+            "pieType": "donut"
+          }
+        },
+        {
+          "id": 30,
+          "type": "barchart",
+          "title": "用户请求量 Top10",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 86
+          },
+          "targets": [
+            {
+              "expr": "topk(10, sum(one_api_user_requests_total{username=~\"$username\",group=~\"$group\"}) by (username, group))",
+              "legendFormat": "{{username}}({{group}})",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "orientation": "horizontal",
+            "showValue": "always",
+            "legend": {
+              "displayMode": "list",
+              "placement": "right"
+            }
+          }
+        },
+        {
+          "id": 31,
+          "type": "barchart",
+          "title": "用户 Quota 消耗 Top10",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 86
+          },
+          "targets": [
+            {
+              "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{username=~\"$username\"}[$__rate_interval])) by (username)) / 500000",
+              "legendFormat": "{{username}} (USD)",
+              "refId": "A",
+              "instant": true
+            },
+            {
+              "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{username=~\"$username\"}[$__rate_interval])) by (username)) / 500000 * $exchange_rate",
+              "legendFormat": "{{username}} (CNY)",
+              "refId": "B",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "options": {
+            "orientation": "horizontal",
+            "showValue": "always",
+            "legend": {
+              "displayMode": "list",
+              "placement": "right"
+            }
+          }
+        },
+        {
+          "id": 32,
+          "type": "timeseries",
+          "title": "用户请求速率趋势",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 94
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_user_requests_total{username=~\"$username\",group=~\"$group\"}[$__rate_interval])) by (username, group)",
+              "legendFormat": "{{username}}({{group}})",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 33,
+          "type": "timeseries",
+          "title": "用户 Token 消耗趋势",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 94
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_user_tokens_total{username=~\"$username\"}[$__rate_interval])) by (username, token_type)",
+              "legendFormat": "{{username}}-{{token_type}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 34,
+      "type": "row",
+      "title": "计费 Billing",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 102
+      },
+      "panels": [
+        {
+          "id": 35,
+          "type": "timeseries",
+          "title": "计费操作速率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 103
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_billing_operations_total[$__rate_interval])) by (operation, success)",
+              "legendFormat": "{{operation}}-{{success}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 36,
+          "type": "timeseries",
+          "title": "计费 P95 延迟",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 103
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(one_api_billing_operation_duration_seconds_bucket[$__rate_interval])) by (le, operation))",
+              "legendFormat": "{{operation}} P95",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 37,
+          "type": "stat",
+          "title": "计费成功率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 111
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_billing_operations_total{success=\"true\"}[$__rate_interval])) / sum(rate(one_api_billing_operations_total[$__rate_interval]))",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "decimals": 2,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.95
+                  },
+                  {
+                    "color": "green",
+                    "value": 0.99
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none"
+          }
+        },
+        {
+          "id": 41,
+          "type": "timeseries",
+          "title": "计费超时次数",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 8,
+            "x": 4,
+            "y": 111
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_billing_timeouts_total[$__rate_interval])) by (model_name)",
+              "legendFormat": "{{model_name}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "short",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 42,
+          "type": "timeseries",
+          "title": "计费错误分布",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 115
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_billing_errors_total[$__rate_interval])) by (error_type, operation)",
+              "legendFormat": "{{error_type}}-{{operation}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "short",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 38,
+          "type": "stat",
+          "title": "计费总操作数",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 0,
+            "y": 123
+          },
+          "targets": [
+            {
+              "expr": "one_api_billing_stats{stat_type=\"total_operations\"}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none"
+          }
+        },
+        {
+          "id": 39,
+          "type": "stat",
+          "title": "计费成功数",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 123
+          },
+          "targets": [
+            {
+              "expr": "one_api_billing_stats{stat_type=\"successful_operations\"}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "noValue": "暂无数据",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none"
+          }
+        },
+        {
+          "id": 40,
+          "type": "stat",
+          "title": "计费失败数",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 123
+          },
+          "targets": [
+            {
+              "expr": "one_api_billing_stats{stat_type=\"failed_operations\"}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "noValue": "暂无数据",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none"
+          }
+        },
+        {
+          "id": 43,
+          "type": "timeseries",
+          "title": "Quota 处理金额趋势",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 123
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_billing_quota_processed_total[$__rate_interval])) by (model_name) / 500000",
+              "legendFormat": "{{model_name}} (USD)",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(one_api_billing_quota_processed_total[$__rate_interval])) by (model_name) / 500000 * $exchange_rate",
+              "legendFormat": "{{model_name}} (CNY)",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 44,
+      "type": "row",
+      "title": "基础设施 DB 与 Redis",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 123
+      },
+      "panels": [
+        {
+          "id": 45,
+          "type": "timeseries",
+          "title": "DB 连接池",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 124
+          },
+          "targets": [
+            {
+              "expr": "one_api_db_connections_in_use",
+              "legendFormat": "在用",
+              "refId": "A"
+            },
+            {
+              "expr": "one_api_db_connections_idle",
+              "legendFormat": "空闲",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 46,
+          "type": "timeseries",
+          "title": "DB 查询速率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 124
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_db_queries_total[$__rate_interval])) by (operation, table)",
+              "legendFormat": "{{operation}}-{{table}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 47,
+          "type": "timeseries",
+          "title": "DB 查询 P95 延迟",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 132
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(one_api_db_query_duration_seconds_bucket[$__rate_interval])) by (le, table))",
+              "legendFormat": "{{table}} P95",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 48,
+          "type": "timeseries",
+          "title": "DB 查询失败率",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 132
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_db_queries_total{success=\"false\"}[$__rate_interval])) by (table)",
+              "legendFormat": "{{table}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 49,
+          "type": "barchart",
+          "title": "DB 热点表 Top5",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 140
+          },
+          "targets": [
+            {
+              "expr": "topk(5, sum(rate(one_api_db_queries_total[$__rate_interval])) by (table))",
+              "legendFormat": "{{table}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "options": {
+            "orientation": "horizontal",
+            "showValue": "always",
+            "legend": {
+              "displayMode": "list",
+              "placement": "right"
+            }
+          }
+        },
+        {
+          "id": 50,
+          "type": "timeseries",
+          "title": "Redis 活跃连接",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 148
+          },
+          "targets": [
+            {
+              "expr": "one_api_redis_connections_active",
+              "legendFormat": "活跃连接",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "single"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 51,
+          "type": "timeseries",
+          "title": "Redis 命令速率",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 148
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_redis_commands_total[$__rate_interval])) by (command)",
+              "legendFormat": "{{command}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ops",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 52,
+          "type": "timeseries",
+          "title": "Redis 命令 P95 延迟",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 148
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(one_api_redis_command_duration_seconds_bucket[$__rate_interval])) by (le, command))",
+              "legendFormat": "{{command}} P95",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "s",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 53,
+      "type": "row",
+      "title": "安全与限流 + Go Runtime",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 156
+      },
+      "panels": [
+        {
+          "id": 54,
+          "type": "timeseries",
+          "title": "认证成功/失败趋势",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 157
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_token_auth_attempts_total[$__rate_interval])) by (success)",
+              "legendFormat": "success={{success}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ops",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 55,
+          "type": "stat",
+          "title": "认证失败率",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 12,
+            "y": 157
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_token_auth_attempts_total{success=\"false\"}[$__rate_interval])) / sum(rate(one_api_token_auth_attempts_total[$__rate_interval]))",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "decimals": 2,
+              "noValue": "暂无数据",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "none"
+          }
+        },
+        {
+          "id": 56,
+          "type": "timeseries",
+          "title": "限流触发速率",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 157
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_rate_limit_hits_total[$__rate_interval])) by (type)",
+              "legendFormat": "{{type}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ops",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 57,
+          "type": "timeseries",
+          "title": "错误分布",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 165
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(one_api_errors_total[$__rate_interval])) by (error_type, component)",
+              "legendFormat": "{{component}}-{{error_type}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "ops",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            },
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            }
+          }
+        },
+        {
+          "id": 58,
+          "type": "barchart",
+          "title": "错误 Top5 组件",
+          "description": "预留：当前无数据",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 165
+          },
+          "targets": [
+            {
+              "expr": "topk(5, sum(rate(one_api_errors_total[$__rate_interval])) by (component))",
+              "legendFormat": "{{component}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops",
+              "noValue": "暂无数据"
+            },
+            "overrides": []
+          },
+          "options": {
+            "orientation": "horizontal",
+            "showValue": "always",
+            "legend": {
+              "displayMode": "list",
+              "placement": "right"
+            }
+          }
+        },
+        {
+          "id": 59,
+          "type": "timeseries",
+          "title": "Goroutines",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 173
+          },
+          "targets": [
+            {
+              "expr": "go_goroutines",
+              "legendFormat": "goroutines",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "single"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 60,
+          "type": "timeseries",
+          "title": "堆内存",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 173
+          },
+          "targets": [
+            {
+              "expr": "go_memstats_heap_inuse_bytes",
+              "legendFormat": "使用中",
+              "refId": "A"
+            },
+            {
+              "expr": "go_memstats_heap_idle_bytes",
+              "legendFormat": "空闲",
+              "refId": "B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "stacking": {
+                  "mode": "normal"
+                }
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "multi"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 61,
+          "type": "timeseries",
+          "title": "GC 暂停时间",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 173
+          },
+          "targets": [
+            {
+              "expr": "rate(go_gc_duration_seconds_sum[$__rate_interval])",
+              "legendFormat": "GC 耗时",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "single"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 62,
+          "type": "timeseries",
+          "title": "进程 CPU",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 181
+          },
+          "targets": [
+            {
+              "expr": "rate(process_cpu_seconds_total[$__rate_interval])",
+              "legendFormat": "CPU 使用率",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 2,
+                "fillOpacity": 10
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "options": {
+            "tooltip": {
+              "mode": "single"
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            }
+          }
+        },
+        {
+          "id": 63,
+          "type": "stat",
+          "title": "进程 RSS 内存",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 181
+          },
+          "targets": [
+            {
+              "expr": "process_resident_memory_bytes",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ]
+            },
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "one-api",
+    "llm-gateway"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "channel_id",
+        "label": "渠道 ID",
+        "type": "query",
+        "query": "label_values(one_api_relay_requests_total, channel_id)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "channel_type",
+        "label": "渠道类型",
+        "type": "query",
+        "query": "label_values(one_api_relay_requests_total, channel_type)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "model",
+        "label": "模型",
+        "type": "query",
+        "query": "label_values(one_api_relay_requests_total, model)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "username",
+        "label": "用户名",
+        "type": "query",
+        "query": "label_values(one_api_user_requests_total, username)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 3
+      },
+      {
+        "name": "group",
+        "label": "用户组",
+        "type": "query",
+        "query": "label_values(one_api_user_requests_total, group)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "currency",
+        "label": "货币",
+        "type": "custom",
+        "query": "USD,CNY",
+        "current": {
+          "selected": true,
+          "text": "USD",
+          "value": "USD"
+        },
+        "includeAll": false,
+        "multi": false
+      },
+      {
+        "name": "exchange_rate",
+        "label": "汇率",
+        "type": "textbox",
+        "query": "8",
+        "current": {
+          "text": "8",
+          "value": "8"
+        }
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "One API Dashboard",
+  "uid": "one-api-main",
+  "version": 1
+}

--- a/docs/manuals/PROMETHEUS.md
+++ b/docs/manuals/PROMETHEUS.md
@@ -20,6 +20,7 @@ The Prometheus monitoring system provides detailed metrics about:
 ### Environment Variables
 
 - `ENABLE_PROMETHEUS_METRICS`: Enable/disable Prometheus metrics collection (default: `true`)
+- `METRICS_TOKEN`: Bearer token required to access the `/metrics` endpoint. When not set, the endpoint returns 403. (default: empty)
 - `ENABLE_METRIC`: Enable/disable the existing channel monitoring system (default: `false`)
 
 ### Metrics Endpoint
@@ -28,6 +29,30 @@ When Prometheus monitoring is enabled, metrics are available at:
 
 ```
 http://your-server:port/metrics
+```
+
+**Authentication:** The `/metrics` endpoint requires a Bearer token configured via the `METRICS_TOKEN` environment variable. Requests without a valid token will be rejected.
+
+### Prometheus Scrape Configuration
+
+```yaml
+scrape_configs:
+  - job_name: 'one-api'
+    bearer_token: '<your-metrics-token>'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['one-api:3000']
+```
+
+Or using a file-based token (recommended for production):
+
+```yaml
+scrape_configs:
+  - job_name: 'one-api'
+    bearer_token_file: /etc/prometheus/one-api-token
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['one-api:3000']
 ```
 
 ## Available Metrics

--- a/docs/superpowers/plans/2026-04-01-grafana-dashboard.md
+++ b/docs/superpowers/plans/2026-04-01-grafana-dashboard.md
@@ -29,7 +29,7 @@ All monetary panels use two queries:
 - Query B (CNY): `<base expression> / 500000 * $exchange_rate`
 
 Visibility is controlled via Grafana panel `overrides` based on the `$currency` variable, or using a single PromQL:
-```
+```text
 <base expression> / 500000 * (1 + ($currency == "CNY") * ($exchange_rate - 1))
 ```
 
@@ -150,10 +150,10 @@ Add the following variable definitions in order to the `templating.list` array:
     "sort": 1
   },
   {
-    "name": "user_id",
-    "label": "User ID",
+    "name": "username",
+    "label": "Username",
     "type": "query",
-    "query": "label_values(one_api_user_requests_total, user_id)",
+    "query": "label_values(one_api_user_requests_total, username)",
     "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
     "refresh": 2,
     "includeAll": true,
@@ -499,7 +499,7 @@ id:11, x:0, y:14, w:12, h:8
   "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
   "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
   "targets": [{
-    "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",channel_type=~\"$channel_type\",model=~\"$model\",user_id=~\"$user_id\"}[$__rate_interval])) by (model)",
+    "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",channel_type=~\"$channel_type\",model=~\"$model\"}[$__rate_interval])) by (model)",
     "legendFormat": "{{model}}",
     "refId": "A"
   }],
@@ -937,8 +937,8 @@ Row id:25, y:79. Child panels id:26-33.
   "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
   "gridPos": { "h": 8, "w": 12, "x": 0, "y": 86 },
   "targets": [{
-    "expr": "topk(10, sum(one_api_user_requests_total{user_id=~\"$user_id\",group=~\"$group\"}) by (user_id, group))",
-    "legendFormat": "user{{user_id}}({{group}})",
+    "expr": "topk(10, sum(one_api_user_requests_total{username=~\"$username\",group=~\"$group\"}) by (username, group))",
+    "legendFormat": "{{username}}({{group}})",
     "refId": "A",
     "instant": true
   }],
@@ -957,14 +957,14 @@ Row id:25, y:79. Child panels id:26-33.
   "gridPos": { "h": 8, "w": 12, "x": 12, "y": 86 },
   "targets": [
     {
-      "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{user_id=~\"$user_id\"}[$__rate_interval])) by (user_id)) / 500000",
-      "legendFormat": "user{{user_id}} (USD)",
+      "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{username=~\"$username\"}[$__rate_interval])) by (username)) / 500000",
+      "legendFormat": "{{username}} (USD)",
       "refId": "A",
       "instant": true
     },
     {
-      "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{user_id=~\"$user_id\"}[$__rate_interval])) by (user_id)) / 500000 * $exchange_rate",
-      "legendFormat": "user{{user_id}} (CNY)",
+      "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{username=~\"$username\"}[$__rate_interval])) by (username)) / 500000 * $exchange_rate",
+      "legendFormat": "{{username}} (CNY)",
       "refId": "B",
       "instant": true
     }
@@ -983,8 +983,8 @@ Row id:25, y:79. Child panels id:26-33.
   "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
   "gridPos": { "h": 8, "w": 12, "x": 0, "y": 94 },
   "targets": [{
-    "expr": "sum(rate(one_api_user_requests_total{user_id=~\"$user_id\",group=~\"$group\"}[$__rate_interval])) by (user_id, group)",
-    "legendFormat": "user{{user_id}}({{group}})",
+    "expr": "sum(rate(one_api_user_requests_total{username=~\"$username\",group=~\"$group\"}[$__rate_interval])) by (username, group)",
+    "legendFormat": "{{username}}({{group}})",
     "refId": "A"
   }],
   "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "reqps" }, "overrides": [] },
@@ -1001,8 +1001,8 @@ Row id:25, y:79. Child panels id:26-33.
   "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
   "gridPos": { "h": 8, "w": 12, "x": 12, "y": 94 },
   "targets": [{
-    "expr": "sum(rate(one_api_user_tokens_total{user_id=~\"$user_id\"}[$__rate_interval])) by (user_id, token_type)",
-    "legendFormat": "user{{user_id}}-{{token_type}}",
+    "expr": "sum(rate(one_api_user_tokens_total{username=~\"$username\"}[$__rate_interval])) by (username, token_type)",
+    "legendFormat": "{{username}}-{{token_type}}",
     "refId": "A"
   }],
   "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal" } }, "unit": "short" }, "overrides": [] },

--- a/docs/superpowers/plans/2026-04-01-grafana-dashboard.md
+++ b/docs/superpowers/plans/2026-04-01-grafana-dashboard.md
@@ -455,7 +455,7 @@ Append the following panels to the `panels` array (`id` starts at 1 and incremen
 
 - [ ] **Step 3: Validate JSON**
 
-Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')"` 
 
 Expected: `panels: 9` (1 Row + 6 Stat + 2 time series)
 
@@ -672,7 +672,7 @@ Note: The Quota consumption panel provides both USD and CNY queries; users selec
 
 - [ ] **Step 7: Validate JSON and commit**
 
-Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')"` 
 
 Expected: `panels: 10` (9 + 1 collapsed Row, where Row 2 contains 7 child panels)
 
@@ -830,7 +830,7 @@ Row id:18, y:46. Child panels id:19-24.
 
 - [ ] **Step 2: Validate JSON and commit**
 
-Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')"` 
 
 Expected: `panels: 11` (previous 10 + 1 collapsed Row 3, containing 6 child panels)
 
@@ -1012,7 +1012,7 @@ Row id:25, y:79. Child panels id:26-33.
 
 - [ ] **Step 2: Validate JSON and commit**
 
-Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')"` 
 
 Expected: `panels: 12` (previous 11 + 1 collapsed Row 4, containing 8 child panels)
 
@@ -1553,7 +1553,7 @@ Row id:53, y:156. Child panels id:54-63.
 
 - [ ] **Step 2: Validate JSON and commit**
 
-Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); total=len(d['panels']); collapsed=[p for p in d['panels'] if p.get('collapsed')]; inner=sum(len(p.get('panels',[])) for p in collapsed); print(f'top-level: {total}, collapsed inner: {inner}, total panels: {total+inner}')" `
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); total=len(d['panels']); collapsed=[p for p in d['panels'] if p.get('collapsed')]; inner=sum(len(p.get('panels',[])) for p in collapsed); print(f'top-level: {total}, collapsed inner: {inner}, total panels: {total+inner}')"` 
 
 Expected: `top-level: 16, collapsed inner: 49, total panels: 65` (16 = 1 Row (expanded) + 8 panels + 6 collapsed Rows + 1 expanded panel... exact number depends on structure, the key point is JSON parses successfully and panels are not empty)
 

--- a/docs/superpowers/plans/2026-04-01-grafana-dashboard.md
+++ b/docs/superpowers/plans/2026-04-01-grafana-dashboard.md
@@ -1,0 +1,1635 @@
+# One API Grafana Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a complete Grafana Dashboard JSON configuration file, containing 7 Rows, 54 panels, top-level variables, and currency conversion logic.
+
+**Architecture:** A single `docs/grafana-dashboard.json` file, in Grafana 10.x+ Dashboard JSON Model format. Built incrementally by Row, with each Task responsible for one Row's panel definitions. Uses Grafana's `templating` for variable filtering, and Transformations + Math expression for currency conversion.
+
+**Tech Stack:** Grafana 10.x+ Dashboard JSON Model, Prometheus PromQL
+
+**Design spec:** `docs/superpowers/specs/2026-04-01-grafana-dashboard-design.md`
+
+---
+
+## File Structure
+
+- **Create:** `docs/grafana-dashboard.json` — Complete Grafana Dashboard JSON (replaces the missing file referenced in documentation)
+
+---
+
+## Key Conventions
+
+The following conventions are reused in every Task and will not be repeated:
+
+### Currency Conversion PromQL Pattern
+
+All monetary panels use two queries:
+- Query A (USD): `<base expression> / 500000`
+- Query B (CNY): `<base expression> / 500000 * $exchange_rate`
+
+Visibility is controlled via Grafana panel `overrides` based on the `$currency` variable, or using a single PromQL:
+```
+<base expression> / 500000 * (1 + ($currency == "CNY") * ($exchange_rate - 1))
+```
+
+Since PromQL does not support string comparison, the actual implementation uses two queries + hide conditions.
+
+### Panel Size Grid
+
+Grafana 24-column grid:
+- Stat cards: `w:4, h:4` (6 per row)
+- Time series / Bar charts: `w:12, h:8` (2 per row)
+- Pie charts: `w:8, h:8` (3 per row)
+- Tables: `w:24, h:8` (full width)
+- Gauge: `w:6, h:6`
+
+### Common datasource
+
+```json
+{ "type": "prometheus", "uid": "${DS_PROMETHEUS}" }
+```
+
+All panels use this value for the `datasource` field, allowing dynamic binding on import.
+
+---
+
+## Task 1: Dashboard Skeleton and Top-Level Variables
+
+**Files:**
+- Create: `docs/grafana-dashboard.json`
+
+- [ ] **Step 1: Create Dashboard JSON skeleton**
+
+Create `docs/grafana-dashboard.json` with the following top-level structure:
+
+```json
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" },
+    { "type": "panel", "id": "barchart", "name": "Bar chart", "version": "" },
+    { "type": "panel", "id": "piechart", "name": "Pie chart", "version": "" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "" }
+  ],
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "schemaVersion": 39,
+  "tags": ["one-api", "llm-gateway"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "One API Dashboard",
+  "uid": "one-api-main",
+  "version": 1
+}
+```
+
+- [ ] **Step 2: Add 7 top-level variables to `templating.list`**
+
+Add the following variable definitions in order to the `templating.list` array:
+
+```json
+[
+  {
+    "name": "channel_id",
+    "label": "Channel ID",
+    "type": "query",
+    "query": "label_values(one_api_relay_requests_total, channel_id)",
+    "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+    "refresh": 2,
+    "includeAll": true,
+    "multi": true,
+    "allValue": ".*",
+    "current": { "selected": true, "text": "All", "value": "$__all" },
+    "sort": 1
+  },
+  {
+    "name": "channel_type",
+    "label": "Channel Type",
+    "type": "query",
+    "query": "label_values(one_api_relay_requests_total, channel_type)",
+    "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+    "refresh": 2,
+    "includeAll": true,
+    "multi": true,
+    "allValue": ".*",
+    "current": { "selected": true, "text": "All", "value": "$__all" },
+    "sort": 1
+  },
+  {
+    "name": "model",
+    "label": "Model",
+    "type": "query",
+    "query": "label_values(one_api_relay_requests_total, model)",
+    "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+    "refresh": 2,
+    "includeAll": true,
+    "multi": true,
+    "allValue": ".*",
+    "current": { "selected": true, "text": "All", "value": "$__all" },
+    "sort": 1
+  },
+  {
+    "name": "user_id",
+    "label": "User ID",
+    "type": "query",
+    "query": "label_values(one_api_user_requests_total, user_id)",
+    "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+    "refresh": 2,
+    "includeAll": true,
+    "multi": true,
+    "allValue": ".*",
+    "current": { "selected": true, "text": "All", "value": "$__all" },
+    "sort": 3
+  },
+  {
+    "name": "group",
+    "label": "User Group",
+    "type": "query",
+    "query": "label_values(one_api_user_requests_total, group)",
+    "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+    "refresh": 2,
+    "includeAll": true,
+    "multi": true,
+    "allValue": ".*",
+    "current": { "selected": true, "text": "All", "value": "$__all" },
+    "sort": 1
+  },
+  {
+    "name": "currency",
+    "label": "Currency",
+    "type": "custom",
+    "query": "USD,CNY",
+    "current": { "selected": true, "text": "USD", "value": "USD" },
+    "includeAll": false,
+    "multi": false
+  },
+  {
+    "name": "exchange_rate",
+    "label": "Exchange Rate",
+    "type": "textbox",
+    "query": "8",
+    "current": { "text": "8", "value": "8" }
+  }
+]
+```
+
+- [ ] **Step 3: Validate JSON**
+
+Run: `python3 -c "import json; json.load(open('docs/grafana-dashboard.json'))"`
+
+Expected: no output (successful parse)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard skeleton with template variables"
+```
+
+---
+
+## Task 2: Row 1 — Overview
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Append Row + 8 panels to the `panels` array
+
+- [ ] **Step 1: Add Row 1 header and 6 Stat cards**
+
+Append the following panels to the `panels` array (`id` starts at 1 and increments):
+
+**Row panel:**
+```json
+{
+  "id": 1,
+  "type": "row",
+  "title": "Overview",
+  "collapsed": false,
+  "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+  "panels": []
+}
+```
+
+**Stat 1 — System Uptime** (gridPos: x:0, y:1, w:4, h:4):
+```json
+{
+  "id": 2,
+  "type": "stat",
+  "title": "System Uptime",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+  "targets": [{
+    "expr": "time() - one_api_system_start_time_seconds",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "s",
+      "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**Stat 2 — Total Request Rate** (x:4, y:1, w:4, h:4):
+```json
+{
+  "id": 3,
+  "type": "stat",
+  "title": "Total Request Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+  "targets": [{
+    "expr": "sum(rate(one_api_http_requests_total[$__rate_interval]))",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "reqps",
+      "decimals": 2,
+      "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" }
+}
+```
+
+**Stat 3 — Relay Success Rate** (x:8, y:1, w:4, h:4):
+```json
+{
+  "id": 4,
+  "type": "stat",
+  "title": "Relay Success Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+  "targets": [{
+    "expr": "sum(rate(one_api_relay_requests_total{success=\"true\"}[$__rate_interval])) / sum(rate(one_api_relay_requests_total[$__rate_interval]))",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "percentunit",
+      "decimals": 2,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          { "color": "red", "value": null },
+          { "color": "yellow", "value": 0.95 },
+          { "color": "green", "value": 0.99 }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**Stat 4 — Active Users** (x:12, y:1, w:4, h:4):
+```json
+{
+  "id": 5,
+  "type": "stat",
+  "title": "Active Users",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+  "targets": [{
+    "expr": "one_api_site_active_users",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "none",
+      "thresholds": { "mode": "absolute", "steps": [{ "color": "blue", "value": null }] }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**Stat 5 — Site-wide Quota Usage** (x:16, y:1, w:4, h:4):
+```json
+{
+  "id": 6,
+  "type": "stat",
+  "title": "Site-wide Quota Usage",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+  "targets": [{
+    "expr": "one_api_site_used_quota / one_api_site_total_quota",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "percentunit",
+      "decimals": 2,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          { "color": "green", "value": null },
+          { "color": "yellow", "value": 0.6 },
+          { "color": "red", "value": 0.8 }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" }
+}
+```
+
+**Stat 6 — Auth Failure Rate** (x:20, y:1, w:4, h:4):
+```json
+{
+  "id": 7,
+  "type": "stat",
+  "title": "Auth Failure Rate",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+  "targets": [{
+    "expr": "sum(rate(one_api_token_auth_attempts_total{success=\"false\"}[$__rate_interval])) / sum(rate(one_api_token_auth_attempts_total[$__rate_interval]))",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "percentunit",
+      "decimals": 2,
+      "noValue": "No data",
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          { "color": "green", "value": null },
+          { "color": "yellow", "value": 0.01 },
+          { "color": "red", "value": 0.05 }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+- [ ] **Step 2: Add 2 time series panels**
+
+**Time Series 1 — HTTP Request Rate (by Status Code)** (x:0, y:5, w:12, h:8):
+```json
+{
+  "id": 8,
+  "type": "timeseries",
+  "title": "HTTP Request Rate (by Status Code)",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+  "targets": [{
+    "expr": "sum(rate(one_api_http_requests_total[$__rate_interval])) by (status_code)",
+    "legendFormat": "{{status_code}}",
+    "refId": "A"
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "pointSize": 5, "stacking": { "mode": "none" } },
+      "unit": "reqps"
+    },
+    "overrides": []
+  },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Time Series 2 — Error Overview** (x:12, y:5, w:12, h:8):
+```json
+{
+  "id": 9,
+  "type": "timeseries",
+  "title": "Error Overview",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+  "targets": [{
+    "expr": "sum(rate(one_api_errors_total[$__rate_interval])) by (component)",
+    "legendFormat": "{{component}}",
+    "refId": "A"
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+      "unit": "short",
+      "noValue": "No data"
+    },
+    "overrides": []
+  },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+- [ ] **Step 3: Validate JSON**
+
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+
+Expected: `panels: 9` (1 Row + 6 Stat + 2 time series)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard Row 1 - Overview panels"
+```
+
+---
+
+## Task 3: Row 2 — Relay Requests
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Append Row + 7 panels to the `panels` array
+
+- [ ] **Step 1: Add Row 2 header**
+
+```json
+{
+  "id": 10,
+  "type": "row",
+  "title": "Relay Requests",
+  "collapsed": true,
+  "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+  "panels": [...]
+}
+```
+
+Row 2 has `collapsed: true`, all child panels are placed inside this Row's `panels` array. Child panel `gridPos.y` starts from 14.
+
+- [ ] **Step 2: Add Relay QPS time series**
+
+id:11, x:0, y:14, w:12, h:8
+```json
+{
+  "id": 11,
+  "type": "timeseries",
+  "title": "Relay QPS",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+  "targets": [{
+    "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",channel_type=~\"$channel_type\",model=~\"$model\",user_id=~\"$user_id\"}[$__rate_interval])) by (model)",
+    "legendFormat": "{{model}}",
+    "refId": "A"
+  }],
+  "fieldConfig": {
+    "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "reqps" },
+    "overrides": []
+  },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "last"] } }
+}
+```
+
+- [ ] **Step 3: Add Relay Success Rate time series**
+
+id:12, x:12, y:14, w:12, h:8
+```json
+{
+  "id": 12,
+  "type": "timeseries",
+  "title": "Relay Success Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+  "targets": [{
+    "expr": "sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\",success=\"true\"}[$__rate_interval])) by (model) / sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\",model=~\"$model\"}[$__rate_interval])) by (model)",
+    "legendFormat": "{{model}}",
+    "refId": "A"
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+      "unit": "percentunit",
+      "min": 0, "max": 1,
+      "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 0.95 }, { "color": "green", "value": 0.99 }] }
+    },
+    "overrides": []
+  },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "min", "last"] } }
+}
+```
+
+- [ ] **Step 4: Add Relay Latency P50/P95/P99 time series**
+
+id:13, x:0, y:22, w:24, h:8 (full width, 3 percentile lines)
+```json
+{
+  "id": 13,
+  "type": "timeseries",
+  "title": "Relay Latency P50/P95/P99",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 24, "x": 0, "y": 22 },
+  "targets": [
+    {
+      "expr": "histogram_quantile(0.5, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\"}[$__rate_interval])) by (le, model))",
+      "legendFormat": "{{model}} P50",
+      "refId": "A"
+    },
+    {
+      "expr": "histogram_quantile(0.95, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\"}[$__rate_interval])) by (le, model))",
+      "legendFormat": "{{model}} P95",
+      "refId": "B"
+    },
+    {
+      "expr": "histogram_quantile(0.99, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~\"$channel_id\",model=~\"$model\"}[$__rate_interval])) by (le, model))",
+      "legendFormat": "{{model}} P99",
+      "refId": "C"
+    }
+  ],
+  "fieldConfig": {
+    "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 5 }, "unit": "s" },
+    "overrides": []
+  },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+- [ ] **Step 5: Add Token Consumption Rate and Quota Consumption Rate time series**
+
+**Token Consumption Rate** id:14, x:0, y:30, w:12, h:8:
+```json
+{
+  "id": 14,
+  "type": "timeseries",
+  "title": "Token Consumption Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 30 },
+  "targets": [{
+    "expr": "sum(rate(one_api_relay_tokens_total{channel_id=~\"$channel_id\",model=~\"$model\"}[$__rate_interval])) by (model, token_type)",
+    "legendFormat": "{{model}}-{{token_type}}",
+    "refId": "A"
+  }],
+  "fieldConfig": {
+    "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal" } }, "unit": "short" },
+    "overrides": []
+  },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Quota Consumption Rate** id:15, x:12, y:30, w:12, h:8:
+```json
+{
+  "id": 15,
+  "type": "timeseries",
+  "title": "Quota Consumption Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 30 },
+  "targets": [
+    {
+      "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\"}[$__rate_interval])) by (model) / 500000",
+      "legendFormat": "{{model}} (USD)",
+      "refId": "A",
+      "hide": false
+    },
+    {
+      "expr": "sum(rate(one_api_relay_quota_used_total{channel_id=~\"$channel_id\",model=~\"$model\"}[$__rate_interval])) by (model) / 500000 * $exchange_rate",
+      "legendFormat": "{{model}} (CNY)",
+      "refId": "B",
+      "hide": false
+    }
+  ],
+  "fieldConfig": {
+    "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "currencyUSD" },
+    "overrides": []
+  },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+  "transformations": []
+}
+```
+
+Note: The Quota consumption panel provides both USD and CNY queries; users select which to focus on based on the `$currency` variable.
+
+- [ ] **Step 6: Add 2 pie charts**
+
+**Request Distribution (by Channel Type)** id:16, x:0, y:38, w:12, h:8:
+```json
+{
+  "id": 16,
+  "type": "piechart",
+  "title": "Request Distribution (by Channel Type)",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 38 },
+  "targets": [{
+    "expr": "sum(one_api_relay_requests_total{channel_id=~\"$channel_id\"}) by (channel_type)",
+    "legendFormat": "{{channel_type}}",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": { "defaults": {}, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" }
+}
+```
+
+**Request Distribution (by API Format)** id:17, x:12, y:38, w:12, h:8:
+```json
+{
+  "id": 17,
+  "type": "piechart",
+  "title": "Request Distribution (by API Format)",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 38 },
+  "targets": [{
+    "expr": "sum(one_api_relay_requests_total{channel_id=~\"$channel_id\"}) by (api_format)",
+    "legendFormat": "{{api_format}}",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": { "defaults": {}, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" }
+}
+```
+
+- [ ] **Step 7: Validate JSON and commit**
+
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+
+Expected: `panels: 10` (9 + 1 collapsed Row, where Row 2 contains 7 child panels)
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard Row 2 - Relay panels"
+```
+
+---
+
+## Task 4: Row 3 — Channel Health
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Append collapsed Row + 6 panels to the `panels` array
+
+- [ ] **Step 1: Add Row 3 header (collapsed) and 6 child panels**
+
+Row id:18, y:46. Child panels id:19-24.
+
+**Channel Status Table** id:19, x:0, y:47, w:24, h:8, type: table:
+```json
+{
+  "id": 19,
+  "type": "table",
+  "title": "Channel Status Table",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 24, "x": 0, "y": 47 },
+  "targets": [{
+    "expr": "one_api_channel_status",
+    "refId": "A",
+    "instant": true,
+    "format": "table"
+  }],
+  "fieldConfig": {
+    "defaults": { "noValue": "No data" },
+    "overrides": [
+      {
+        "matcher": { "id": "byName", "options": "Value" },
+        "properties": [{
+          "id": "custom.cellOptions",
+          "value": { "type": "color-background" }
+        }, {
+          "id": "thresholds",
+          "value": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": -1 }, { "color": "red", "value": 0 }, { "color": "green", "value": 1 }] }
+        }]
+      }
+    ]
+  },
+  "options": { "showHeader": true },
+  "transformations": [{ "id": "organize", "options": { "excludeByName": { "Time": true, "__name__": true }, "renameByName": { "channel_id": "Channel ID", "channel_name": "Channel Name", "channel_type": "Channel Type", "Value": "Status" } } }]
+}
+```
+
+**Channel In-Flight Requests** id:20, x:0, y:55, w:12, h:8:
+```json
+{
+  "id": 20,
+  "type": "timeseries",
+  "title": "Channel In-Flight Requests",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 55 },
+  "targets": [{
+    "expr": "one_api_channel_requests_in_flight{channel_id=~\"$channel_id\"}",
+    "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "last"] } }
+}
+```
+
+**Channel Response Time** id:21, x:12, y:55, w:12, h:8:
+```json
+{
+  "id": 21,
+  "type": "timeseries",
+  "title": "Channel Response Time",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 55 },
+  "targets": [{
+    "expr": "one_api_channel_response_time_ms{channel_id=~\"$channel_id\"}",
+    "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ms", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Channel Success Rate** id:22, x:0, y:63, w:12, h:8:
+```json
+{
+  "id": 22,
+  "type": "timeseries",
+  "title": "Channel Success Rate",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 63 },
+  "targets": [{
+    "expr": "one_api_channel_success_rate{channel_id=~\"$channel_id\"}",
+    "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "percentunit", "min": 0, "max": 1, "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "min"] } }
+}
+```
+
+**Channel Balance** id:23, x:12, y:63, w:12, h:8:
+```json
+{
+  "id": 23,
+  "type": "stat",
+  "title": "Channel Balance",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 63 },
+  "targets": [
+    {
+      "expr": "one_api_channel_balance_usd{channel_id=~\"$channel_id\"}",
+      "legendFormat": "ch{{channel_id}} (USD)",
+      "refId": "A"
+    },
+    {
+      "expr": "one_api_channel_balance_usd{channel_id=~\"$channel_id\"} * $exchange_rate",
+      "legendFormat": "ch{{channel_id}} (CNY)",
+      "refId": "B"
+    }
+  ],
+  "fieldConfig": { "defaults": { "unit": "currencyUSD", "noValue": "No data" }, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none", "textMode": "auto" }
+}
+```
+
+**Channel Request Volume Top10** id:24, x:0, y:71, w:24, h:8:
+```json
+{
+  "id": 24,
+  "type": "barchart",
+  "title": "Channel Request Volume Top10",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 24, "x": 0, "y": 71 },
+  "targets": [{
+    "expr": "topk(10, sum(rate(one_api_relay_requests_total{channel_id=~\"$channel_id\"}[$__rate_interval])) by (channel_id, channel_type))",
+    "legendFormat": "ch{{channel_id}}-{{channel_type}}",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+  "options": { "orientation": "horizontal", "showValue": "always", "stacking": "none", "legend": { "displayMode": "list", "placement": "right" } }
+}
+```
+
+- [ ] **Step 2: Validate JSON and commit**
+
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+
+Expected: `panels: 11` (previous 10 + 1 collapsed Row 3, containing 6 child panels)
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard Row 3 - Channel Health panels"
+```
+
+---
+
+## Task 5: Row 4 — Users & Quota
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Append collapsed Row + 8 panels to the `panels` array
+
+- [ ] **Step 1: Add Row 4 header (collapsed) and 8 child panels**
+
+Row id:25, y:79. Child panels id:26-33.
+
+**Site-wide Quota Usage (Gauge)** id:26, x:0, y:80, w:6, h:6:
+```json
+{
+  "id": 26,
+  "type": "gauge",
+  "title": "Site-wide Quota Usage",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 6, "w": 6, "x": 0, "y": 80 },
+  "targets": [{
+    "expr": "one_api_site_used_quota / one_api_site_total_quota",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "percentunit",
+      "min": 0, "max": 1,
+      "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.6 }, { "color": "red", "value": 0.8 }] }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "showThresholdMarkers": true, "showThresholdLabels": false }
+}
+```
+
+**Site-wide Used Quota** id:27, x:6, y:80, w:6, h:6:
+```json
+{
+  "id": 27,
+  "type": "stat",
+  "title": "Site-wide Used Quota",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 6, "w": 6, "x": 6, "y": 80 },
+  "targets": [
+    { "expr": "one_api_site_used_quota / 500000", "legendFormat": "USD", "refId": "A", "instant": true },
+    { "expr": "one_api_site_used_quota / 500000 * $exchange_rate", "legendFormat": "CNY", "refId": "B", "instant": true }
+  ],
+  "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 2 }, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**Site-wide Total Quota** id:28, x:12, y:80, w:6, h:6:
+```json
+{
+  "id": 28,
+  "type": "stat",
+  "title": "Site-wide Total Quota",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 6, "w": 6, "x": 12, "y": 80 },
+  "targets": [
+    { "expr": "one_api_site_total_quota / 500000", "legendFormat": "USD", "refId": "A", "instant": true },
+    { "expr": "one_api_site_total_quota / 500000 * $exchange_rate", "legendFormat": "CNY", "refId": "B", "instant": true }
+  ],
+  "fieldConfig": { "defaults": { "unit": "currencyUSD", "decimals": 2 }, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**User Group Distribution (Pie Chart)** id:29, x:18, y:80, w:6, h:6:
+```json
+{
+  "id": 29,
+  "type": "piechart",
+  "title": "User Group Distribution",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 6, "w": 6, "x": 18, "y": 80 },
+  "targets": [{
+    "expr": "sum(one_api_user_requests_total) by (group)",
+    "legendFormat": "{{group}}",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": { "defaults": {}, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "legend": { "displayMode": "table", "placement": "right", "values": ["value", "percent"] }, "pieType": "donut" }
+}
+```
+
+**User Request Volume Top10** id:30, x:0, y:86, w:12, h:8:
+```json
+{
+  "id": 30,
+  "type": "barchart",
+  "title": "User Request Volume Top10",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 86 },
+  "targets": [{
+    "expr": "topk(10, sum(one_api_user_requests_total{user_id=~\"$user_id\",group=~\"$group\"}) by (user_id, group))",
+    "legendFormat": "user{{user_id}}({{group}})",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+  "options": { "orientation": "horizontal", "showValue": "always", "legend": { "displayMode": "list", "placement": "right" } }
+}
+```
+
+**User Quota Consumption Top10** id:31, x:12, y:86, w:12, h:8:
+```json
+{
+  "id": 31,
+  "type": "barchart",
+  "title": "User Quota Consumption Top10",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 86 },
+  "targets": [
+    {
+      "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{user_id=~\"$user_id\"}[$__rate_interval])) by (user_id)) / 500000",
+      "legendFormat": "user{{user_id}} (USD)",
+      "refId": "A",
+      "instant": true
+    },
+    {
+      "expr": "topk(10, sum(rate(one_api_billing_quota_processed_total{user_id=~\"$user_id\"}[$__rate_interval])) by (user_id)) / 500000 * $exchange_rate",
+      "legendFormat": "user{{user_id}} (CNY)",
+      "refId": "B",
+      "instant": true
+    }
+  ],
+  "fieldConfig": { "defaults": { "unit": "currencyUSD" }, "overrides": [] },
+  "options": { "orientation": "horizontal", "showValue": "always", "legend": { "displayMode": "list", "placement": "right" } }
+}
+```
+
+**User Request Rate Trend** id:32, x:0, y:94, w:12, h:8:
+```json
+{
+  "id": 32,
+  "type": "timeseries",
+  "title": "User Request Rate Trend",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 94 },
+  "targets": [{
+    "expr": "sum(rate(one_api_user_requests_total{user_id=~\"$user_id\",group=~\"$group\"}[$__rate_interval])) by (user_id, group)",
+    "legendFormat": "user{{user_id}}({{group}})",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "reqps" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**User Token Consumption Trend** id:33, x:12, y:94, w:12, h:8:
+```json
+{
+  "id": 33,
+  "type": "timeseries",
+  "title": "User Token Consumption Trend",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 94 },
+  "targets": [{
+    "expr": "sum(rate(one_api_user_tokens_total{user_id=~\"$user_id\"}[$__rate_interval])) by (user_id, token_type)",
+    "legendFormat": "user{{user_id}}-{{token_type}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal" } }, "unit": "short" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+- [ ] **Step 2: Validate JSON and commit**
+
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); print(f'panels: {len(d[\"panels\"])}')" `
+
+Expected: `panels: 12` (previous 11 + 1 collapsed Row 4, containing 8 child panels)
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard Row 4 - Users & Quota panels"
+```
+
+---
+
+## Task 6: Row 5 — Billing
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Append collapsed Row + 7 panels to the `panels` array
+
+- [ ] **Step 1: Add Row 5 header (collapsed) and 7 child panels**
+
+Row id:34, y:102. Child panels id:35-41.
+
+**Billing Operation Rate** id:35, x:0, y:103, w:12, h:8:
+```json
+{
+  "id": 35,
+  "type": "timeseries",
+  "title": "Billing Operation Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 103 },
+  "targets": [{
+    "expr": "sum(rate(one_api_billing_operations_total[$__rate_interval])) by (operation, success)",
+    "legendFormat": "{{operation}}-{{success}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Billing P95 Latency** id:36, x:12, y:103, w:12, h:8:
+```json
+{
+  "id": 36,
+  "type": "timeseries",
+  "title": "Billing P95 Latency",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 103 },
+  "targets": [{
+    "expr": "histogram_quantile(0.95, sum(rate(one_api_billing_operation_duration_seconds_bucket[$__rate_interval])) by (le, operation))",
+    "legendFormat": "{{operation}} P95",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "s" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Billing Success Rate** id:37, x:0, y:111, w:4, h:4:
+```json
+{
+  "id": 37,
+  "type": "stat",
+  "title": "Billing Success Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 0, "y": 111 },
+  "targets": [{
+    "expr": "sum(rate(one_api_billing_operations_total{success=\"true\"}[$__rate_interval])) / sum(rate(one_api_billing_operations_total[$__rate_interval]))",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "percentunit", "decimals": 2,
+      "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 0.95 }, { "color": "green", "value": 0.99 }] }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**Billing Statistics Overview (3 Stat cards)** id:38-40, x:4/8/12, y:111, w:4, h:4:
+```json
+{
+  "id": 38,
+  "type": "stat",
+  "title": "Total Billing Operations",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 4, "y": 111 },
+  "targets": [{ "expr": "one_api_billing_stats{stat_type=\"total_operations\"}", "refId": "A", "instant": true }],
+  "fieldConfig": { "defaults": { "unit": "short", "noValue": "No data" }, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+```json
+{
+  "id": 39,
+  "type": "stat",
+  "title": "Successful Billing Operations",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 8, "y": 111 },
+  "targets": [{ "expr": "one_api_billing_stats{stat_type=\"successful_operations\"}", "refId": "A", "instant": true }],
+  "fieldConfig": { "defaults": { "unit": "short", "noValue": "No data", "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+```json
+{
+  "id": 40,
+  "type": "stat",
+  "title": "Failed Billing Operations",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 12, "y": 111 },
+  "targets": [{ "expr": "one_api_billing_stats{stat_type=\"failed_operations\"}", "refId": "A", "instant": true }],
+  "fieldConfig": { "defaults": { "unit": "short", "noValue": "No data", "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }] } }, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**Billing Timeouts** id:41, x:16, y:111, w:8, h:4:
+```json
+{
+  "id": 41,
+  "type": "timeseries",
+  "title": "Billing Timeouts",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 8, "x": 16, "y": 111 },
+  "targets": [{
+    "expr": "sum(rate(one_api_billing_timeouts_total[$__rate_interval])) by (model_name)",
+    "legendFormat": "{{model_name}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "short", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**Billing Error Distribution** id:42, x:0, y:115, w:12, h:8:
+```json
+{
+  "id": 42,
+  "type": "timeseries",
+  "title": "Billing Error Distribution",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 115 },
+  "targets": [{
+    "expr": "sum(rate(one_api_billing_errors_total[$__rate_interval])) by (error_type, operation)",
+    "legendFormat": "{{error_type}}-{{operation}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "short", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Quota Processed Amount Trend** id:43, x:12, y:115, w:12, h:8:
+```json
+{
+  "id": 43,
+  "type": "timeseries",
+  "title": "Quota Processed Amount Trend",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 115 },
+  "targets": [
+    {
+      "expr": "sum(rate(one_api_billing_quota_processed_total[$__rate_interval])) by (model_name) / 500000",
+      "legendFormat": "{{model_name}} (USD)",
+      "refId": "A"
+    },
+    {
+      "expr": "sum(rate(one_api_billing_quota_processed_total[$__rate_interval])) by (model_name) / 500000 * $exchange_rate",
+      "legendFormat": "{{model_name}} (CNY)",
+      "refId": "B"
+    }
+  ],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "currencyUSD" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+- [ ] **Step 2: Validate JSON and commit**
+
+Run the validation command then:
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard Row 5 - Billing panels"
+```
+
+---
+
+## Task 7: Row 6 — Infrastructure DB & Redis
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Append collapsed Row + 8 panels to the `panels` array
+
+- [ ] **Step 1: Add Row 6 header (collapsed) and 8 child panels**
+
+Row id:44, y:123. Child panels id:45-52.
+
+**DB Connection Pool** id:45, x:0, y:124, w:12, h:8:
+```json
+{
+  "id": 45,
+  "type": "timeseries",
+  "title": "DB Connection Pool",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 124 },
+  "targets": [
+    { "expr": "one_api_db_connections_in_use", "legendFormat": "In Use", "refId": "A" },
+    { "expr": "one_api_db_connections_idle", "legendFormat": "Idle", "refId": "B" }
+  ],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**DB Query Rate** id:46, x:12, y:124, w:12, h:8:
+```json
+{
+  "id": 46,
+  "type": "timeseries",
+  "title": "DB Query Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 124 },
+  "targets": [{
+    "expr": "sum(rate(one_api_db_queries_total[$__rate_interval])) by (operation, table)",
+    "legendFormat": "{{operation}}-{{table}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**DB Query P95 Latency** id:47, x:0, y:132, w:12, h:8:
+```json
+{
+  "id": 47,
+  "type": "timeseries",
+  "title": "DB Query P95 Latency",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 132 },
+  "targets": [{
+    "expr": "histogram_quantile(0.95, sum(rate(one_api_db_query_duration_seconds_bucket[$__rate_interval])) by (le, table))",
+    "legendFormat": "{{table}} P95",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "s" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**DB Query Failure Rate** id:48, x:12, y:132, w:12, h:8:
+```json
+{
+  "id": 48,
+  "type": "timeseries",
+  "title": "DB Query Failure Rate",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 132 },
+  "targets": [{
+    "expr": "sum(rate(one_api_db_queries_total{success=\"false\"}[$__rate_interval])) by (table)",
+    "legendFormat": "{{table}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**DB Hot Tables Top5** id:49, x:0, y:140, w:24, h:8:
+```json
+{
+  "id": 49,
+  "type": "barchart",
+  "title": "DB Hot Tables Top5",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 24, "x": 0, "y": 140 },
+  "targets": [{
+    "expr": "topk(5, sum(rate(one_api_db_queries_total[$__rate_interval])) by (table))",
+    "legendFormat": "{{table}}",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+  "options": { "orientation": "horizontal", "showValue": "always", "legend": { "displayMode": "list", "placement": "right" } }
+}
+```
+
+**Redis Active Connections** id:50, x:0, y:148, w:8, h:8:
+```json
+{
+  "id": 50,
+  "type": "timeseries",
+  "title": "Redis Active Connections",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 8, "x": 0, "y": 148 },
+  "targets": [{ "expr": "one_api_redis_connections_active", "legendFormat": "Active Connections", "refId": "A" }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "single" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**Redis Command Rate** id:51, x:8, y:148, w:8, h:8:
+```json
+{
+  "id": 51,
+  "type": "timeseries",
+  "title": "Redis Command Rate",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 8, "x": 8, "y": 148 },
+  "targets": [{
+    "expr": "sum(rate(one_api_redis_commands_total[$__rate_interval])) by (command)",
+    "legendFormat": "{{command}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Redis Command P95 Latency** id:52, x:16, y:148, w:8, h:8:
+```json
+{
+  "id": 52,
+  "type": "timeseries",
+  "title": "Redis Command P95 Latency",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 8, "x": 16, "y": 148 },
+  "targets": [{
+    "expr": "histogram_quantile(0.95, sum(rate(one_api_redis_command_duration_seconds_bucket[$__rate_interval])) by (le, command))",
+    "legendFormat": "{{command}} P95",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "s", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+- [ ] **Step 2: Validate JSON and commit**
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard Row 6 - Infrastructure panels"
+```
+
+---
+
+## Task 8: Row 7 — Security & Rate Limiting + Go Runtime
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Append collapsed Row + 10 panels to the `panels` array
+
+- [ ] **Step 1: Add Row 7 header (collapsed) and 10 child panels**
+
+Row id:53, y:156. Child panels id:54-63.
+
+**Auth Success/Failure Trend** id:54, x:0, y:157, w:12, h:8:
+```json
+{
+  "id": 54,
+  "type": "timeseries",
+  "title": "Auth Success/Failure Trend",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 157 },
+  "targets": [{
+    "expr": "sum(rate(one_api_token_auth_attempts_total[$__rate_interval])) by (success)",
+    "legendFormat": "success={{success}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**Auth Failure Rate** id:55, x:12, y:157, w:4, h:4:
+```json
+{
+  "id": 55,
+  "type": "stat",
+  "title": "Auth Failure Rate",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 4, "w": 4, "x": 12, "y": 157 },
+  "targets": [{
+    "expr": "sum(rate(one_api_token_auth_attempts_total{success=\"false\"}[$__rate_interval])) / sum(rate(one_api_token_auth_attempts_total[$__rate_interval]))",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "percentunit", "decimals": 2, "noValue": "No data",
+      "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.01 }, { "color": "red", "value": 0.05 }] }
+    },
+    "overrides": []
+  },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "none" }
+}
+```
+
+**Rate Limit Trigger Rate** id:56, x:16, y:157, w:8, h:8:
+```json
+{
+  "id": 56,
+  "type": "timeseries",
+  "title": "Rate Limit Trigger Rate",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 8, "x": 16, "y": 157 },
+  "targets": [{
+    "expr": "sum(rate(one_api_rate_limit_hits_total[$__rate_interval])) by (type)",
+    "legendFormat": "{{type}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**Error Distribution** id:57, x:0, y:165, w:12, h:8:
+```json
+{
+  "id": 57,
+  "type": "timeseries",
+  "title": "Error Distribution",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 165 },
+  "targets": [{
+    "expr": "sum(rate(one_api_errors_total[$__rate_interval])) by (error_type, component)",
+    "legendFormat": "{{component}}-{{error_type}}",
+    "refId": "A"
+  }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops", "noValue": "No data" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi", "sort": "desc" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } }
+}
+```
+
+**Error Top5 Components** id:58, x:12, y:165, w:12, h:8:
+```json
+{
+  "id": 58,
+  "type": "barchart",
+  "title": "Error Top5 Components",
+  "description": "Reserved: no data available yet",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 165 },
+  "targets": [{
+    "expr": "topk(5, sum(rate(one_api_errors_total[$__rate_interval])) by (component))",
+    "legendFormat": "{{component}}",
+    "refId": "A",
+    "instant": true
+  }],
+  "fieldConfig": { "defaults": { "unit": "ops", "noValue": "No data" }, "overrides": [] },
+  "options": { "orientation": "horizontal", "showValue": "always", "legend": { "displayMode": "list", "placement": "right" } }
+}
+```
+
+**Goroutines** id:59, x:0, y:173, w:8, h:8:
+```json
+{
+  "id": 59,
+  "type": "timeseries",
+  "title": "Goroutines",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 8, "x": 0, "y": 173 },
+  "targets": [{ "expr": "go_goroutines", "legendFormat": "goroutines", "refId": "A" }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "single" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**Heap Memory** id:60, x:8, y:173, w:8, h:8:
+```json
+{
+  "id": 60,
+  "type": "timeseries",
+  "title": "Heap Memory",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 8, "x": 8, "y": 173 },
+  "targets": [
+    { "expr": "go_memstats_heap_inuse_bytes", "legendFormat": "In Use", "refId": "A" },
+    { "expr": "go_memstats_heap_idle_bytes", "legendFormat": "Idle", "refId": "B" }
+  ],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal" } }, "unit": "bytes" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**GC Pause Time** id:61, x:16, y:173, w:8, h:8:
+```json
+{
+  "id": 61,
+  "type": "timeseries",
+  "title": "GC Pause Time",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 8, "x": 16, "y": 173 },
+  "targets": [{ "expr": "rate(go_gc_duration_seconds_sum[$__rate_interval])", "legendFormat": "GC Duration", "refId": "A" }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "s" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "single" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**Process CPU** id:62, x:0, y:181, w:12, h:8:
+```json
+{
+  "id": 62,
+  "type": "timeseries",
+  "title": "Process CPU",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 181 },
+  "targets": [{ "expr": "rate(process_cpu_seconds_total[$__rate_interval])", "legendFormat": "CPU Usage", "refId": "A" }],
+  "fieldConfig": { "defaults": { "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 }, "unit": "percentunit" }, "overrides": [] },
+  "options": { "tooltip": { "mode": "single" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+}
+```
+
+**Process RSS Memory** id:63, x:12, y:181, w:12, h:8:
+```json
+{
+  "id": 63,
+  "type": "stat",
+  "title": "Process RSS Memory",
+  "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+  "gridPos": { "h": 8, "w": 12, "x": 12, "y": 181 },
+  "targets": [{ "expr": "process_resident_memory_bytes", "refId": "A", "instant": true }],
+  "fieldConfig": { "defaults": { "unit": "bytes", "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+  "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "value", "graphMode": "area" }
+}
+```
+
+- [ ] **Step 2: Validate JSON and commit**
+
+Run: `python3 -c "import json; d=json.load(open('docs/grafana-dashboard.json')); total=len(d['panels']); collapsed=[p for p in d['panels'] if p.get('collapsed')]; inner=sum(len(p.get('panels',[])) for p in collapsed); print(f'top-level: {total}, collapsed inner: {inner}, total panels: {total+inner}')" `
+
+Expected: `top-level: 16, collapsed inner: 49, total panels: 65` (16 = 1 Row (expanded) + 8 panels + 6 collapsed Rows + 1 expanded panel... exact number depends on structure, the key point is JSON parses successfully and panels are not empty)
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: add Grafana dashboard Row 7 - Security & Go Runtime panels"
+```
+
+---
+
+## Task 9: Final Validation and Cleanup
+
+**Files:**
+- Modify: `docs/grafana-dashboard.json` — Final check
+
+- [ ] **Step 1: Validate complete JSON structure**
+
+```bash
+python3 -c "
+import json
+with open('docs/grafana-dashboard.json') as f:
+    d = json.load(f)
+print(f'Title: {d[\"title\"]}')
+print(f'Variables: {len(d[\"templating\"][\"list\"])}')
+top = d['panels']
+print(f'Top-level panels: {len(top)}')
+rows = [p for p in top if p['type'] == 'row']
+print(f'Rows: {len(rows)}')
+collapsed = [r for r in rows if r.get('collapsed')]
+inner = sum(len(r.get('panels', [])) for r in collapsed)
+non_row_top = len([p for p in top if p['type'] != 'row'])
+print(f'Non-row top panels: {non_row_top}')
+print(f'Collapsed inner panels: {inner}')
+print(f'Total panels (excl rows): {non_row_top + inner}')
+ids = []
+for p in top:
+    ids.append(p['id'])
+    for sub in p.get('panels', []):
+        ids.append(sub['id'])
+print(f'Unique IDs: {len(set(ids))}, duplicates: {len(ids) - len(set(ids))}')
+"
+```
+
+Expected:
+- Title: One API Dashboard
+- Variables: 7
+- Rows: 7
+- Total panels (excl rows): ~54
+- duplicates: 0
+
+- [ ] **Step 2: Format JSON**
+
+```bash
+python3 -c "
+import json
+with open('docs/grafana-dashboard.json') as f:
+    d = json.load(f)
+with open('docs/grafana-dashboard.json', 'w') as f:
+    json.dump(d, f, indent=2, ensure_ascii=False)
+"
+```
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add docs/grafana-dashboard.json
+git commit -m "feat: complete One API Grafana dashboard with 7 rows and 54 panels
+
+Includes:
+- Overview with key stats and HTTP request trends
+- Relay request metrics (QPS, latency, tokens, quota)
+- Channel health monitoring
+- User & quota tracking with currency conversion (USD/CNY)
+- Billing operation metrics
+- DB & Redis infrastructure panels
+- Security, rate limiting & Go runtime panels
+
+Refs: docs/superpowers/specs/2026-04-01-grafana-dashboard-design.md"
+```

--- a/docs/superpowers/specs/2026-04-01-grafana-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-01-grafana-dashboard-design.md
@@ -1,0 +1,204 @@
+# One API Grafana Dashboard Design Document
+
+## Overview
+
+A single Grafana Dashboard containing 7 collapsible Row sections, covering both Ops/SRE and platform management perspectives. All `one_api_*` Prometheus metrics are mapped to panels. Panels marked as "reserved" currently have no production data, but are pre-configured with PromQL and will automatically display data when it becomes available.
+
+**Data source**: Prometheus, scraping `GET /metrics` (requires AdminAuth session authentication).
+
+---
+
+## Top-level Variables
+
+| Variable | Type | Query / Values | Default | Multi/All |
+|------|------|-------------|--------|-----------|
+| `$channel_id` | Query | `label_values(one_api_relay_requests_total, channel_id)` | All | Yes |
+| `$channel_type` | Query | `label_values(one_api_relay_requests_total, channel_type)` | All | Yes |
+| `$model` | Query | `label_values(one_api_relay_requests_total, model)` | All | Yes |
+| `$username` | Query | `label_values(one_api_user_requests_total, username)` | All | Yes |
+| `$group` | Query | `label_values(one_api_user_requests_total, group)` | All | Yes |
+| `$currency` | Custom | `USD,CNY` | USD | No |
+| `$exchange_rate` | Textbox | - | 8 | No |
+
+### Currency Conversion
+
+All monetary panels use the following formula:
+
+```
+quota_value / 500000 * (1 + ($currency == "CNY") * ($exchange_rate - 1))
+```
+
+- `500000` = `QuotaPerUnit` (hardcoded in `common/config/config.go:1132`)
+- When `$currency = USD`: display `$` symbol
+- When `$currency = CNY`: multiply by `$exchange_rate` (default 8), display `¥` symbol
+
+---
+
+## Row 1: Overview (expanded by default)
+
+### Stat Cards (top row, 6 cards)
+
+| Panel | PromQL | Unit / Thresholds |
+|------|--------|-------------|
+| System Uptime | `time() - one_api_system_start_time_seconds` | Duration (s) |
+| Total Request Rate | `sum(rate(one_api_http_requests_total[$__rate_interval]))` | req/s |
+| Relay Success Rate | `sum(rate(one_api_relay_requests_total{success="true"}[$__rate_interval])) / sum(rate(one_api_relay_requests_total[$__rate_interval]))` | Percentage; green >99%, yellow >95%, red <=95% |
+| Active Users | `one_api_site_active_users` | Count |
+| Site-wide Quota Usage | `one_api_site_used_quota / one_api_site_total_quota` | Percentage + progress bar; green <60%, yellow <80%, red >=80% |
+| Auth Failure Rate | `sum(rate(one_api_token_auth_attempts_total{success="false"}[$__rate_interval])) / sum(rate(one_api_token_auth_attempts_total[$__rate_interval]))` | Percentage; green <1%, yellow <5%, red >=5% (reserved) |
+
+### Time Series (bottom row, 2 charts)
+
+| Panel | PromQL | Legend |
+|------|--------|------|
+| HTTP Request Rate (by status code) | `sum(rate(one_api_http_requests_total[$__rate_interval])) by (status_code)` | `{{status_code}}` |
+| Error Overview | `sum(rate(one_api_errors_total[$__rate_interval])) by (component)` | `{{component}}` (reserved) |
+
+---
+
+## Row 2: Relay Requests (collapsed)
+
+| Panel | Type | PromQL | Legend / Description |
+|------|------|--------|-------------|
+| Relay QPS | Time series | `sum(rate(one_api_relay_requests_total{channel_id=~"$channel_id",model=~"$model",username=~"$username"}[$__rate_interval])) by (model)` | `{{model}}` |
+| Relay Success Rate | Time series | `sum(rate(one_api_relay_requests_total{...,success="true"}[$__rate_interval])) by (model) / sum(rate(one_api_relay_requests_total{...}[$__rate_interval])) by (model)` | `{{model}}` |
+| Relay Latency P50/P95/P99 | Time series | `histogram_quantile(0.5/0.95/0.99, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~"$channel_id",model=~"$model"}[$__rate_interval])) by (le, model))` | `{{model}} p50/p95/p99` |
+| Token Consumption Rate | Time series | `sum(rate(one_api_relay_tokens_total{channel_id=~"$channel_id",model=~"$model"}[$__rate_interval])) by (model, token_type)` | `{{model}}-{{token_type}}` |
+| Quota Consumption Rate | Time series | `sum(rate(one_api_relay_quota_used_total{channel_id=~"$channel_id",model=~"$model"}[$__rate_interval])) by (model) / 500000 * currency_multiplier` | `{{model}}`, unit=$currency |
+| Request Distribution (by channel type) | Pie chart | `sum(one_api_relay_requests_total{channel_id=~"$channel_id"}) by (channel_type)` | `{{channel_type}}` |
+| Request Distribution (by API format) | Pie chart | `sum(one_api_relay_requests_total{channel_id=~"$channel_id"}) by (api_format)` | `{{api_format}}` |
+
+---
+
+## Row 3: Channel Health (collapsed)
+
+| Panel | Type | PromQL | Description |
+|------|------|--------|------|
+| Channel Status Table | Table | `one_api_channel_status` | Columns: channel_id, channel_name, channel_type, status. Colors: green=1 (enabled), red=0 (disabled), yellow=-1 (auto-disabled). (reserved) |
+| Channel In-flight Requests | Time series | `one_api_channel_requests_in_flight{channel_id=~"$channel_id"}` | `{{channel_id}}-{{channel_type}}` |
+| Channel Response Time | Time series | `one_api_channel_response_time_ms{channel_id=~"$channel_id"}` | Milliseconds (reserved) |
+| Channel Success Rate | Time series | `one_api_channel_success_rate{channel_id=~"$channel_id"}` | 0-1 (reserved) |
+| Channel Balance | Stat (repeated by channel_id) | `one_api_channel_balance_usd{channel_id=~"$channel_id"} * currency_multiplier` | Unit=$currency (reserved) |
+| Channel Request Volume TopK | Bar chart | `topk(10, sum(rate(one_api_relay_requests_total{channel_id=~"$channel_id"}[$__rate_interval])) by (channel_id, channel_type))` | `{{channel_id}}-{{channel_type}}` |
+
+---
+
+## Row 4: Users & Quota (collapsed)
+
+| Panel | Type | PromQL | Description |
+|------|------|--------|------|
+| Site-wide Quota Usage | Gauge | `one_api_site_used_quota / one_api_site_total_quota` | Green <60%, yellow <80%, red >=80% |
+| Site-wide Used Quota | Stat | `one_api_site_used_quota / 500000 * currency_multiplier` | Unit=$currency |
+| Site-wide Total Quota | Stat | `one_api_site_total_quota / 500000 * currency_multiplier` | Unit=$currency |
+| User Request Volume Top10 | Bar chart | `topk(10, sum(one_api_user_requests_total{username=~"$username",group=~"$group"}) by (username, group))` | `{{username}}({{group}})` |
+| User Quota Consumption Top10 | Bar chart | `topk(10, sum(rate(one_api_billing_quota_processed_total{username=~"$username"}[$__rate_interval])) by (username)) / 500000 * currency_multiplier` | Unit=$currency |
+| User Request Rate Trend | Time series | `sum(rate(one_api_user_requests_total{username=~"$username",group=~"$group"}[$__rate_interval])) by (username, group)` | `{{username}}({{group}})` |
+| User Token Consumption Trend | Time series | `sum(rate(one_api_user_tokens_total{username=~"$username"}[$__rate_interval])) by (username, token_type)` | `{{username}}-{{token_type}}` |
+| User Group Distribution | Pie chart | `sum(one_api_user_requests_total) by (group)` | default vs vip |
+
+---
+
+## Row 5: Billing (collapsed)
+
+| Panel | Type | PromQL | Description |
+|------|------|--------|------|
+| Billing Operation Rate | Time series | `sum(rate(one_api_billing_operations_total[$__rate_interval])) by (operation, success)` | `{{operation}}-{{success}}` |
+| Billing P95 Latency | Time series | `histogram_quantile(0.95, sum(rate(one_api_billing_operation_duration_seconds_bucket[$__rate_interval])) by (le, operation))` | `{{operation}}` |
+| Billing Success Rate | Stat | `sum(rate(one_api_billing_operations_total{success="true"}[$__rate_interval])) / sum(rate(one_api_billing_operations_total[$__rate_interval]))` | Green >99%, yellow >95%, red <=95% |
+| Billing Timeout Count | Time series | `sum(rate(one_api_billing_timeouts_total[$__rate_interval])) by (model_name)` | `{{model_name}}` (reserved) |
+| Billing Error Distribution | Time series | `sum(rate(one_api_billing_errors_total[$__rate_interval])) by (error_type, operation)` | `{{error_type}}-{{operation}}` (reserved) |
+| Billing Stats Overview | Stat (3 cards) | `one_api_billing_stats{stat_type="total_operations"}` / `successful_operations` / `failed_operations` | (reserved) |
+| Quota Processed Amount Trend | Time series | `sum(rate(one_api_billing_quota_processed_total[$__rate_interval])) by (model_name) / 500000 * currency_multiplier` | `{{model_name}}`, unit=$currency |
+
+---
+
+## Row 6: Infrastructure - DB & Redis (collapsed)
+
+| Panel | Type | PromQL | Description |
+|------|------|--------|------|
+| DB Connection Pool | Time series | `one_api_db_connections_in_use` and `one_api_db_connections_idle` | Two lines: in-use, idle |
+| DB Query Rate | Time series | `sum(rate(one_api_db_queries_total[$__rate_interval])) by (operation, table)` | `{{operation}}-{{table}}` |
+| DB Query P95 Latency | Time series | `histogram_quantile(0.95, sum(rate(one_api_db_query_duration_seconds_bucket[$__rate_interval])) by (le, table))` | `{{table}}` |
+| DB Query Failure Rate | Time series | `sum(rate(one_api_db_queries_total{success="false"}[$__rate_interval])) by (table)` | `{{table}}` |
+| DB Hot Tables Top5 | Bar chart | `topk(5, sum(rate(one_api_db_queries_total[$__rate_interval])) by (table))` | `{{table}}` |
+| Redis Active Connections | Time series | `one_api_redis_connections_active` | Single line |
+| Redis Command Rate | Time series | `sum(rate(one_api_redis_commands_total[$__rate_interval])) by (command)` | `{{command}}` (reserved) |
+| Redis Command P95 Latency | Time series | `histogram_quantile(0.95, sum(rate(one_api_redis_command_duration_seconds_bucket[$__rate_interval])) by (le, command))` | `{{command}}` (reserved) |
+
+---
+
+## Row 7: Security & Rate Limiting + Go Runtime (collapsed)
+
+### Security & Rate Limiting
+
+| Panel | Type | PromQL | Description |
+|------|------|--------|------|
+| Auth Success/Failure Trend | Time series | `sum(rate(one_api_token_auth_attempts_total[$__rate_interval])) by (success)` | (reserved) |
+| Auth Failure Rate | Stat | `sum(rate(one_api_token_auth_attempts_total{success="false"}[$__rate_interval])) / sum(rate(one_api_token_auth_attempts_total[$__rate_interval]))` | Green <1%, yellow <5%, red >=5% (reserved) |
+| Rate Limit Trigger Rate | Time series | `sum(rate(one_api_rate_limit_hits_total[$__rate_interval])) by (type)` | `{{type}}` (reserved) |
+| Error Distribution | Time series | `sum(rate(one_api_errors_total[$__rate_interval])) by (error_type, component)` | `{{component}}-{{error_type}}` (reserved) |
+| Error Top5 Components | Bar chart | `topk(5, sum(rate(one_api_errors_total[$__rate_interval])) by (component))` | `{{component}}` (reserved) |
+
+### Go Runtime
+
+| Panel | Type | PromQL | Description |
+|------|------|--------|------|
+| Goroutines | Time series | `go_goroutines` | Count |
+| Heap Memory | Time series | `go_memstats_heap_inuse_bytes` and `go_memstats_heap_idle_bytes` | Bytes (auto) |
+| GC Pause Time | Time series | `rate(go_gc_duration_seconds_sum[$__rate_interval])` | Seconds |
+| Process CPU | Time series | `rate(process_cpu_seconds_total[$__rate_interval])` | Ratio (0-1) |
+| Process RSS Memory | Stat | `process_resident_memory_bytes` | Bytes (auto) |
+
+---
+
+## Panel Count Summary
+
+| Row | Panel Count |
+|-----|--------|
+| 1. Overview | 8 |
+| 2. Relay Requests | 7 |
+| 3. Channel Health | 6 |
+| 4. Users & Quota | 8 |
+| 5. Billing | 7 |
+| 6. Infrastructure DB+Redis | 8 |
+| 7. Security & Rate Limiting + Go Runtime | 10 |
+| **Total** | **54** |
+
+---
+
+## Production Data Status
+
+Metrics with actual production data (confirmed from `https://one-api.xxx.com/metrics`):
+
+- `one_api_http_requests_total`, `one_api_http_active_requests`, `one_api_http_request_duration_seconds`
+- `one_api_relay_requests_total`, `one_api_relay_request_duration_seconds`
+- `one_api_billing_operations_total`, `one_api_billing_operation_duration_seconds`, `one_api_billing_quota_processed_total`
+- `one_api_channel_requests_in_flight` (3 channels: 1=openaicompatible, 2=openaicompatible, 3=alibailian)
+- `one_api_model_usage_total`, `one_api_model_latency_seconds` (qwen3.5-plus, MiniMax-M2, Qwen3-30B-A3B)
+- `one_api_user_requests_total`, `one_api_user_tokens_total`, `one_api_user_balance`
+- `one_api_db_queries_total`, `one_api_db_query_duration_seconds`, `one_api_db_connections_*`
+- `one_api_site_*` (active_users=87, total_users=87)
+- `one_api_system_info`, `one_api_system_start_time_seconds`
+- `one_api_redis_connections_active`
+- `go_*`, `process_*`
+
+Reserved metrics (currently no data):
+
+- `one_api_channel_status`, `one_api_channel_balance_usd`, `one_api_channel_response_time_ms`, `one_api_channel_success_rate`
+- `one_api_relay_tokens_total`, `one_api_relay_quota_used_total`
+- `one_api_token_auth_attempts_total`, `one_api_active_tokens`
+- `one_api_rate_limit_hits_total`, `one_api_rate_limit_remaining`
+- `one_api_errors_total`
+- `one_api_billing_timeouts_total`, `one_api_billing_errors_total`, `one_api_billing_stats`
+- `one_api_redis_commands_total`, `one_api_redis_command_duration_seconds`
+- `one_api_user_quota_used_total`
+
+---
+
+## Implementation Notes
+
+- Dashboard JSON will be saved to `docs/grafana-dashboard.json` (replacing the file referenced in documentation but actually missing)
+- Target Grafana version: 10.x+
+- All panels use `$__rate_interval` for rate calculations (Grafana best practice)
+- Reserved panels display a "No data" message rather than being hidden; they will automatically display when data becomes available
+- `$username` variable note: panels use `username` as the user identifier; the TokenAuth middleware has been updated to set the username

--- a/docs/superpowers/specs/2026-04-01-grafana-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-01-grafana-dashboard-design.md
@@ -4,7 +4,7 @@
 
 A single Grafana Dashboard containing 7 collapsible Row sections, covering both Ops/SRE and platform management perspectives. All `one_api_*` Prometheus metrics are mapped to panels. Panels marked as "reserved" currently have no production data, but are pre-configured with PromQL and will automatically display data when it becomes available.
 
-**Data source**: Prometheus, scraping `GET /metrics` (requires AdminAuth session authentication).
+**Data source**: Prometheus, scraping `GET /metrics` (requires Bearer token authentication via `METRICS_TOKEN`).
 
 ---
 
@@ -24,7 +24,7 @@ A single Grafana Dashboard containing 7 collapsible Row sections, covering both 
 
 All monetary panels use the following formula:
 
-```
+```text
 quota_value / 500000 * (1 + ($currency == "CNY") * ($exchange_rate - 1))
 ```
 
@@ -60,7 +60,7 @@ quota_value / 500000 * (1 + ($currency == "CNY") * ($exchange_rate - 1))
 
 | Panel | Type | PromQL | Legend / Description |
 |------|------|--------|-------------|
-| Relay QPS | Time series | `sum(rate(one_api_relay_requests_total{channel_id=~"$channel_id",model=~"$model",username=~"$username"}[$__rate_interval])) by (model)` | `{{model}}` |
+| Relay QPS | Time series | `sum(rate(one_api_relay_requests_total{channel_id=~"$channel_id",model=~"$model"}[$__rate_interval])) by (model)` | `{{model}}` |
 | Relay Success Rate | Time series | `sum(rate(one_api_relay_requests_total{...,success="true"}[$__rate_interval])) by (model) / sum(rate(one_api_relay_requests_total{...}[$__rate_interval])) by (model)` | `{{model}}` |
 | Relay Latency P50/P95/P99 | Time series | `histogram_quantile(0.5/0.95/0.99, sum(rate(one_api_relay_request_duration_seconds_bucket{channel_id=~"$channel_id",model=~"$model"}[$__rate_interval])) by (le, model))` | `{{model}} p50/p95/p99` |
 | Token Consumption Rate | Time series | `sum(rate(one_api_relay_tokens_total{channel_id=~"$channel_id",model=~"$model"}[$__rate_interval])) by (model, token_type)` | `{{model}}-{{token_type}}` |

--- a/docs/superpowers/specs/2026-04-02-metrics-token-auth-design.md
+++ b/docs/superpowers/specs/2026-04-02-metrics-token-auth-design.md
@@ -4,7 +4,7 @@
 
 Protect the `/metrics` Prometheus endpoint with a dedicated Bearer token to prevent unauthorized access to sensitive system telemetry data (usernames, model names, channel IDs, quota data, system internals).
 
-## Current State
+## Previous State
 
 - `/metrics` is registered without any auth middleware (`main.go:217`)
 - Enabled by default via `ENABLE_PROMETHEUS_METRICS=true`
@@ -26,7 +26,7 @@ Protect the `/metrics` Prometheus endpoint with a dedicated Bearer token to prev
 
 New function in `middleware/prometheus.go`:
 
-```
+```go
 MetricsAuth() gin.HandlerFunc
 ```
 

--- a/docs/superpowers/specs/2026-04-02-metrics-token-auth-design.md
+++ b/docs/superpowers/specs/2026-04-02-metrics-token-auth-design.md
@@ -6,9 +6,9 @@ Protect the `/metrics` Prometheus endpoint with a dedicated Bearer token to prev
 
 ## Previous State
 
-- `/metrics` is registered without any auth middleware (`main.go:217`)
+- `/metrics` was registered with `middleware.AdminAuth()` session authentication (`main.go:217`), which required admin login via browser — unsuitable for Prometheus scraping
 - Enabled by default via `ENABLE_PROMETHEUS_METRICS=true`
-- Exposes all `one_api_*` metrics plus Go runtime metrics to anyone who can reach the endpoint
+- Exposes all `one_api_*` metrics plus Go runtime metrics
 
 ## Design
 

--- a/docs/superpowers/specs/2026-04-02-metrics-token-auth-design.md
+++ b/docs/superpowers/specs/2026-04-02-metrics-token-auth-design.md
@@ -1,0 +1,103 @@
+# Metrics Endpoint Token Authentication Design
+
+## Overview
+
+Protect the `/metrics` Prometheus endpoint with a dedicated Bearer token to prevent unauthorized access to sensitive system telemetry data (usernames, model names, channel IDs, quota data, system internals).
+
+## Current State
+
+- `/metrics` is registered without any auth middleware (`main.go:217`)
+- Enabled by default via `ENABLE_PROMETHEUS_METRICS=true`
+- Exposes all `one_api_*` metrics plus Go runtime metrics to anyone who can reach the endpoint
+
+## Design
+
+### Configuration
+
+| Variable | Location | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `METRICS_TOKEN` | Environment variable | `string` | `""` (empty) | Bearer token for `/metrics` authentication |
+
+- Read at startup in `common/config/config.go` via `env.String()`
+- Not stored in DB — consistent with other security credentials like `SESSION_SECRET`
+- Not hot-reloadable — requires restart to change (matches Prometheus scrape config lifecycle)
+
+### Middleware: `MetricsAuth()`
+
+New function in `middleware/prometheus.go`:
+
+```
+MetricsAuth() gin.HandlerFunc
+```
+
+Logic:
+
+1. If `config.MetricsToken` is empty (not configured):
+   - Return `403` with `{"error": "metrics endpoint requires METRICS_TOKEN configuration"}`
+   - This is the default — metrics are blocked until explicitly configured
+2. Extract token from `Authorization: Bearer <token>` header:
+   - If header is missing or malformed → `401` with `{"error": "invalid metrics token, please check your METRICS_TOKEN configuration"}`
+   - If token does not match `config.MetricsToken` → `401` with same message
+   - Use constant-time comparison (`subtle.ConstantTimeCompare`) to prevent timing attacks
+3. Token matches → `c.Next()`
+
+### Route Registration
+
+Change in `main.go`:
+
+```go
+// Before
+server.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
+// After
+server.GET("/metrics", middleware.MetricsAuth(), gin.WrapH(promhttp.Handler()))
+```
+
+### Prometheus Scrape Configuration
+
+Example for `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'one-api'
+    bearer_token: '<your-metrics-token>'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['one-api:3000']
+```
+
+Or using a file-based token (recommended for production):
+
+```yaml
+scrape_configs:
+  - job_name: 'one-api'
+    bearer_token_file: /etc/prometheus/one-api-token
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['one-api:3000']
+```
+
+### Docker Compose Example
+
+```yaml
+services:
+  oneapi:
+    environment:
+      - METRICS_TOKEN=your-secure-token-here
+```
+
+## Out of Scope
+
+- IP whitelist — can be layered on later if needed
+- Rate limiting on `/metrics` — Prometheus scrape interval is fixed
+- Modifications to existing `TokenAuth` / `AdminAuth` middleware
+- Token rotation without restart — keep it simple
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `common/config/config.go` | Add `MetricsToken` variable, read from `METRICS_TOKEN` env |
+| `middleware/prometheus.go` | Add `MetricsAuth()` function |
+| `main.go` | Add `middleware.MetricsAuth()` to `/metrics` route |
+| `docs/manuals/PROMETHEUS.md` | Add Bearer token auth configuration examples |

--- a/main.go
+++ b/main.go
@@ -214,7 +214,7 @@ func main() {
 
 	// Add Prometheus metrics endpoint if enabled
 	if config.EnablePrometheusMetrics {
-		server.GET("/metrics", middleware.AdminAuth(), gin.WrapH(promhttp.Handler()))
+		server.GET("/metrics", middleware.MetricsAuth(), gin.WrapH(promhttp.Handler()))
 		logger.Logger.Info("Prometheus metrics endpoint available at /metrics")
 	}
 

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Laisky/errors/v2"
 	gmw "github.com/Laisky/gin-middlewares/v7"
+	"github.com/Laisky/zap"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 
@@ -236,7 +237,12 @@ func TokenAuth() func(c *gin.Context) {
 
 		// Set token-related context for downstream handlers
 		c.Set(ctxkey.Id, token.UserId)
-		c.Set(ctxkey.Username, model.GetUsernameById(token.UserId))
+		username, err := model.CacheGetUsername(c.Request.Context(), token.UserId)
+		if err != nil {
+			gmw.GetLogger(c).Warn("failed to get username, using empty string", zap.Error(err))
+			username = ""
+		}
+		c.Set(ctxkey.Username, username)
 		c.Set(ctxkey.TokenId, token.Id)
 		c.Set(ctxkey.TokenName, token.Name)
 		c.Set(ctxkey.TokenQuota, token.RemainQuota)

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/Laisky/errors/v2"
 	gmw "github.com/Laisky/gin-middlewares/v7"
-	"github.com/Laisky/zap"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 
@@ -237,12 +236,7 @@ func TokenAuth() func(c *gin.Context) {
 
 		// Set token-related context for downstream handlers
 		c.Set(ctxkey.Id, token.UserId)
-		username, err := model.CacheGetUsername(c.Request.Context(), token.UserId)
-		if err != nil {
-			gmw.GetLogger(c).Warn("failed to get username, using empty string", zap.Error(err))
-			username = ""
-		}
-		c.Set(ctxkey.Username, username)
+		c.Set(ctxkey.Username, model.CacheGetUsername(c.Request.Context(), token.UserId))
 		c.Set(ctxkey.TokenId, token.Id)
 		c.Set(ctxkey.TokenName, token.Name)
 		c.Set(ctxkey.TokenQuota, token.RemainQuota)

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -236,6 +236,7 @@ func TokenAuth() func(c *gin.Context) {
 
 		// Set token-related context for downstream handlers
 		c.Set(ctxkey.Id, token.UserId)
+		c.Set(ctxkey.Username, model.GetUsernameById(token.UserId))
 		c.Set(ctxkey.TokenId, token.Id)
 		c.Set(ctxkey.TokenName, token.Name)
 		c.Set(ctxkey.TokenQuota, token.RemainQuota)

--- a/middleware/prometheus.go
+++ b/middleware/prometheus.go
@@ -1,14 +1,52 @@
 package middleware
 
 import (
+	"crypto/subtle"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/metrics"
 )
+
+// MetricsAuth protects the /metrics endpoint with a dedicated Bearer token.
+// Returns 403 if METRICS_TOKEN is not configured, 401 if the token is invalid.
+func MetricsAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token := config.MetricsToken
+		if token == "" {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "metrics endpoint requires METRICS_TOKEN configuration",
+			})
+			c.Abort()
+			return
+		}
+
+		authHeader := c.GetHeader("Authorization")
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "invalid metrics token, please check your METRICS_TOKEN configuration",
+			})
+			c.Abort()
+			return
+		}
+
+		provided := strings.TrimPrefix(authHeader, "Bearer ")
+		if subtle.ConstantTimeCompare([]byte(provided), []byte(token)) != 1 {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "invalid metrics token, please check your METRICS_TOKEN configuration",
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
 
 // PrometheusMiddleware instruments HTTP endpoints with Prometheus metrics
 func PrometheusMiddleware() gin.HandlerFunc {

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
 
 	"github.com/songquanpeng/one-api/common/config"
 )
 
+// TestMetricsAuth verifies that the MetricsAuth middleware correctly enforces
+// Bearer token authentication on the /metrics endpoint across all branches.
 func TestMetricsAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -71,12 +74,8 @@ func TestMetricsAuth(t *testing.T) {
 			w := httptest.NewRecorder()
 			r.ServeHTTP(w, req)
 
-			if w.Code != tt.expectedStatus {
-				t.Errorf("expected status %d, got %d", tt.expectedStatus, w.Code)
-			}
-			if nextCalled != tt.expectNext {
-				t.Errorf("expected next handler called=%v, got %v", tt.expectNext, nextCalled)
-			}
+			require.Equal(t, tt.expectedStatus, w.Code, "unexpected status code")
+			require.Equal(t, tt.expectNext, nextCalled, "unexpected next-handler invocation")
 		})
 	}
 }

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/songquanpeng/one-api/common/config"
+)
+
+func TestMetricsAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		metricsToken   string
+		authHeader     string
+		expectedStatus int
+		expectNext     bool
+	}{
+		{
+			name:           "empty MetricsToken returns 403",
+			metricsToken:   "",
+			authHeader:     "",
+			expectedStatus: http.StatusForbidden,
+			expectNext:     false,
+		},
+		{
+			name:           "no Authorization header returns 401",
+			metricsToken:   "secret-token",
+			authHeader:     "",
+			expectedStatus: http.StatusUnauthorized,
+			expectNext:     false,
+		},
+		{
+			name:           "wrong token returns 401",
+			metricsToken:   "secret-token",
+			authHeader:     "Bearer wrong-token",
+			expectedStatus: http.StatusUnauthorized,
+			expectNext:     false,
+		},
+		{
+			name:           "correct Bearer token returns 200",
+			metricsToken:   "secret-token",
+			authHeader:     "Bearer secret-token",
+			expectedStatus: http.StatusOK,
+			expectNext:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore MetricsToken
+			originalToken := config.MetricsToken
+			config.MetricsToken = tt.metricsToken
+			defer func() { config.MetricsToken = originalToken }()
+
+			nextCalled := false
+			r := gin.New()
+			r.GET("/metrics", MetricsAuth(), func(c *gin.Context) {
+				nextCalled = true
+				c.Status(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+			if nextCalled != tt.expectNext {
+				t.Errorf("expected next handler called=%v, got %v", tt.expectNext, nextCalled)
+			}
+		})
+	}
+}

--- a/model/cache.go
+++ b/model/cache.go
@@ -97,6 +97,9 @@ func CacheGetUserGroup(ctx context.Context, id int) (group string, err error) {
 	return group, nil
 }
 
+// CacheGetUsername retrieves a username by user ID, using Redis cache when available.
+// On cache miss it falls back to GetUsernameById and populates the cache.
+// Empty usernames (non-existent users) are not cached to allow retry on the next request.
 func CacheGetUsername(ctx context.Context, id int) (username string, err error) {
 	lg := logger.FromContext(ctx)
 	if !common.IsRedisEnabled() {
@@ -105,9 +108,11 @@ func CacheGetUsername(ctx context.Context, id int) (username string, err error) 
 	username, err = common.RedisGet(ctx, fmt.Sprintf("user_username:%d", id))
 	if err != nil {
 		username = GetUsernameById(id)
-		err = common.RedisSet(ctx, fmt.Sprintf("user_username:%d", id), username, time.Duration(UserId2GroupCacheSeconds)*time.Second)
-		if err != nil {
-			lg.Warn("Redis set username failed, continuing without cache", zap.Int("user_id", id), zap.Error(err))
+		if username == "" {
+			return username, nil
+		}
+		if setErr := common.RedisSet(ctx, fmt.Sprintf("user_username:%d", id), username, time.Duration(UserId2GroupCacheSeconds)*time.Second); setErr != nil {
+			lg.Warn("Redis set username failed, continuing without cache", zap.Int("user_id", id), zap.Error(setErr))
 		}
 	}
 	return username, nil

--- a/model/cache.go
+++ b/model/cache.go
@@ -97,6 +97,22 @@ func CacheGetUserGroup(ctx context.Context, id int) (group string, err error) {
 	return group, nil
 }
 
+func CacheGetUsername(ctx context.Context, id int) (username string, err error) {
+	lg := logger.FromContext(ctx)
+	if !common.IsRedisEnabled() {
+		return GetUsernameById(id), nil
+	}
+	username, err = common.RedisGet(ctx, fmt.Sprintf("user_username:%d", id))
+	if err != nil {
+		username = GetUsernameById(id)
+		err = common.RedisSet(ctx, fmt.Sprintf("user_username:%d", id), username, time.Duration(UserId2GroupCacheSeconds)*time.Second)
+		if err != nil {
+			lg.Warn("Redis set username failed, continuing without cache", zap.Int("user_id", id), zap.Error(err))
+		}
+	}
+	return username, nil
+}
+
 func fetchAndUpdateUserQuota(ctx context.Context, id int) (quota int64, err error) {
 	lg := logger.FromContext(ctx)
 	quota, err = GetUserQuota(id)

--- a/model/cache.go
+++ b/model/cache.go
@@ -23,9 +23,10 @@ import (
 
 var (
 	TokenCacheSeconds         = config.SyncFrequency
-	UserId2GroupCacheSeconds  = config.SyncFrequency
-	UserId2QuotaCacheSeconds  = config.SyncFrequency
-	UserId2StatusCacheSeconds = config.SyncFrequency
+	UserId2GroupCacheSeconds    = config.SyncFrequency
+	UserId2QuotaCacheSeconds   = config.SyncFrequency
+	UserId2StatusCacheSeconds  = config.SyncFrequency
+	UserId2UsernameCacheSeconds = config.SyncFrequency
 	GroupModelsCacheSeconds   = config.SyncFrequency
 )
 
@@ -100,22 +101,22 @@ func CacheGetUserGroup(ctx context.Context, id int) (group string, err error) {
 // CacheGetUsername retrieves a username by user ID, using Redis cache when available.
 // On cache miss it falls back to GetUsernameById and populates the cache.
 // Empty usernames (non-existent users) are not cached to allow retry on the next request.
-func CacheGetUsername(ctx context.Context, id int) (username string, err error) {
+func CacheGetUsername(ctx context.Context, id int) string {
 	lg := logger.FromContext(ctx)
 	if !common.IsRedisEnabled() {
-		return GetUsernameById(id), nil
+		return GetUsernameById(id)
 	}
-	username, err = common.RedisGet(ctx, fmt.Sprintf("user_username:%d", id))
+	username, err := common.RedisGet(ctx, fmt.Sprintf("user_username:%d", id))
 	if err != nil {
 		username = GetUsernameById(id)
 		if username == "" {
-			return username, nil
+			return username
 		}
-		if setErr := common.RedisSet(ctx, fmt.Sprintf("user_username:%d", id), username, time.Duration(UserId2GroupCacheSeconds)*time.Second); setErr != nil {
+		if setErr := common.RedisSet(ctx, fmt.Sprintf("user_username:%d", id), username, time.Duration(UserId2UsernameCacheSeconds)*time.Second); setErr != nil {
 			lg.Warn("Redis set username failed, continuing without cache", zap.Int("user_id", id), zap.Error(setErr))
 		}
 	}
-	return username, nil
+	return username
 }
 
 func fetchAndUpdateUserQuota(ctx context.Context, id int) (quota int64, err error) {


### PR DESCRIPTION
## Summary
- Add complete Grafana dashboard JSON (7 rows, 54+ panels) covering relay requests, channel health, user quota, billing, DB/Redis, and Go runtime metrics
- Remove admin auth from `/metrics` endpoint for Prometheus scraping
- Fix `TokenAuth` to populate `username` in context, resolving "unknown" user labels in metrics
- Update dashboard to use `username` instead of `user_id` for display and filtering

## Test plan
- [ ] Import `docs/grafana-dashboard.json` into Grafana 10.x+ and verify panels load
- [ ] Confirm `/metrics` endpoint accessible without admin auth
- [ ] Verify Prometheus metrics show actual usernames instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Grafana dashboard design and stepwise implementation plan (54 panels) and expanded Prometheus docs with bearer-token scrape examples.

* **Improvements**
  * /metrics now requires a configured bearer token (METRICS_TOKEN) and uses dedicated metrics authentication instead of admin auth.
  * Token-authenticated requests now populate the username in request context.

* **Tests**
  * Added unit tests covering the metrics authentication behavior.

* **Chores**
  * Added a local Docker Compose configuration for development with metrics support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->