### PR TITLE
fix: strip /v1 from request path when base URL ends with any version …

### DIFF
--- a/relay/adaptor/openai/helper.go
+++ b/relay/adaptor/openai/helper.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Laisky/one-api/relay/channeltype"
@@ -16,6 +17,9 @@ func ResponseText2Usage(responseText string, modelName string, promptTokens int)
 	return usage
 }
 
+// openaiVersionSuffixRe matches base URLs ending with a version segment like /v1, /v4, /v1beta, etc.
+var openaiVersionSuffixRe = regexp.MustCompile(`/v\d+[a-zA-Z0-9]*$`)
+
 func GetFullRequestURL(baseURL string, requestURL string, channelType int) string {
 	if channelType == channeltype.OpenAICompatible {
 		trimmedBase := strings.TrimRight(baseURL, "/")
@@ -23,10 +27,9 @@ func GetFullRequestURL(baseURL string, requestURL string, channelType int) strin
 		if !strings.HasPrefix(path, "/") {
 			path = "/" + path
 		}
-		if strings.HasSuffix(trimmedBase, "/v1") {
-			// Preserve legacy custom-channel behaviour: if the stored base already contains /v1,
-			// avoid duplicating the segment. Otherwise leave the path untouched so providers that
-			// expect /v1 in the request keep working.
+		if openaiVersionSuffixRe.MatchString(trimmedBase) {
+			// Preserve legacy custom-channel behaviour: if the stored base already contains a version
+			// suffix (e.g. /v1, /v4, /v1beta), strip /v1 from the request path to avoid duplication.
 			path = strings.TrimPrefix(path, "/v1")
 			if path == "" {
 				path = "/"

--- a/relay/adaptor/openai/helper.go
+++ b/relay/adaptor/openai/helper.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Laisky/one-api/relay/model"
 )
 
+// ResponseText2Usage creates a Usage struct from response text by estimating completion tokens.
 func ResponseText2Usage(responseText string, modelName string, promptTokens int) *model.Usage {
 	usage := &model.Usage{}
 	usage.PromptTokens = promptTokens
@@ -20,6 +21,8 @@ func ResponseText2Usage(responseText string, modelName string, promptTokens int)
 // openaiVersionSuffixRe matches base URLs ending with a version segment like /v1, /v4, /v1beta, etc.
 var openaiVersionSuffixRe = regexp.MustCompile(`/v\d+[a-zA-Z0-9]*$`)
 
+// GetFullRequestURL constructs the full request URL for OpenAI and compatible APIs,
+// handling version suffix deduplication to avoid paths like /v4/v1/chat/completions.
 func GetFullRequestURL(baseURL string, requestURL string, channelType int) string {
 	if channelType == channeltype.OpenAICompatible {
 		trimmedBase := strings.TrimRight(baseURL, "/")
@@ -30,12 +33,10 @@ func GetFullRequestURL(baseURL string, requestURL string, channelType int) strin
 		if openaiVersionSuffixRe.MatchString(trimmedBase) {
 			// Preserve legacy custom-channel behaviour: if the stored base already contains a version
 			// suffix (e.g. /v1, /v4, /v1beta), strip /v1 from the request path to avoid duplication.
-			path = strings.TrimPrefix(path, "/v1")
-			if path == "" {
+			if path == "/v1" {
 				path = "/"
-			}
-			if !strings.HasPrefix(path, "/") {
-				path = "/" + path
+			} else if strings.HasPrefix(path, "/v1/") {
+				path = path[len("/v1"):]
 			}
 		}
 		return trimmedBase + path

--- a/relay/adaptor/openai/helper_test.go
+++ b/relay/adaptor/openai/helper_test.go
@@ -38,6 +38,25 @@ func TestGetFullRequestURLForOpenAICompatible(t *testing.T) {
 			requestPath: "/dashboard/billing/subscription",
 			expect:      "https://api.example.com/v1/dashboard/billing/subscription",
 		},
+		// Version suffix cases: base URL ends with /v{N} or /v{N}{suffix}
+		{
+			name:        "base-with-v4-zhipu-coding",
+			baseURL:     "https://open.bigmodel.cn/api/coding/paas/v4",
+			requestPath: "/v1/chat/completions",
+			expect:      "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions",
+		},
+		{
+			name:        "base-with-v2",
+			baseURL:     "https://api.example.com/v2",
+			requestPath: "/v1/chat/completions",
+			expect:      "https://api.example.com/v2/chat/completions",
+		},
+		{
+			name:        "base-with-v1beta",
+			baseURL:     "https://api.example.com/v1beta",
+			requestPath: "/v1/chat/completions",
+			expect:      "https://api.example.com/v1beta/chat/completions",
+		},
 	}
 
 	for _, tt := range tests {

--- a/relay/adaptor/openai/helper_test.go
+++ b/relay/adaptor/openai/helper_test.go
@@ -57,6 +57,12 @@ func TestGetFullRequestURLForOpenAICompatible(t *testing.T) {
 			requestPath: "/v1/chat/completions",
 			expect:      "https://api.example.com/v1beta/chat/completions",
 		},
+		{
+			name:        "v11-path-not-trimmed",
+			baseURL:     "https://api.example.com/v1",
+			requestPath: "/v11/chat/completions",
+			expect:      "https://api.example.com/v1/v11/chat/completions",
+		},
 	}
 
 	for _, tt := range tests {

--- a/relay/adaptor/openai_compatible/utils.go
+++ b/relay/adaptor/openai_compatible/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/Laisky/errors/v2"
@@ -114,6 +115,26 @@ func CountTokenText(text string, modelName string) int {
 	return len(text) / 4
 }
 
+// versionSuffixRe matches base URLs ending with a version segment like /v1, /v4, /v1beta, etc.
+var versionSuffixRe = regexp.MustCompile(`/v\d+[a-zA-Z0-9]*$`)
+
+// stripV1Prefix removes the leading /v1 from a path, ensuring the result starts with /.
+func stripV1Prefix(path string) string {
+	path = strings.TrimPrefix(path, "/v1")
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path
+}
+
+// hasVersionSuffix reports whether the base URL ends with a version-like segment (e.g. /v1, /v4, /v1beta).
+func hasVersionSuffix(base string) bool {
+	return versionSuffixRe.MatchString(base)
+}
+
 // GetFullRequestURL constructs the full request URL for OpenAI-compatible APIs
 func GetFullRequestURL(baseURL string, requestURL string, channelType int) string {
 	trimmedBase := strings.TrimRight(baseURL, "/")
@@ -123,14 +144,8 @@ func GetFullRequestURL(baseURL string, requestURL string, channelType int) strin
 	}
 
 	if channelType == channeltype.OpenAICompatible {
-		if strings.HasSuffix(trimmedBase, "/v1") {
-			path = strings.TrimPrefix(path, "/v1")
-			if path == "" {
-				path = "/"
-			}
-			if !strings.HasPrefix(path, "/") {
-				path = "/" + path
-			}
+		if hasVersionSuffix(trimmedBase) {
+			path = stripV1Prefix(path)
 		}
 		if path == "" {
 			return trimmedBase
@@ -138,14 +153,11 @@ func GetFullRequestURL(baseURL string, requestURL string, channelType int) strin
 		return trimmedBase + path
 	}
 
-	if strings.HasSuffix(trimmedBase, "/v1") {
+	if hasVersionSuffix(trimmedBase) {
 		if path == "/v1" {
 			path = ""
 		} else if strings.HasPrefix(path, "/v1/") {
 			path = path[len("/v1"):]
-			if path == "" {
-				path = ""
-			}
 		}
 	}
 

--- a/relay/adaptor/openai_compatible/utils.go
+++ b/relay/adaptor/openai_compatible/utils.go
@@ -23,6 +23,8 @@ const (
 	Done             = "[DONE]"
 )
 
+// shouldLogDetailedUpstreamBody determines whether to log the full upstream response body
+// for debugging purposes based on query parameter or logger level.
 func shouldLogDetailedUpstreamBody(c *gin.Context) bool {
 	if c == nil {
 		return true
@@ -119,13 +121,14 @@ func CountTokenText(text string, modelName string) int {
 var versionSuffixRe = regexp.MustCompile(`/v\d+[a-zA-Z0-9]*$`)
 
 // stripV1Prefix removes the leading /v1 from a path, ensuring the result starts with /.
+// It only strips "/v1" when followed by "/" or end-of-string, to avoid partially
+// trimming paths like "/v11/chat/completions".
 func stripV1Prefix(path string) string {
-	path = strings.TrimPrefix(path, "/v1")
-	if path == "" {
-		path = "/"
+	if path == "/v1" {
+		return "/"
 	}
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
+	if strings.HasPrefix(path, "/v1/") {
+		return path[len("/v1"):]
 	}
 	return path
 }

--- a/relay/adaptor/openai_compatible/utils_url_test.go
+++ b/relay/adaptor/openai_compatible/utils_url_test.go
@@ -67,6 +67,35 @@ func TestGetFullRequestURL(t *testing.T) {
 			expect:      "https://oneapi.laisky.com/v1/embeddings",
 			channelType: channeltype.OpenAI,
 		},
+		// Version suffix cases: base URL ends with /v{N} or /v{N}{suffix}
+		{
+			name:        "compatible-base-with-v4-zhipu-coding",
+			base:        "https://open.bigmodel.cn/api/coding/paas/v4",
+			path:        "/v1/chat/completions",
+			expect:      "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions",
+			channelType: channeltype.OpenAICompatible,
+		},
+		{
+			name:        "compatible-base-with-v2",
+			base:        "https://proxy.example.com/v2",
+			path:        "/v1/chat/completions",
+			expect:      "https://proxy.example.com/v2/chat/completions",
+			channelType: channeltype.OpenAICompatible,
+		},
+		{
+			name:        "compatible-base-with-v1beta",
+			base:        "https://proxy.example.com/v1beta",
+			path:        "/v1/chat/completions",
+			expect:      "https://proxy.example.com/v1beta/chat/completions",
+			channelType: channeltype.OpenAICompatible,
+		},
+		{
+			name:        "other-type-base-with-v4",
+			base:        "https://api.example.com/v4",
+			path:        "/v1/chat/completions",
+			expect:      "https://api.example.com/v4/chat/completions",
+			channelType: channeltype.OpenAI,
+		},
 	}
 
 	for _, tc := range cases {

--- a/relay/adaptor/openai_compatible/utils_url_test.go
+++ b/relay/adaptor/openai_compatible/utils_url_test.go
@@ -90,6 +90,13 @@ func TestGetFullRequestURL(t *testing.T) {
 			channelType: channeltype.OpenAICompatible,
 		},
 		{
+			name:        "compatible-v11-path-not-trimmed",
+			base:        "https://proxy.example.com/v1",
+			path:        "/v11/chat/completions",
+			expect:      "https://proxy.example.com/v1/v11/chat/completions",
+			channelType: channeltype.OpenAICompatible,
+		},
+		{
 			name:        "other-type-base-with-v4",
 			base:        "https://api.example.com/v4",
 			path:        "/v1/chat/completions",


### PR DESCRIPTION
Previously, GetFullRequestURL only stripped /v1 from the request path when the base URL ended with exactly '/v1'. This caused double-path issues for providers whose base URL ends with other version segments like /v4 (e.g. Zhipu Coding Plan endpoint).

Now uses a regex to detect any version suffix (/v1, /v2, /v4, /v1beta, etc.) and strips /v1 from the request path accordingly.

Affected files:
- relay/adaptor/openai_compatible/utils.go
- relay/adaptor/openai/helper.go (parallel implementation)

Includes test cases for v4, v2, v1beta base URL suffixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved compatibility with OpenAI-compatible API endpoints using different version segment formats. The relay now better supports endpoints with various version paths (e.g., `/v2`, `/v4`, `/v1beta`) and ensures proper URL construction for diverse API endpoint configurations without path conflicts.

**Tests**
* Added comprehensive test coverage for OpenAI-compatible endpoints with multiple version segment format scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->