### PR TITLE
fix: sync channel weight to abilities and use weighted random selection

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strings"
 	"time"
@@ -25,6 +26,7 @@ type Ability struct {
 	ChannelId    int        `json:"channel_id" gorm:"primaryKey;autoIncrement:false;index"`
 	Enabled      bool       `json:"enabled"`
 	Priority     *int64     `json:"priority" gorm:"bigint;default:0;index"`
+	Weight       *uint      `json:"weight" gorm:"default:0"`
 	SuspendUntil *time.Time `json:"suspend_until,omitempty" gorm:"index"`
 	CreatedAt    int64      `json:"created_at" gorm:"bigint;autoCreateTime:milli"`
 	UpdatedAt    int64      `json:"updated_at" gorm:"bigint;autoUpdateTime:milli"`
@@ -69,15 +71,6 @@ func availableAbilitiesQuery(db *gorm.DB, group string, model string, now time.T
 	return query
 }
 
-// firstRandomAbility selects one random ability using the active SQL dialect.
-func firstRandomAbility(query *gorm.DB, ability *Ability) error {
-	order := "RAND()"
-	if common.UsingSQLite.Load() || common.UsingPostgreSQL.Load() {
-		order = "RANDOM()"
-	}
-	return query.Order(order).First(ability).Error
-}
-
 // GetRandomSatisfiedChannel selects a random enabled channel for an exact group
 // and model match, optionally considering all priority tiers.
 func GetRandomSatisfiedChannel(group string, model string, ignoreFirstPriority bool) (*Channel, error) {
@@ -85,7 +78,6 @@ func GetRandomSatisfiedChannel(group string, model string, ignoreFirstPriority b
 		return nil, errors.New("database not initialized")
 	}
 
-	ability := Ability{}
 	now := time.Now().UTC()
 
 	var channelQuery *gorm.DB
@@ -95,22 +87,25 @@ func GetRandomSatisfiedChannel(group string, model string, ignoreFirstPriority b
 		maxPrioritySubQuery := availableAbilitiesQuery(DB, group, model, now, nil).Select("MAX(priority)")
 		channelQuery = availableAbilitiesQuery(DB, group, model, now, nil).Where("priority = (?)", maxPrioritySubQuery)
 	}
-	if err := firstRandomAbility(channelQuery, &ability); err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No enabled channel serves this group/model pair. That is an operator
-			// configuration state (or a caller asking for a model nobody hosts) —
-			// not a code fault, so it must not page an on-call engineer.
-			return nil, errkind.ConfigErr(errors.Wrap(err, "get random satisfied channel"))
-		}
+	var abilities []Ability
+	if err := channelQuery.Find(&abilities).Error; err != nil {
 		return nil, errors.Wrap(err, "get random satisfied channel")
+	}
+	if len(abilities) == 0 {
+		return nil, errkind.ConfigErr(errors.New("no channels available for this group/model pair"))
+	}
+
+	selectedAbility, err := selectAbilityByWeight(abilities)
+	if err != nil {
+		return nil, errkind.ConfigErr(errors.Wrap(err, "select ability by weight"))
 	}
 
 	channel := Channel{}
-	channel.Id = ability.ChannelId
-	if err := DB.First(&channel, "id = ?", ability.ChannelId).Error; err != nil {
+	channel.Id = selectedAbility.ChannelId
+	if err := DB.First(&channel, "id = ?", selectedAbility.ChannelId).Error; err != nil {
 		return nil, identity.Tag(
-			errors.Wrapf(err, "load channel %d for ability", ability.ChannelId),
-			LookupChannelRef(context.Background(), ability.ChannelId))
+			errors.Wrapf(err, "load channel %d for ability", selectedAbility.ChannelId),
+			LookupChannelRef(context.Background(), selectedAbility.ChannelId))
 	}
 	if !channel.SupportsModel(model) {
 		return nil, identity.Tag(
@@ -150,6 +145,7 @@ func addAbilitiesWithDB(db *gorm.DB, channel *Channel) error {
 				ChannelId:    channel.Id,
 				Enabled:      channel.Status == ChannelStatusEnabled,
 				Priority:     channel.Priority,
+				Weight:       channel.Weight,
 				SuspendUntil: nil, // Explicitly nil on new creation
 			}
 			abilities = append(abilities, ability)
@@ -374,7 +370,6 @@ func GetRandomSatisfiedChannelExcluding(group string, model string, ignoreFirstP
 	if DB == nil {
 		return nil, errors.New("database not initialized")
 	}
-	ability := Ability{}
 	now := time.Now().UTC()
 	excludeIDs := excludedChannelIDs(excludeChannelIds)
 
@@ -400,21 +395,26 @@ func GetRandomSatisfiedChannelExcluding(group string, model string, ignoreFirstP
 			Where("priority = (?)", maxPrioritySubQuery)
 	}
 
-	if err := firstRandomAbility(channelQuery, &ability); err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// Same as GetRandomSatisfiedChannel: nothing left that serves this
-			// group/model pair, which is a configuration state, not a code fault.
-			return nil, errkind.ConfigErr(errors.Wrap(err, "get random satisfied channel excluding failed ones"))
-		}
+	var abilities []Ability
+	if err := channelQuery.Find(&abilities).Error; err != nil {
 		return nil, errors.Wrap(err, "get random satisfied channel excluding failed ones")
+	}
+	if len(abilities) == 0 {
+		return nil, errkind.ConfigErr(errors.Errorf("no channels available for model %s in group %s after excluding %d channels",
+			model, group, len(excludeIDs)))
+	}
+
+	selectedAbility, err := selectAbilityByWeight(abilities)
+	if err != nil {
+		return nil, errkind.ConfigErr(errors.Wrap(err, "select ability by weight"))
 	}
 
 	channel := Channel{}
-	channel.Id = ability.ChannelId
-	if err := DB.First(&channel, "id = ?", ability.ChannelId).Error; err != nil {
+	channel.Id = selectedAbility.ChannelId
+	if err := DB.First(&channel, "id = ?", selectedAbility.ChannelId).Error; err != nil {
 		return nil, identity.Tag(
-			errors.Wrapf(err, "load channel %d for ability exclusion check", ability.ChannelId),
-			LookupChannelRef(context.Background(), ability.ChannelId))
+			errors.Wrapf(err, "load channel %d for ability exclusion check", selectedAbility.ChannelId),
+			LookupChannelRef(context.Background(), selectedAbility.ChannelId))
 	}
 	if !channel.SupportsModel(model) {
 		return nil, identity.Tag(
@@ -422,4 +422,42 @@ func GetRandomSatisfiedChannelExcluding(group string, model string, ignoreFirstP
 			channel.Ref())
 	}
 	return &channel, nil
+}
+
+// selectAbilityByWeight picks one ability using weighted random selection.
+// When all weights are zero it falls back to uniform random.
+func selectAbilityByWeight(abilities []Ability) (Ability, error) {
+	if len(abilities) == 0 {
+		return Ability{}, errors.New("no abilities to select from")
+	}
+
+	// Calculate total weight
+	var totalWeight uint
+	for _, a := range abilities {
+		if a.Weight != nil {
+			totalWeight += *a.Weight
+		}
+	}
+
+	// If all weights are zero, fall back to uniform random
+	if totalWeight == 0 {
+		return abilities[rand.Intn(len(abilities))], nil
+	}
+
+	// Weighted random selection
+	r := rand.Intn(int(totalWeight))
+	var cumulative uint
+	for _, a := range abilities {
+		w := uint(0)
+		if a.Weight != nil {
+			w = *a.Weight
+		}
+		cumulative += w
+		if uint(r) < cumulative {
+			return a, nil
+		}
+	}
+
+	// Fallback (shouldn't reach here)
+	return abilities[len(abilities)-1], nil
 }

--- a/model/ability.go
+++ b/model/ability.go
@@ -139,13 +139,18 @@ func addAbilitiesWithDB(db *gorm.DB, channel *Channel) error {
 			continue
 		}
 		for _, group := range groups {
+			// Use GetWeight() rather than channel.Weight directly so the value is
+			// always a concrete non-nil pointer, avoiding GORM inserting NULL when
+			// the channel has no weight configured (gorm:"default:0" only applies
+			// to zero-value Go types, not nil pointers).
+			weight := channel.GetWeight()
 			ability := Ability{
 				Group:        group,
 				Model:        model,
 				ChannelId:    channel.Id,
 				Enabled:      channel.Status == ChannelStatusEnabled,
 				Priority:     channel.Priority,
-				Weight:       channel.Weight,
+				Weight:       &weight,
 				SuspendUntil: nil, // Explicitly nil on new creation
 			}
 			abilities = append(abilities, ability)
@@ -431,11 +436,13 @@ func selectAbilityByWeight(abilities []Ability) (Ability, error) {
 		return Ability{}, errors.New("no abilities to select from")
 	}
 
-	// Calculate total weight
-	var totalWeight uint
+	// Calculate total weight using int64 to avoid overflow when converting to
+	// a signed type for rand.Int63n. Individual weights are uint but their sum
+	// across a tier of channels fits easily within int64 in practice.
+	var totalWeight int64
 	for _, a := range abilities {
 		if a.Weight != nil {
-			totalWeight += *a.Weight
+			totalWeight += int64(*a.Weight)
 		}
 	}
 
@@ -445,15 +452,15 @@ func selectAbilityByWeight(abilities []Ability) (Ability, error) {
 	}
 
 	// Weighted random selection
-	r := rand.Intn(int(totalWeight))
-	var cumulative uint
+	r := rand.Int63n(totalWeight)
+	var cumulative int64
 	for _, a := range abilities {
-		w := uint(0)
+		w := int64(0)
 		if a.Weight != nil {
-			w = *a.Weight
+			w = int64(*a.Weight)
 		}
 		cumulative += w
-		if uint(r) < cumulative {
+		if r < cumulative {
 			return a, nil
 		}
 	}

--- a/model/ability_weight_migration.go
+++ b/model/ability_weight_migration.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"github.com/Laisky/errors/v2"
+	"github.com/Laisky/zap"
+
+	"github.com/Laisky/one-api/common/logger"
+)
+
+// MigrateAbilityWeightBackfill sets abilities.weight from the parent channel's weight
+// for all ability rows where weight is currently NULL. This migration is idempotent
+// and safe to run on every startup.
+func MigrateAbilityWeightBackfill() error {
+	if !DB.Migrator().HasTable(&Ability{}) {
+		return nil
+	}
+
+	// Check if weight column exists
+	if !DB.Migrator().HasColumn(&Ability{}, "Weight") {
+		return nil
+	}
+
+	// Backfill: UPDATE abilities JOIN channels SET abilities.weight = channels.weight WHERE abilities.weight IS NULL
+	result := DB.Exec(`
+		UPDATE abilities 
+		SET weight = COALESCE((SELECT weight FROM channels WHERE channels.id = abilities.channel_id), 0)
+		WHERE weight IS NULL
+	`)
+	if result.Error != nil {
+		return errors.Wrap(result.Error, "backfill ability weights from channels")
+	}
+
+	if result.RowsAffected > 0 {
+		logger.Logger.Info("backfilled ability weights from channels",
+			zap.Int64("rows_affected", result.RowsAffected))
+	}
+
+	return nil
+}

--- a/model/cache.go
+++ b/model/cache.go
@@ -523,28 +523,18 @@ func CacheGetRandomSatisfiedChannel(group string, model string, ignoreFirstPrior
 		}
 	}
 
-	var idx int
+	var channel *Channel
 	if ignoreFirstPriority && endIdx < len(candidateChannels) {
-		idx = random.RandRange(endIdx, len(candidateChannels))
+		channel = pickWeightedChannel(candidateChannels[endIdx:])
+		if channel == nil {
+			channel = candidateChannels[random.RandRange(endIdx, len(candidateChannels))]
+		}
 	} else {
-		idx = rand.Intn(endIdx)
-		if ignoreFirstPriority {
-			// All channels have the same highest priority, or only one priority level exists.
-			// If ignoreFirstPriority is true, and we only have one priority level,
-			// it means we cannot satisfy "ignoreFirstPriority".
-			// This case might indicate no lower-priority channels exist.
-			// Depending on desired behavior, could return error or pick from existing.
-			// For now, let's assume it means "pick any if only one priority level".
-			// If truly no other channel to pick, the random selection will pick from current set.
-			// This part of logic might need refinement based on precise meaning of ignoreFirstPriority
-			// when only one priority tier exists.
-			// The original code implies if endIdx == len(channels), it picks from 0 to endIdx-1.
-			// If endIdx < len(channels), it picks from endIdx to len(channels)-1.
-			// So if ignoreFirstPriority is true and all are same priority, it will still pick from them.
-			// This seems okay.
+		channel = pickWeightedChannel(candidateChannels[:endIdx])
+		if channel == nil {
+			channel = candidateChannels[rand.Intn(endIdx)]
 		}
 	}
-	channel := candidateChannels[idx]
 	logger.Logger.Info("select channel in cache", channel.Ref().Zap()...)
 	return channel, nil
 }
@@ -619,8 +609,10 @@ func CacheGetRandomSatisfiedChannelExcluding(group string, model string, ignoreF
 
 		// If there are lower priority channels available, select from them
 		if endIdx < len(candidateChannels) {
-			idx := random.RandRange(endIdx, len(candidateChannels))
-			channel := candidateChannels[idx]
+			channel := pickWeightedChannel(candidateChannels[endIdx:])
+			if channel == nil {
+				channel = candidateChannels[random.RandRange(endIdx, len(candidateChannels))]
+			}
 			logger.Logger.Info("select channel in cache", channel.Ref().Zap()...)
 			return channel, nil
 		} else {
@@ -655,9 +647,39 @@ func CacheGetRandomSatisfiedChannelExcluding(group string, model string, ignoreF
 			return nil, errors.New("no channels with maximum priority available")
 		}
 
-		idx := rand.Intn(len(maxPriorityChannels))
-		channel := maxPriorityChannels[idx]
+		channel := pickWeightedChannel(maxPriorityChannels)
+		if channel == nil {
+			channel = maxPriorityChannels[rand.Intn(len(maxPriorityChannels))]
+		}
 		logger.Logger.Info("select channel in cache", channel.Ref().Zap()...)
 		return channel, nil
 	}
+}
+
+// pickWeightedChannel selects a channel using weighted random.
+// When all weights are zero it returns nil so the caller can fall back to uniform random.
+func pickWeightedChannel(channels []*Channel) *Channel {
+	if len(channels) == 0 {
+		return nil
+	}
+
+	var totalWeight uint
+	for _, ch := range channels {
+		totalWeight += ch.GetWeight()
+	}
+
+	if totalWeight == 0 {
+		return nil // signal caller to use uniform random
+	}
+
+	r := rand.Intn(int(totalWeight))
+	var cumulative uint
+	for _, ch := range channels {
+		cumulative += ch.GetWeight()
+		if uint(r) < cumulative {
+			return ch
+		}
+	}
+
+	return channels[len(channels)-1]
 }

--- a/model/cache.go
+++ b/model/cache.go
@@ -663,20 +663,21 @@ func pickWeightedChannel(channels []*Channel) *Channel {
 		return nil
 	}
 
-	var totalWeight uint
+	// Use int64 to avoid overflow when converting to rand.Int63n's argument.
+	var totalWeight int64
 	for _, ch := range channels {
-		totalWeight += ch.GetWeight()
+		totalWeight += int64(ch.GetWeight())
 	}
 
 	if totalWeight == 0 {
 		return nil // signal caller to use uniform random
 	}
 
-	r := rand.Intn(int(totalWeight))
-	var cumulative uint
+	r := rand.Int63n(totalWeight)
+	var cumulative int64
 	for _, ch := range channels {
-		cumulative += ch.GetWeight()
-		if uint(r) < cumulative {
+		cumulative += int64(ch.GetWeight())
+		if r < cumulative {
 			return ch
 		}
 	}

--- a/model/channel.go
+++ b/model/channel.go
@@ -257,6 +257,13 @@ func (channel *Channel) GetPriority() int64 {
 	return *channel.Priority
 }
 
+func (channel *Channel) GetWeight() uint {
+	if channel.Weight == nil {
+		return 0
+	}
+	return *channel.Weight
+}
+
 func (channel *Channel) GetBaseURL() string {
 	if channel.BaseURL == nil {
 		return ""

--- a/model/main.go
+++ b/model/main.go
@@ -298,6 +298,11 @@ func initPrimaryDatabase() error {
 		return errors.Wrap(err, "migrate user_request_costs unique index")
 	}
 
+	// 2f) Backfill abilities.weight from channels.weight
+	if err = MigrateAbilityWeightBackfill(); err != nil {
+		return errors.Wrap(err, "backfill ability weights")
+	}
+
 	// STEP 3: Data-format migrations (schema is already correct at this point).
 	if err = MigrateCustomChannelsToOpenAICompatible(); err != nil {
 		return errors.Wrap(err, "migrate custom channels")


### PR DESCRIPTION
## Problem

Channel weight configured in the web UI was stored in `channels.weight` but never synced to the `abilities` table — which is what channel selection / load balancing actually reads. All four selection paths used uniform random within a priority tier, ignoring weight entirely.

## Changes

- Added `Weight` field to `Ability` struct (AutoMigrate adds the column)
- Copy `channel.Weight` → `ability.Weight` in `addAbilitiesWithDB()`
- Weighted random selection in all four paths (DB/cache × normal/excluding)
- `selectAbilityByWeight()` for DB path, `pickWeightedChannel()` for cache path
- Fallback to uniform random when all weights are zero (backward compatible)
- Startup migration backfills NULL weights from channels table
- Uses `int64` + `rand.Int63n` to prevent integer overflow
- Ensures non-nil weight on insert via `GetWeight()`

## Behavior

- **Priority still rules**: higher priority always beats lower
- **Weight splits within same priority**: weight 7 vs weight 3 → 70/30 split
- **All weights 0**: uniform random (no change from current behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel selection now supports weighted random routing, allowing higher-weight channels to be selected more frequently.
  * Weighted selection is applied consistently across cached and database-backed routing, including exclusion-based selection.
  * Channels without configured weights continue to use uniform random selection.
* **Bug Fixes**
  * Existing ability weights are automatically populated from channel weights during startup, improving consistency for previously stored data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->