### PR TITLE
fix: add SSE event type line for Anthropic SDK streaming compatibility

### DIFF
--- a/relay/adaptor/anthropic/main.go
+++ b/relay/adaptor/anthropic/main.go
@@ -947,19 +947,31 @@ func ClaudeNativeStreamHandler(c *gin.Context, resp *http.Response) (*model.Erro
 		data = strings.TrimPrefix(data, "data:")
 		data = strings.TrimSpace(data)
 
+		// Skip [DONE] marker (OpenAI convention, not part of Anthropic protocol)
+		if data == "[DONE]" {
+			continue
+		}
+
 		logger.Debug("stream received", zap.String("data", data))
 
-		// For Claude native streaming, we pass through the events directly
-		c.Writer.Write([]byte("data: " + data + "\n\n"))
-		c.Writer.(http.Flusher).Flush()
-
-		// Parse the response to extract usage and model info
+		// Parse the response to extract event type and usage info
 		var claudeResponse StreamResponse
 		err = json.Unmarshal([]byte(data), &claudeResponse)
 		if err != nil {
 			logger.Error("error unmarshalling stream response", zap.Error(err))
+			// Still forward unparseable events as-is
+			c.Writer.Write([]byte("data: " + data + "\n\n"))
+			c.Writer.(http.Flusher).Flush()
 			continue
 		}
+
+		// Write SSE event with proper event: type line for Anthropic SDK compatibility
+		if claudeResponse.Type != "" {
+			c.Writer.Write([]byte("event: " + claudeResponse.Type + "\ndata: " + data + "\n\n"))
+		} else {
+			c.Writer.Write([]byte("data: " + data + "\n\n"))
+		}
+		c.Writer.(http.Flusher).Flush()
 
 		// Extract usage info from message_delta and message_start
 		if claudeResponse.Usage != nil {


### PR DESCRIPTION
## Summary
- Add `event: {type}` line before each `data:` line in `ClaudeNativeStreamHandler` — the Anthropic Python SDK requires this to dispatch streaming events correctly
- Skip upstream `data: [DONE]` marker to avoid JSON parse error logs
- Forward unparseable SSE events as-is instead of silently dropping them

## Root Cause
The Anthropic SDK's `__stream__` method checks `sse.event` value (e.g. `message_start`, `content_block_delta`) to dispatch events. Without the `event:` line, `sse.event` is `None` and all events are silently skipped, resulting in zero streaming output.

## Test plan
- [x] Docker local build with SQLite, Anthropic-type channel proxying to upstream
- [x] 10/10 test cases passed: basic, multi-turn, system prompt, streaming (text_stream + events + raw), tool use, tool result round-trip, streaming tool use, metrics
- [x] No `error unmarshalling stream response` logs for `[DONE]` marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive Grafana dashboard template with 54 monitoring panels covering system overview, relay status, channel health, user quotas, and billing metrics.
  * Metrics endpoint is now publicly accessible without requiring admin authentication.

* **Bug Fixes**
  * Improved streaming event handling for Anthropic API responses.

* **Documentation**
  * Added Grafana dashboard design specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->