### PR TITLE
feat(email): optional Resend HTTP API for outbound mail

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -1418,6 +1418,23 @@ var (
 	// Runtime variable (set via admin UI)
 	// Default: "" (no authentication)
 	SMTPToken = ""
+
+	// ResendAPIKey holds the API key for Resend.com email service.
+	// Used when EmailProvider is set to "resend".
+	//
+	// Runtime variable (set via admin UI; env override on startup)
+	// Default: ""
+	// Example: "re_123456789"
+	ResendAPIKey = env.String("RESEND_API_KEY", "")
+
+	// EmailProvider selects the outbound email backend.
+	// Valid values: "smtp" (default), "resend".
+	// When unset, the backend falls back to "resend" if ResendAPIKey is configured,
+	// otherwise "smtp" — preserving behaviour for installations upgraded from older versions.
+	//
+	// Runtime variable (set via admin UI; env override on startup)
+	// Default: "" (auto-detected as described above)
+	EmailProvider = strings.ToLower(strings.TrimSpace(env.String("EMAIL_PROVIDER", "")))
 )
 
 // =============================================================================

--- a/common/message/email.go
+++ b/common/message/email.go
@@ -40,6 +40,11 @@ type ResendEmailResponse struct {
 // resendAPIURL is the Resend emails endpoint. Tests may override it to point at httptest.
 var resendAPIURL = "https://api.resend.com/emails"
 
+// resendHTTPClient is shared across Resend sends to reuse TCP connections.
+var resendHTTPClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
 // loginAuth implements the LOGIN authentication mechanism
 type loginAuth struct {
 	username, password string
@@ -184,8 +189,7 @@ func sendEmailViaResend(subject, receiver, content string) error {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+config.ResendAPIKey)
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := resendHTTPClient.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to send request to Resend API")
 	}

--- a/common/message/email.go
+++ b/common/message/email.go
@@ -1,12 +1,16 @@
 package message
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"net/smtp"
 	"strings"
 	"time"
@@ -15,6 +19,26 @@ import (
 
 	"github.com/Laisky/one-api/common/config"
 )
+
+// ResendEmailRequest is the JSON body sent to POST https://api.resend.com/emails.
+type ResendEmailRequest struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	Html    string   `json:"html"`
+}
+
+// ResendEmailResponse models both the success and error payloads returned by the Resend API.
+// Success: {"id": "..."}. Error: {"statusCode": 422, "name": "validation_error", "message": "..."}.
+type ResendEmailResponse struct {
+	ID         string `json:"id,omitempty"`
+	StatusCode int    `json:"statusCode,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+// resendAPIURL is the Resend emails endpoint. Tests may override it to point at httptest.
+var resendAPIURL = "https://api.resend.com/emails"
 
 // loginAuth implements the LOGIN authentication mechanism
 type loginAuth struct {
@@ -101,6 +125,98 @@ func shouldAuth() bool {
 	return config.SMTPAccount != "" || config.SMTPToken != ""
 }
 
+// sendEmailViaResend posts an HTML email through the Resend HTTP API.
+// It returns an error when the API key is missing, no recipients are valid,
+// the HTTP request fails, or Resend responds with a non-2xx status.
+func sendEmailViaResend(subject, receiver, content string) error {
+	if config.ResendAPIKey == "" {
+		return errors.New("Resend API key is not configured")
+	}
+
+	emails := []string{}
+	for email := range strings.SplitSeq(receiver, ";") {
+		email = strings.TrimSpace(email)
+		if email != "" {
+			emails = append(emails, email)
+		}
+	}
+
+	if len(emails) == 0 {
+		return errors.New("no valid recipient email addresses")
+	}
+
+	// Resend requires the from address to be on a verified domain. Prefer SMTPFrom,
+	// fall back to SMTPAccount, and wrap with the SystemName display name when both
+	// are set so the recipient inbox shows a friendly sender (e.g. "Acme <noreply@acme.com>").
+	fromAddr := strings.TrimSpace(config.SMTPFrom)
+	if fromAddr == "" {
+		fromAddr = strings.TrimSpace(config.SMTPAccount)
+	}
+	if fromAddr == "" {
+		return errors.New("Resend sender address is not configured (set SMTPFrom or SMTPAccount)")
+	}
+	from := fromAddr
+	if name := strings.TrimSpace(config.SystemName); name != "" && !strings.Contains(fromAddr, "<") {
+		from = fmt.Sprintf("%s <%s>", name, fromAddr)
+	}
+
+	reqBody := ResendEmailRequest{
+		From:    from,
+		To:      emails,
+		Subject: subject,
+		Html:    content,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal Resend request")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resendAPIURL, bytes.NewReader(body))
+	if err != nil {
+		return errors.Wrap(err, "failed to create Resend request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+config.ResendAPIKey)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to send request to Resend API")
+	}
+	defer resp.Body.Close()
+
+	// Read the body once so we can include it in error messages even when it isn't JSON
+	// (e.g. an HTML error page from an upstream proxy or Railway edge).
+	rawBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if readErr != nil {
+		return errors.Wrapf(readErr, "failed to read Resend response (status %d)", resp.StatusCode)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var res ResendEmailResponse
+		if jsonErr := json.Unmarshal(rawBody, &res); jsonErr == nil && res.Message != "" {
+			return errors.Errorf("Resend API error (status %d, %s): %s", resp.StatusCode, res.Name, res.Message)
+		}
+		return errors.Errorf("Resend API returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(rawBody)))
+	}
+
+	var res ResendEmailResponse
+	if err := json.Unmarshal(rawBody, &res); err != nil {
+		return errors.Wrapf(err, "failed to decode Resend success response: %s", strings.TrimSpace(string(rawBody)))
+	}
+	if res.ID == "" {
+		return errors.Errorf("Resend API returned success status %d but no message id; body: %s", resp.StatusCode, strings.TrimSpace(string(rawBody)))
+	}
+
+	return nil
+}
+
 // dialSMTPClient establishes a connection to the SMTP server, preferring implicit TLS when available.
 // It falls back to a plain connection with STARTTLS when the server does not accept immediate TLS.
 // localName is used for the EHLO/HELO greeting and should be a hostname (e.g., the sender domain or "localhost").
@@ -172,12 +288,32 @@ func dialSMTPClient(ctx context.Context, addr, localName string) (*smtp.Client, 
 	return client, authMechs, usingTLS, nil
 }
 
-// SendEmail transmits an HTML email using the configured SMTP server, authenticating when credentials are provided.
+// SendEmail transmits an HTML email using Resend API or SMTP server.
 // It returns an error when the message cannot be constructed or delivered.
 func SendEmail(subject string, receiver string, content string) error {
 	if receiver == "" {
 		return errors.Errorf("receiver is empty")
 	}
+
+	// Resolve provider: explicit EmailProvider wins; otherwise fall back to legacy
+	// auto-detection (Resend if API key present, else SMTP) for backwards compatibility.
+	provider := strings.ToLower(strings.TrimSpace(config.EmailProvider))
+	if provider == "" {
+		if config.ResendAPIKey != "" {
+			provider = "resend"
+		} else {
+			provider = "smtp"
+		}
+	}
+	switch provider {
+	case "resend":
+		return sendEmailViaResend(subject, receiver, content)
+	case "smtp":
+		// fall through to SMTP path below
+	default:
+		return errors.Errorf("unknown email provider %q (expected \"smtp\" or \"resend\")", provider)
+	}
+
 	if config.SMTPFrom == "" { // for compatibility
 		config.SMTPFrom = config.SMTPAccount
 	}

--- a/common/message/email_resend_test.go
+++ b/common/message/email_resend_test.go
@@ -1,0 +1,129 @@
+package message
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/common/config"
+)
+
+// TestSendEmailViaResendSuccess verifies a successful Resend API round-trip and request shape.
+func TestSendEmailViaResendSuccess(t *testing.T) {
+	var gotAuth string
+	var gotBody ResendEmailRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		gotAuth = r.Header.Get("Authorization")
+		raw, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"re_test_msg_1"}`))
+	}))
+	defer server.Close()
+
+	prevURL := resendAPIURL
+	prevKey := config.ResendAPIKey
+	prevFrom := config.SMTPFrom
+	prevProvider := config.EmailProvider
+	prevName := config.SystemName
+	resendAPIURL = server.URL
+	config.ResendAPIKey = "re_test_key"
+	config.SMTPFrom = "noreply@example.com"
+	config.EmailProvider = "resend"
+	config.SystemName = "OneAPI Test"
+	t.Cleanup(func() {
+		resendAPIURL = prevURL
+		config.ResendAPIKey = prevKey
+		config.SMTPFrom = prevFrom
+		config.EmailProvider = prevProvider
+		config.SystemName = prevName
+	})
+
+	err := SendEmail("Hello", "user@example.com", "<b>hi</b>")
+	require.NoError(t, err)
+	require.Equal(t, "Bearer re_test_key", gotAuth)
+	require.Equal(t, "OneAPI Test <noreply@example.com>", gotBody.From)
+	require.Equal(t, []string{"user@example.com"}, gotBody.To)
+	require.Equal(t, "Hello", gotBody.Subject)
+	require.Equal(t, "<b>hi</b>", gotBody.Html)
+}
+
+// TestSendEmailViaResendAPIError surfaces Resend top-level error payloads.
+func TestSendEmailViaResendAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"statusCode":422,"name":"validation_error","message":"Invalid from address"}`))
+	}))
+	defer server.Close()
+
+	prevURL := resendAPIURL
+	prevKey := config.ResendAPIKey
+	prevFrom := config.SMTPFrom
+	prevProvider := config.EmailProvider
+	resendAPIURL = server.URL
+	config.ResendAPIKey = "re_test_key"
+	config.SMTPFrom = "bad@example.com"
+	config.EmailProvider = "resend"
+	t.Cleanup(func() {
+		resendAPIURL = prevURL
+		config.ResendAPIKey = prevKey
+		config.SMTPFrom = prevFrom
+		config.EmailProvider = prevProvider
+	})
+
+	err := SendEmail("s", "a@b.com", "c")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid from address")
+	require.Contains(t, err.Error(), "validation_error")
+}
+
+// TestSendEmailProviderRouting rejects unknown providers and missing Resend config.
+func TestSendEmailProviderRouting(t *testing.T) {
+	prevProvider := config.EmailProvider
+	prevKey := config.ResendAPIKey
+	t.Cleanup(func() {
+		config.EmailProvider = prevProvider
+		config.ResendAPIKey = prevKey
+	})
+
+	config.EmailProvider = "not-a-provider"
+	err := SendEmail("s", "a@b.com", "c")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown email provider")
+
+	config.EmailProvider = "resend"
+	config.ResendAPIKey = ""
+	err = SendEmail("s", "a@b.com", "c")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Resend API key is not configured")
+}
+
+// TestSendEmailViaResendMissingFrom requires SMTPFrom or SMTPAccount.
+func TestSendEmailViaResendMissingFrom(t *testing.T) {
+	prevProvider := config.EmailProvider
+	prevKey := config.ResendAPIKey
+	prevFrom := config.SMTPFrom
+	prevAccount := config.SMTPAccount
+	t.Cleanup(func() {
+		config.EmailProvider = prevProvider
+		config.ResendAPIKey = prevKey
+		config.SMTPFrom = prevFrom
+		config.SMTPAccount = prevAccount
+	})
+	config.EmailProvider = "resend"
+	config.ResendAPIKey = "re_test"
+	config.SMTPFrom = ""
+	config.SMTPAccount = ""
+	err := SendEmail("s", "a@b.com", "c")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sender address is not configured")
+}

--- a/controller/option.go
+++ b/controller/option.go
@@ -16,12 +16,13 @@ import (
 )
 
 // isSensitiveOptionKey reports whether the option key holds a secret value
-// (e.g. tokens, secrets, passwords) and should never be echoed back to the
-// client or overwritten with an empty value submitted by a UI form.
+// (e.g. tokens, secrets, passwords, API keys) and should never be echoed back
+// to the client or overwritten with an empty value submitted by a UI form.
 func isSensitiveOptionKey(key string) bool {
 	return strings.HasSuffix(key, "Token") ||
 		strings.HasSuffix(key, "Secret") ||
-		strings.HasSuffix(key, "Password")
+		strings.HasSuffix(key, "Password") ||
+		strings.HasSuffix(key, "APIKey")
 }
 
 // GetOptions returns the current configuration options excluding sensitive values.

--- a/controller/option.go
+++ b/controller/option.go
@@ -78,6 +78,14 @@ func UpdateOption(c *gin.Context) {
 			helper.RespondError(c, errors.New("invalid theme"))
 			return
 		}
+	case "EmailProvider":
+		// Normalize and reject typos before they are persisted.
+		val := strings.ToLower(strings.TrimSpace(option.Value))
+		if val != "" && val != "smtp" && val != "resend" {
+			helper.RespondError(c, errors.Errorf("invalid email provider %q (expected \"smtp\", \"resend\", or empty)", val))
+			return
+		}
+		option.Value = val
 	case "GitHubOAuthEnabled":
 		if option.Value == "true" && config.GitHubClientId == "" {
 			helper.RespondError(c, errors.New("Unable to enable GitHub OAuth, please fill in the GitHub Client Id and GitHub Client Secret first!"))

--- a/controller/option_test.go
+++ b/controller/option_test.go
@@ -99,6 +99,7 @@ func TestUpdateOption_SensitiveEmptyValueIsIgnored(t *testing.T) {
 		{name: "secret suffix", key: "GitHubClientSecret", value: "real-github-secret"},
 		{name: "token suffix", key: "SMTPToken", value: "real-smtp-token"},
 		{name: "password suffix", key: "SMTPPassword", value: "real-smtp-password"},
+		{name: "api key suffix", key: "ResendAPIKey", value: "re_test_key"},
 	}
 
 	for _, tc := range cases {

--- a/model/option.go
+++ b/model/option.go
@@ -202,7 +202,11 @@ func updateOptionMap(key string, value string) (err error) {
 	case "SMTPToken":
 		config.SMTPToken = value
 	case "EmailProvider":
-		config.EmailProvider = strings.ToLower(strings.TrimSpace(value))
+		val := strings.ToLower(strings.TrimSpace(value))
+		if val != "" && val != "smtp" && val != "resend" {
+			return errors.Errorf("invalid email provider %q (expected \"smtp\", \"resend\", or empty)", val)
+		}
+		config.EmailProvider = val
 	case "ResendAPIKey":
 		config.ResendAPIKey = strings.TrimSpace(value)
 	case "ServerAddress":

--- a/model/option.go
+++ b/model/option.go
@@ -56,6 +56,8 @@ func InitOptionMap() {
 	config.OptionMap["SMTPPort"] = strconv.Itoa(config.SMTPPort)
 	config.OptionMap["SMTPAccount"] = ""
 	config.OptionMap["SMTPToken"] = ""
+	config.OptionMap["EmailProvider"] = config.EmailProvider
+	config.OptionMap["ResendAPIKey"] = config.ResendAPIKey
 	config.OptionMap["Notice"] = ""
 	config.OptionMap["About"] = ""
 	config.OptionMap["HomePageContent"] = ""
@@ -199,6 +201,10 @@ func updateOptionMap(key string, value string) (err error) {
 		config.SMTPFrom = value
 	case "SMTPToken":
 		config.SMTPToken = value
+	case "EmailProvider":
+		config.EmailProvider = strings.ToLower(strings.TrimSpace(value))
+	case "ResendAPIKey":
+		config.ResendAPIKey = strings.TrimSpace(value)
 	case "ServerAddress":
 		config.ServerAddress = value
 	case "GitHubClientId":

--- a/web/modern/src/i18n/locales/en/settings.json
+++ b/web/modern/src/i18n/locales/en/settings.json
@@ -320,11 +320,13 @@
       "QuotaRemindThreshold": "When remaining quota falls below this value, users will be reminded.",
       "RegisterEnabled": "Master switch for user registration. Turn off to stop all new sign-ups.",
       "RetryTimes": "Automatic retry attempts for upstream requests on transient errors.",
-      "SMTPAccount": "SMTP username or account email used to authenticate.",
-      "SMTPFrom": "From address used in outgoing emails (e.g., no-reply@yourdomain).",
-      "SMTPPort": "SMTP server port (e.g., 587 for STARTTLS, 465 for SMTPS).",
-      "SMTPServer": "SMTP server hostname for sending emails.",
-      "SMTPToken": "SMTP password or application token used to authenticate. Stored securely and never displayed.",
+      "EmailProvider": "Which backend to use for outbound email. Pick SMTP for a traditional mail server, or Resend to send via the Resend HTTP API (recommended for PaaS like Railway that block outbound SMTP).",
+      "ResendAPIKey": "Resend API key (starts with re_). Only used when Email Provider is set to Resend. Stored securely and never displayed.",
+      "SMTPAccount": "SMTP username or account email used to authenticate. Only used when Email Provider is SMTP.",
+      "SMTPFrom": "From address used in outgoing emails (e.g., no-reply@yourdomain). For Resend, the domain must be verified in your Resend account.",
+      "SMTPPort": "SMTP server port (e.g., 587 for STARTTLS, 465 for SMTPS). Only used when Email Provider is SMTP.",
+      "SMTPServer": "SMTP server hostname for sending emails. Only used when Email Provider is SMTP.",
+      "SMTPToken": "SMTP password or application token used to authenticate. Only used when Email Provider is SMTP. Stored securely and never displayed.",
       "ServerAddress": "Public base URL of this server (used in links/callbacks).",
       "SystemName": "System display name shown in the UI and emails.",
       "Theme": "UI theme (berry, air, modern).",
@@ -338,6 +340,10 @@
       "WeChatServerToken": "Verification token for your WeChat server integration. Stored securely and never displayed."
     },
     "disabled": "Disabled",
+    "email_provider": {
+      "resend": "Resend (HTTP API)",
+      "smtp": "SMTP"
+    },
     "email_whitelist": {
       "add": "Add",
       "duplicate_domain": "Domain \"{{domain}}\" is already in the list.",
@@ -364,8 +370,8 @@
         "title": "Channels \u0026 Reliability"
       },
       "email": {
-        "description": "Set up outbound email delivery.",
-        "title": "Email (SMTP)"
+        "description": "Set up outbound email delivery. Choose between SMTP and the Resend HTTP API.",
+        "title": "Email"
       },
       "links": {
         "description": "Control external links exposed to your end users.",

--- a/web/modern/src/i18n/locales/es/settings.json
+++ b/web/modern/src/i18n/locales/es/settings.json
@@ -320,11 +320,13 @@
       "QuotaRemindThreshold": "Se notifica a los usuarios cuando la cuota restante baja de este valor.",
       "RegisterEnabled": "Interruptor maestro para los registros. Desactívalo para bloquear nuevos registros.",
       "RetryTimes": "Reintentos automáticos ante errores transitorios aguas arriba.",
-      "SMTPAccount": "Usuario o correo SMTP usado para autenticarse.",
-      "SMTPFrom": "Dirección del remitente para correos salientes.",
-      "SMTPPort": "Puerto del servidor SMTP (p. ej. 587 para STARTTLS, 465 para SMTPS).",
-      "SMTPServer": "Nombre de host del servidor SMTP.",
-      "SMTPToken": "Contraseña o token SMTP usado para autenticarse (se almacena de forma segura).",
+      "EmailProvider": "Backend para el envío de correo. Selecciona SMTP para un servidor tradicional o Resend para usar la API HTTP de Resend (recomendado en PaaS como Railway que bloquean SMTP saliente).",
+      "ResendAPIKey": "Clave API de Resend (empieza con re_). Solo se usa cuando el proveedor de correo es Resend. Se almacena de forma segura.",
+      "SMTPAccount": "Usuario o correo SMTP usado para autenticarse. Solo se usa con el backend SMTP.",
+      "SMTPFrom": "Dirección del remitente para correos salientes. Con Resend, el dominio debe estar verificado en tu cuenta de Resend.",
+      "SMTPPort": "Puerto del servidor SMTP (p. ej. 587 para STARTTLS, 465 para SMTPS). Solo se usa con el backend SMTP.",
+      "SMTPServer": "Nombre de host del servidor SMTP. Solo se usa con el backend SMTP.",
+      "SMTPToken": "Contraseña o token SMTP usado para autenticarse. Solo se usa con el backend SMTP (se almacena de forma segura).",
       "ServerAddress": "URL base pública del servidor (para enlaces y callbacks).",
       "SystemName": "Nombre del sistema mostrado en la interfaz y correos.",
       "Theme": "Tema de la UI (berry, air, modern).",
@@ -338,6 +340,10 @@
       "WeChatServerToken": "Token de verificación para la integración con WeChat (se almacena de forma segura)."
     },
     "disabled": "Desactivado",
+    "email_provider": {
+      "resend": "Resend (API HTTP)",
+      "smtp": "SMTP"
+    },
     "email_whitelist": {
       "add": "Añadir",
       "duplicate_domain": "El dominio \"{{domain}}\" ya está en la lista.",
@@ -364,8 +370,8 @@
         "title": "Canales y confiabilidad"
       },
       "email": {
-        "description": "Configura el envío de correo saliente.",
-        "title": "Correo (SMTP)"
+        "description": "Configura el envío de correo saliente. Elige entre SMTP y la API HTTP de Resend.",
+        "title": "Correo"
       },
       "links": {
         "description": "Controla los enlaces externos expuestos a los usuarios finales.",

--- a/web/modern/src/i18n/locales/fr/settings.json
+++ b/web/modern/src/i18n/locales/fr/settings.json
@@ -320,11 +320,13 @@
       "QuotaRemindThreshold": "Seuil de rappel lorsque le quota restant est inférieur à la valeur indiquée.",
       "RegisterEnabled": "Interrupteur principal des inscriptions utilisateur. Désactivez pour bloquer les nouveaux comptes.",
       "RetryTimes": "Nombre de tentatives automatiques pour les erreurs amont transitoires.",
-      "SMTPAccount": "Nom d'utilisateur ou adresse e-mail SMTP utilisé pour l'authentification.",
-      "SMTPFrom": "Adresse d'expéditeur utilisée pour les e-mails sortants.",
-      "SMTPPort": "Port du serveur SMTP (ex. 587 pour STARTTLS, 465 pour SMTPS).",
-      "SMTPServer": "Nom d'hôte du serveur SMTP pour l'envoi d'e-mails.",
-      "SMTPToken": "Mot de passe ou jeton SMTP utilisé pour s'authentifier (stocké de façon sécurisée).",
+      "EmailProvider": "Backend utilisé pour l'envoi d'e-mails. Choisissez SMTP pour un serveur de messagerie classique, ou Resend pour l'API HTTP Resend (recommandé sur les PaaS comme Railway qui bloquent le SMTP sortant).",
+      "ResendAPIKey": "Clé API Resend (commençant par re_). Utilisée uniquement lorsque le backend e-mail est Resend. Stockée en toute sécurité.",
+      "SMTPAccount": "Nom d'utilisateur ou adresse e-mail SMTP utilisé pour l'authentification. Utilisé uniquement avec le backend SMTP.",
+      "SMTPFrom": "Adresse d'expéditeur utilisée pour les e-mails sortants. Avec Resend, le domaine doit être vérifié dans votre compte Resend.",
+      "SMTPPort": "Port du serveur SMTP (ex. 587 pour STARTTLS, 465 pour SMTPS). Utilisé uniquement avec le backend SMTP.",
+      "SMTPServer": "Nom d'hôte du serveur SMTP pour l'envoi d'e-mails. Utilisé uniquement avec le backend SMTP.",
+      "SMTPToken": "Mot de passe ou jeton SMTP utilisé pour s'authentifier. Utilisé uniquement avec le backend SMTP (stocké de façon sécurisée).",
       "ServerAddress": "URL publique de ce serveur (utilisée dans les liens/rappels).",
       "SystemName": "Nom d'affichage du système dans l'interface et les e-mails.",
       "Theme": "Thème UI (berry, air, modern).",
@@ -338,6 +340,10 @@
       "WeChatServerToken": "Jeton de vérification pour l'intégration WeChat (stocké de façon sécurisée)."
     },
     "disabled": "Désactivé",
+    "email_provider": {
+      "resend": "Resend (API HTTP)",
+      "smtp": "SMTP"
+    },
     "email_whitelist": {
       "add": "Ajouter",
       "duplicate_domain": "Le domaine \"{{domain}}\" est déjà dans la liste.",
@@ -364,8 +370,8 @@
         "title": "Canaux et fiabilité"
       },
       "email": {
-        "description": "Configurer l'envoi d'e-mails sortants.",
-        "title": "E-mail (SMTP)"
+        "description": "Configurer l'envoi d'e-mails sortants. Choisissez entre SMTP et l'API HTTP Resend.",
+        "title": "E-mail"
       },
       "links": {
         "description": "Contrôlez les liens externes exposés aux utilisateurs finaux.",

--- a/web/modern/src/i18n/locales/ja/settings.json
+++ b/web/modern/src/i18n/locales/ja/settings.json
@@ -320,11 +320,13 @@
       "QuotaRemindThreshold": "残りクォータがこの値を下回ると通知します。",
       "RegisterEnabled": "ユーザー登録のマスタースイッチです。オフにすると新規登録が停止します。",
       "RetryTimes": "上流への再試行回数を自動制御します。",
-      "SMTPAccount": "SMTP 認証に使用するユーザー名／メールアドレス。",
-      "SMTPFrom": "送信メールに使用する送信元アドレス。",
-      "SMTPPort": "SMTP サーバーのポート（例: STARTTLS=587, SMTPS=465）。",
-      "SMTPServer": "メール送信に使用する SMTP サーバーのホスト名。",
-      "SMTPToken": "SMTP 認証用パスワード／アプリトークン（安全に保存）。",
+      "EmailProvider": "送信メールのバックエンド。SMTP サーバーまたは Resend HTTP API を選択します（Railway など SMTP が遮断される PaaS では Resend 推奨）。",
+      "ResendAPIKey": "Resend API キー（re_ で始まる）。メールプロバイダーが Resend の場合にのみ使用します。安全に保管。",
+      "SMTPAccount": "SMTP 認証に使用するユーザー名／メールアドレス。メールプロバイダーが SMTP の場合にのみ使用されます。",
+      "SMTPFrom": "送信メールに使用する送信元アドレス。Resend の場合、ドメインは Resend 側で事前検証が必要です。",
+      "SMTPPort": "SMTP サーバーのポート（例: STARTTLS=587, SMTPS=465）。メールプロバイダーが SMTP の場合にのみ使用。",
+      "SMTPServer": "メール送信に使用する SMTP サーバーのホスト名。メールプロバイダーが SMTP の場合にのみ使用。",
+      "SMTPToken": "SMTP 認証用パスワード／アプリトークン。メールプロバイダーが SMTP の場合にのみ使用。安全に保存。",
       "ServerAddress": "このサーバーの公開ベース URL（リンクやコールバックで使用）。",
       "SystemName": "UI やメールに表示されるシステム名。",
       "Theme": "UI テーマ（berry / air / modern）。",
@@ -338,6 +340,10 @@
       "WeChatServerToken": "WeChat 連携の検証トークン（安全に保管）。"
     },
     "disabled": "無効",
+    "email_provider": {
+      "resend": "Resend (HTTP API)",
+      "smtp": "SMTP"
+    },
     "email_whitelist": {
       "add": "追加",
       "duplicate_domain": "ドメイン \"{{domain}}\" は既に存在します。",
@@ -364,8 +370,8 @@
         "title": "チャネルと信頼性"
       },
       "email": {
-        "description": "送信メール設定を構成します。",
-        "title": "メール（SMTP）"
+        "description": "送信メール設定を構成します。SMTP と Resend HTTP API を切り替えできます。",
+        "title": "メール"
       },
       "links": {
         "description": "エンドユーザーに公開する外部リンクを制御します。",

--- a/web/modern/src/i18n/locales/zh/settings.json
+++ b/web/modern/src/i18n/locales/zh/settings.json
@@ -320,11 +320,13 @@
       "QuotaRemindThreshold": "当剩余配额低于此值时，将提醒用户。",
       "RegisterEnabled": "用户注册总开关。关闭以停止所有新注册。",
       "RetryTimes": "上游请求出现瞬时错误时的自动重试次数。",
-      "SMTPAccount": "用于认证的 SMTP 用户名或帐户邮箱。",
-      "SMTPFrom": "外发邮件中使用的发件人地址（例如 no-reply@yourdomain）。",
-      "SMTPPort": "SMTP 服务器端口（例如 STARTTLS 为 587，SMTPS 为 465）。",
-      "SMTPServer": "用于发送邮件的 SMTP 服务器主机名。",
-      "SMTPToken": "用于认证的 SMTP 密码或应用令牌。安全存储，从不显示。",
+      "EmailProvider": "用于发送邮件的后端。选择 SMTP 使用传统邮件服务器，或选择 Resend 使用 Resend HTTP API（推荐用于 Railway 等封禁出站 SMTP 的 PaaS 平台）。",
+      "ResendAPIKey": "Resend API 密钥（以 re_ 开头）。仅在邮件后端选择 Resend 时使用。安全存储，从不显示。",
+      "SMTPAccount": "用于认证的 SMTP 用户名或帐户邮箱。仅在邮件后端选择 SMTP 时使用。",
+      "SMTPFrom": "外发邮件中使用的发件人地址（例如 no-reply@yourdomain）。使用 Resend 时，域名必须已在 Resend 后台完成验证。",
+      "SMTPPort": "SMTP 服务器端口（例如 STARTTLS 为 587，SMTPS 为 465）。仅在邮件后端选择 SMTP 时使用。",
+      "SMTPServer": "用于发送邮件的 SMTP 服务器主机名。仅在邮件后端选择 SMTP 时使用。",
+      "SMTPToken": "用于认证的 SMTP 密码或应用令牌。仅在邮件后端选择 SMTP 时使用。安全存储，从不显示。",
       "ServerAddress": "此服务器的公共 Base URL（用于链接/回调）。",
       "SystemName": "在 UI 和邮件中显示的系统显示名称。",
       "Theme": "UI 主题（berry, air, modern）。",
@@ -338,6 +340,10 @@
       "WeChatServerToken": "微信服务器集成的验证令牌。安全存储，从不显示。"
     },
     "disabled": "已禁用",
+    "email_provider": {
+      "resend": "Resend (HTTP API)",
+      "smtp": "SMTP"
+    },
     "email_whitelist": {
       "add": "添加",
       "duplicate_domain": "域名 \"{{domain}}\" 已经存在。",
@@ -364,8 +370,8 @@
         "title": "渠道与可靠性"
       },
       "email": {
-        "description": "设置出站邮件投递。",
-        "title": "邮件 (SMTP)"
+        "description": "设置出站邮件投递。可在 SMTP 和 Resend HTTP API 之间切换。",
+        "title": "邮件"
       },
       "links": {
         "description": "控制向最终用户暴露的外部链接。",

--- a/web/modern/src/pages/settings/SystemSettings.tsx
+++ b/web/modern/src/pages/settings/SystemSettings.tsx
@@ -67,9 +67,9 @@ const OPTION_GROUPS: OptionGroup[] = [
   },
   {
     id: 'email',
-    title: 'Email (SMTP)',
+    title: 'Email',
     description: 'Set up outbound email delivery.',
-    keys: ['SMTPServer', 'SMTPPort', 'SMTPAccount', 'SMTPToken', 'SMTPFrom'],
+    keys: ['EmailProvider', 'SMTPServer', 'SMTPPort', 'SMTPAccount', 'SMTPToken', 'SMTPFrom', 'ResendAPIKey'],
   },
   {
     id: 'branding',
@@ -115,12 +115,26 @@ const OPTION_GROUPS: OptionGroup[] = [
 
 const SENSITIVE_OPTION_KEYS = new Set<string>([
   'SMTPToken',
+  'ResendAPIKey',
   'GitHubClientSecret',
   'OidcClientSecret',
   'LarkClientSecret',
   'WeChatServerToken',
   'MessagePusherToken',
 ]);
+
+interface EnumChoice {
+  value: string;
+  labelKey: string;
+}
+
+// ENUM_OPTION_KEYS lists option keys whose value is a fixed enum, rendered as a select.
+const ENUM_OPTION_KEYS: Record<string, EnumChoice[]> = {
+  EmailProvider: [
+    { value: 'smtp', labelKey: 'system_settings.email_provider.smtp' },
+    { value: 'resend', labelKey: 'system_settings.email_provider.resend' },
+  ],
+};
 
 const OPTION_GROUP_KEY_SET = new Set(OPTION_GROUPS.flatMap((group) => group.keys));
 
@@ -209,7 +223,7 @@ export function SystemSettings() {
         id: 'email',
         title: t('system_settings.groups.email.title'),
         description: t('system_settings.groups.email.description'),
-        keys: ['SMTPServer', 'SMTPPort', 'SMTPAccount', 'SMTPToken', 'SMTPFrom'],
+        keys: ['EmailProvider', 'SMTPServer', 'SMTPPort', 'SMTPAccount', 'SMTPToken', 'SMTPFrom', 'ResendAPIKey'],
       },
       {
         id: 'branding',
@@ -289,12 +303,14 @@ export function SystemSettings() {
       TurnstileSiteKey: t('system_settings.descriptions.TurnstileSiteKey'),
       TurnstileSecretKey: t('system_settings.descriptions.TurnstileSecretKey'),
 
-      // Email (SMTP)
+      // Email
+      EmailProvider: t('system_settings.descriptions.EmailProvider'),
       SMTPServer: t('system_settings.descriptions.SMTPServer'),
       SMTPPort: t('system_settings.descriptions.SMTPPort'),
       SMTPAccount: t('system_settings.descriptions.SMTPAccount'),
       SMTPToken: t('system_settings.descriptions.SMTPToken'),
       SMTPFrom: t('system_settings.descriptions.SMTPFrom'),
+      ResendAPIKey: t('system_settings.descriptions.ResendAPIKey'),
 
       // Branding & Content
       SystemName: t('system_settings.descriptions.SystemName'),
@@ -533,6 +549,7 @@ export function SystemSettings() {
                             description={descriptions[option.key]}
                             isSensitive={isSensitive}
                             isBoolean={isBooleanOptionKey(option.key)}
+                            enumChoices={ENUM_OPTION_KEYS[option.key]}
                             onSave={save}
                           />
                         );
@@ -556,6 +573,7 @@ export function SystemSettings() {
                         description={descriptions[opt.key]}
                         isSensitive={SENSITIVE_OPTION_KEYS.has(opt.key)}
                         isBoolean={isBooleanOptionKey(opt.key)}
+                        enumChoices={ENUM_OPTION_KEYS[opt.key]}
                         onSave={save}
                       />
                     ))}
@@ -580,10 +598,11 @@ interface OptionItemProps {
   onSave: (key: string, value: string | string[]) => Promise<void>;
   isSensitive?: boolean;
   isBoolean?: boolean;
+  enumChoices?: EnumChoice[];
   extraAction?: React.ReactNode;
 }
 
-function OptionItem({ option, description, onSave, isSensitive, isBoolean, extraAction }: OptionItemProps) {
+function OptionItem({ option, description, onSave, isSensitive, isBoolean, enumChoices, extraAction }: OptionItemProps) {
   const { t } = useTranslation();
   const [value, setValue] = useState(option.value);
   const [isSaving, setIsSaving] = useState(false);
@@ -659,6 +678,19 @@ function OptionItem({ option, description, onSave, isSensitive, isBoolean, extra
             <SelectContent>
               <SelectItem value="true">{t('system_settings.enabled')}</SelectItem>
               <SelectItem value="false">{t('system_settings.disabled')}</SelectItem>
+            </SelectContent>
+          </Select>
+        ) : enumChoices && enumChoices.length > 0 ? (
+          <Select value={value === '' ? undefined : value} onValueChange={handleBooleanChange} disabled={isSaving}>
+            <SelectTrigger className="flex-1" aria-label={optionValueAriaLabel} disabled={isSaving}>
+              <SelectValue placeholder={t('system_settings.select_value')} />
+            </SelectTrigger>
+            <SelectContent>
+              {enumChoices.map((choice) => (
+                <SelectItem key={choice.value} value={choice.value}>
+                  {t(choice.labelKey)}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         ) : (


### PR DESCRIPTION
## Summary

Adds an optional **Resend** backend for outbound email (verification, password reset, alerts) so operators can send mail on hosts that block outbound SMTP (common on PaaS).

Existing SMTP behaviour is unchanged when `EmailProvider` is `smtp` or when no Resend API key is configured.

### Backend
- New config: `EmailProvider` (`smtp` | `resend`) and `ResendAPIKey` (env: `EMAIL_PROVIDER`, `RESEND_API_KEY`; also admin options)
- `SendEmail` dispatches by provider; empty `EmailProvider` auto-selects Resend if an API key is set, otherwise SMTP
- Resend client: validates from address (`SMTPFrom` / `SMTPAccount`), optional `SystemName` display name, accepts any 2xx, parses Resend’s top-level error shape (`statusCode` / `name` / `message`)
- Option API: treat keys ending in `APIKey` as sensitive (same empty-save protection as `*Token` / `*Secret`) so the key is not echoed by `GetOptions`

### Admin UI (Modern)
- Email settings group: provider select + sensitive `ResendAPIKey` field
- Generic enum-option control for future selects
- i18n: en / zh / ja / fr / es

### Tests
- Unit tests for success path, API error parsing, provider routing, and missing from-address

## Config (operators)

| Variable / option | Purpose |
|---|---|
| `EMAIL_PROVIDER` / `EmailProvider` | `smtp` or `resend` (empty = auto) |
| `RESEND_API_KEY` / `ResendAPIKey` | Resend API key (`re_…`) |
| `SMTPFrom` (or `SMTPAccount`) | From address; domain must be verified in Resend |

## Test plan
- [x] `go test -race ./common/message/ -run 'Resend|ProviderRouting'`
- [x] `go test -race ./controller/ -run 'EmptyValue|Sensitive|Option'`
- [x] `go vet` on touched packages
- [ ] Manual: set provider=resend + API key + verified from, trigger password-reset email
- [ ] Manual: provider=smtp still works with existing SMTP settings