### PR TITLE
fix(siliconflow): 修复嵌入端点响应处理问题

### DIFF
--- a/relay/adaptor/siliconflow/adaptor.go
+++ b/relay/adaptor/siliconflow/adaptor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Laisky/one-api/relay/adaptor/openai_compatible"
 	"github.com/Laisky/one-api/relay/meta"
 	"github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/relaymode"
 )
 
 type Adaptor struct {
@@ -61,6 +62,15 @@ func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Read
 }
 
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	// SiliconFlow exposes an OpenAI-compatible /v1/embeddings endpoint, so route
+	// the response through the shared embedding handler instead of the chat
+	// completion handler (which expects a `choices` field that embedding
+	// responses do not have).
+	if meta.Mode == relaymode.Embeddings {
+		errResp, embeddingUsage := openai_compatible.EmbeddingHandler(c, resp)
+		return embeddingUsage, errResp
+	}
+
 	return openai_compatible.HandleClaudeMessagesResponse(c, resp, meta, func(c *gin.Context, resp *http.Response, promptTokens int, modelName string) (*model.ErrorWithStatusCode, *model.Usage) {
 		if meta.IsStream {
 			return openai_compatible.StreamHandler(c, resp, promptTokens, modelName)

--- a/relay/adaptor/siliconflow/adaptor_test.go
+++ b/relay/adaptor/siliconflow/adaptor_test.go
@@ -1,0 +1,86 @@
+package siliconflow
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/meta"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+// TestDoResponse_Embeddings guards against the regression where SiliconFlow
+// embedding responses (OpenAI-compatible /v1/embeddings schema) were routed
+// through the chat-completion handler, which then failed with
+// "no choices in response from upstream" because embedding payloads expose
+// `data[*].embedding` instead of `choices`.
+//
+// The expected behavior: DoResponse must call openai_compatible.EmbeddingHandler
+// for relaymode.Embeddings, forwarding the original payload to the client
+// and returning the usage block.
+func TestDoResponse_Embeddings(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	// Use a payload modeled after the failing request in the bug report:
+	// a SiliconFlow Qwen/Qwen3-Embedding-8B response carrying a 4-dim
+	// vector. The exact dimensionality is irrelevant; what matters is the
+	// shape (data/usage) is correct.
+	embeddingResponse := map[string]any{
+		"object": "list",
+		"data": []map[string]any{
+			{
+				"object":    "embedding",
+				"index":     0,
+				"embedding": []float64{0.1, 0.2, 0.3, 0.4},
+			},
+		},
+		"model": "Qwen/Qwen3-Embedding-8B",
+		"usage": map[string]any{
+			"prompt_tokens":     10,
+			"completion_tokens": 0,
+			"total_tokens":      10,
+		},
+	}
+	body, err := json.Marshal(embeddingResponse)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/embeddings", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+
+	m := &meta.Meta{
+		Mode:            relaymode.Embeddings,
+		ActualModelName: "Qwen/Qwen3-Embedding-8B",
+	}
+
+	usage, errResp := (&Adaptor{}).DoResponse(c, resp, m)
+
+	// Must not surface the "no choices" error that the chat-completion
+	// handler produced for embedding payloads.
+	require.Nil(t, errResp)
+	require.NotNil(t, usage, "usage must be populated for billing")
+
+	assert.Equal(t, 10, usage.PromptTokens)
+	assert.Equal(t, 0, usage.CompletionTokens)
+	assert.Equal(t, 10, usage.TotalTokens)
+
+	// The original OpenAI-compatible body must be forwarded verbatim so
+	// embedding SDKs can keep parsing it.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.JSONEq(t, string(body), w.Body.String())
+}


### PR DESCRIPTION
这个提交主要是解决使用 `/v1/embeddings` 端点调用硅基流动时报错的问题，具体错误如下
```
2026-06-04T09:25:28+08:00    INFO    one-api.gin    controller/helper.go:239    user has enough quota, trusted and no
  need to pre-consume    {"host": "LAPTOP-BI24KQCK", "url": "/v1/embeddings", "remote": "192.168.80.75:51904", "host":
  "172.168.80.2:3000", "trace_id": "f894114213fda7f8:80106249f2929ec3::4", "cost": "0.00s", "request_size": "101B",
  "user_id": 1, "user_quota": 499976138540007}
  2026-06-04T09:25:32+08:00    ERROR    one-api.gin    openai_compatible/utils.go:301    response has no choices,
  possible upstream error    {"host": "LAPTOP-BI24KQCK", "url": "/v1/embeddings", "remote": "192.168.80.75:51904",
  "host": "172.168.80.2:3000", "trace_id": "f894114213fda7f8:80106249f2929ec3::4", "cost": "0.00s", "request_size":
  "101B", "model": "Qwen/Qwen3-Embedding-8B", "response_body": "{\"object\":\"list\",\"data\":[{\"embedding\":[0.000820
  8271465264261,-0.002655831864103675,-0.0003830526547972113,-0.03712327405810356,0.0047571491450071335,-0.01587662中间省略...
  in@v1.12.0/context.go:192\ngithub.com/Laisky/one-api/middleware.RelayPanicRecover.func1\n\tD:/GoProjects/one-api-next
  /middleware/recover.go:35\ngithub.com/gin-gonic/gin.(*Context).Next\n\tC:/Users/imyuy/go/pkg/mod/github.com/gin-gonic
  /gin@v1.12.0/context.go:192\ngithub.com/Laisky/one-api/router.SetRelayRouter.func1\n\tD:/GoProjects/one-api-next/rout
  er/relay.go:52\ngithub.com/gin-gonic/gin.(*Context).Next\n\tC:/Users/imyuy/go/pkg/mod/github.com/gin-gonic/gin@v1.12.
  0/context.go:192\ngithub.com/Laisky/one-api/middleware.GzipDecodeMiddleware.func1\n\tD:/GoProjects/one-api-next/middl
  eware/gzip.go:26\ngithub.com/gin-gonic/gin.(*Context).Next\n\tC:/Users/imyuy/go/pkg/mod/github.com/gin-gonic/gin@v1.1
  2.0/context.go:192\ngithub.com/Laisky/one-api/middleware.APIFormatAutoDetect.func1\n\tD:/GoProjects/one-api-next/midd
  leware/api_format_detect.go:47\ngithub.com/gin-gonic/gin.(*Context).Next\n\tC:/Users/imyuy/go/pkg/mod/github.com/gin-
  gonic/gin@v1.12.0/context.go:192\ngithub.com/Laisky/one-api/middleware.RewriteClaudeMessagesPrefix.func1\n\tD:/GoProj
  ects/one-api-next/middleware/claude_rewrite.go:35\ngithub.com/gin-gonic/gin.(*Context).Next\n\tC:/Users/imyuy/go/pkg/
  mod/github.com/gin-gonic/gin@v1.12.0/context.go:192\ngithub.com/Laisky/one-api/middleware.RewriteClaudeMessagesPrefix
  .func1\n\tD:/GoProjects/one-api-next/middleware/claude_rewrite.go:35\ngithub.com/gin-gonic/gin.(*Context).Next\n\tC:/
  Users/imyuy/go/pkg/mod/github.com/gin-gonic/gin@v1.12.0/context.go:192\ngithub.com/Laisky/one-api/middleware.RewriteC
  laudeMessagesPrefix.func1\n\tD:/GoProjects/one-api-next/middleware/claude_rewrite.go:35\ngithub.com/gin-gonic/gin.(*C
  ontext).Next\n\tC:/Users/imyuy/go/pkg/mod/github.com/gin-gonic/gin@v1.12.0/context.go:192"}
  2026-06-04T09:25:32+08:00    INFO    one-api.gin    v7@v7.0.3-0.20260320133617-ccf155d4ffea/log.go:344    500 POST
  {"host": "LAPTOP-BI24KQCK", "url": "/v1/embeddings", "remote": "192.168.80.75:51904", "host": "172.168.80.2:3000",
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Embedding requests are now properly supported with dedicated response handling. The system ensures correct response formatting, accurate token usage counting, and seamless integration for all embedding operations.

* **Tests**
  * Added comprehensive tests for embedding request functionality to validate response routing, verify proper error handling, and confirm accurate token usage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->