### PR TITLE
feat(groq): refresh model catalog and metadata

### DIFF
--- a/relay/adaptor/groq/adaptor.go
+++ b/relay/adaptor/groq/adaptor.go
@@ -32,7 +32,7 @@ func (a *Adaptor) GetChannelName() string {
 }
 
 func (a *Adaptor) GetModelList() []string {
-	return adaptor.GetModelListFromPricing(ModelRatios)
+	return slices.Clone(ModelList)
 }
 
 // GetDefaultModelPricing returns the pricing information for Groq models
@@ -109,9 +109,10 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 		promotedEffort = true
 	}
 
-	// Normalize/guard against model-specific reasoning_effort values. GPT-OSS and
-	// MiniMax currently accept low/medium/high, while Qwen 3.6 also accepts
-	// none/default. Unknown models retain the conservative GPT-OSS set.
+	// Normalize/guard against model-specific reasoning_effort values. GPT-OSS
+	// models advertise low/medium/high, Qwen 3.6 advertises none/default, and
+	// known models without a published effort vocabulary drop the field.
+	// Unknown custom models retain the conservative GPT-OSS set.
 	if request.ReasoningEffort != nil {
 		val := strings.ToLower(strings.TrimSpace(*request.ReasoningEffort))
 		if !groqReasoningEffortAllowed(request.Model, val) {
@@ -161,7 +162,7 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 // published for the requested Groq model. Unknown models use the conservative
 // low/medium/high set to avoid forwarding provider-specific values blindly.
 func groqReasoningEffortAllowed(modelName, effort string) bool {
-	if config, ok := ModelRatios[modelName]; ok && len(config.SupportedReasoningEfforts) > 0 {
+	if config, ok := ModelRatios[modelName]; ok {
 		for _, supported := range config.SupportedReasoningEfforts {
 			if effort == strings.ToLower(strings.TrimSpace(supported)) {
 				return true

--- a/relay/adaptor/groq/adaptor_test.go
+++ b/relay/adaptor/groq/adaptor_test.go
@@ -70,14 +70,40 @@ func TestGetRequestURL(t *testing.T) {
 	}
 }
 
-func TestGetModelListIncludesCurrentPreviewModel(t *testing.T) {
+func TestGetModelListMatchesCurrentCatalog(t *testing.T) {
 	t.Parallel()
 
+	want := []string{
+		"openai/gpt-oss-120b",
+		"openai/gpt-oss-20b",
+		"whisper-large-v3",
+		"whisper-large-v3-turbo",
+		"groq/compound",
+		"groq/compound-mini",
+		"canopylabs/orpheus-arabic-saudi",
+		"canopylabs/orpheus-v1-english",
+		"meta-llama/llama-prompt-guard-2-22m",
+		"meta-llama/llama-prompt-guard-2-86m",
+		"minimaxai/minimax-m2.7",
+		"openai/gpt-oss-safeguard-20b",
+		"qwen/qwen3.6-27b",
+	}
+
 	models := (&Adaptor{}).GetModelList()
-	require.Contains(t, models, "minimaxai/minimax-m2.7")
-	require.Contains(t, models, "qwen/qwen3.6-27b")
-	// Retired IDs remain available for existing channels and billing continuity.
-	require.Contains(t, models, "qwen/qwen3-32b")
+	require.ElementsMatch(t, want, models)
+	require.Len(t, models, len(want))
+
+	// Retired IDs keep pricing metadata for enterprise and billing compatibility
+	// but are no longer advertised in the public Groq model list.
+	for _, retired := range []string{
+		"llama-3.1-8b-instant",
+		"llama-3.3-70b-versatile",
+		"meta-llama/llama-4-scout-17b-16e-instruct",
+		"qwen/qwen3-32b",
+	} {
+		require.NotContains(t, models, retired)
+		require.Contains(t, ModelRatios, retired)
+	}
 }
 
 func TestConvertRequest_DropsReasoningFields(t *testing.T) {
@@ -112,11 +138,17 @@ func TestConvertRequest_DropsReasoningFields(t *testing.T) {
 func TestGroqReasoningEffortAllowedIsModelSpecific(t *testing.T) {
 	t.Parallel()
 
-	for _, effort := range []string{"none", "default", "low", "medium", "high"} {
+	for _, effort := range []string{"none", "default"} {
 		require.True(t, groqReasoningEffortAllowed("qwen/qwen3.6-27b", effort), "Qwen 3.6 should accept %q", effort)
 	}
+	for _, effort := range []string{"low", "medium", "high"} {
+		require.False(t, groqReasoningEffortAllowed("qwen/qwen3.6-27b", effort), "Qwen 3.6 should reject %q", effort)
+	}
+
 	require.False(t, groqReasoningEffortAllowed("openai/gpt-oss-120b", "none"))
 	require.True(t, groqReasoningEffortAllowed("openai/gpt-oss-120b", "high"))
+	require.True(t, groqReasoningEffortAllowed("openai/gpt-oss-safeguard-20b", "low"))
+	require.False(t, groqReasoningEffortAllowed("minimaxai/minimax-m2.7", "high"))
 	require.False(t, groqReasoningEffortAllowed("unknown-model", "minimal"))
 }
 
@@ -127,12 +159,15 @@ func TestCurrentGroqModelMetadata(t *testing.T) {
 	require.True(t, ok)
 	require.EqualValues(t, 16_384, qwen.MaxOutputTokens)
 	require.EqualValues(t, 131_072, qwen.ContextLength)
+	require.Equal(t, []string{"none", "default"}, qwen.SupportedReasoningEfforts)
 
 	minimax, ok := ModelRatios["minimaxai/minimax-m2.7"]
 	require.True(t, ok)
 	require.EqualValues(t, 196_608, minimax.ContextLength)
 	require.EqualValues(t, 131_072, minimax.MaxOutputTokens)
 	require.Zero(t, minimax.Ratio, "contact-sales models must not use a guessed token price")
+	require.Empty(t, minimax.SupportedReasoningEfforts)
+	require.NotContains(t, minimax.SupportedFeatures, "structured_outputs")
 
 	compound, ok := ModelRatios["groq/compound"]
 	require.True(t, ok)

--- a/relay/adaptor/groq/constants.go
+++ b/relay/adaptor/groq/constants.go
@@ -10,8 +10,11 @@ import (
 // quantization label, so the Quantization field is intentionally left empty
 // (omitempty) for those models.
 //
-// Sources (last audited 2026-08-13):
+// Sources (last audited 2026-08-18):
 //   - https://console.groq.com/docs/models
+//   - https://console.groq.com/docs/deprecations
+//   - https://console.groq.com/docs/reasoning
+//   - https://console.groq.com/docs/prompt-caching
 //   - https://console.groq.com/docs/agentic-tooling
 //   - Per-model pages under https://console.groq.com/docs/model/<id>
 var (
@@ -55,17 +58,29 @@ var (
 		"reasoning_effort",
 	}
 
+	// groqReasoningNoEffortSamplingParams is used by reasoning models for
+	// which Groq does not publish a discrete reasoning_effort vocabulary.
+	groqReasoningNoEffortSamplingParams = []string{
+		"max_tokens",
+		"stop",
+		"seed",
+		"response_format",
+		"tools",
+		"tool_choice",
+	}
+
 	// groqClassifierSamplingParams covers the minimal parameter set for
 	// classifier-style guard models that emit a fixed label set.
 	groqClassifierSamplingParams = []string{"max_tokens", "seed"}
 )
 
-// ModelRatios contains all supported models and their pricing ratios.
-// Model list is derived from the keys of this map, eliminating redundancy.
-// Pricing source: https://console.groq.com/docs/models
-// Capability source: https://console.groq.com/docs/models
+// ModelRatios contains the current Groq catalog plus retired model IDs kept
+// for enterprise committed-spend compatibility and historical billing.
+// The public model list is intentionally maintained separately below.
+// Pricing and capability source: https://console.groq.com/docs/models
 var ModelRatios = map[string]adaptor.ModelConfig{
-	// Production Models
+	// Retired production IDs. Groq removed these from free and developer plans
+	// on 2026-08-16; committed-spend enterprise access may continue.
 	"llama-3.3-70b-versatile": {
 		Ratio:                       0.59 * ratio.MilliTokensUsd,
 		CompletionRatio:             0.79 / 0.59,
@@ -76,7 +91,7 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		SupportedFeatures:           []string{"tools", "json_mode", "structured_outputs"},
 		SupportedSamplingParameters: groqChatSamplingParams,
 		HuggingFaceID:               "meta-llama/Llama-3.3-70B-Instruct",
-		Description:                 "Meta's 70B Llama 3.3 instruct model served on Groq's LPU with 131K context and tool/JSON support. DEPRECATED: Groq is shutting down this model on 2026-08-16; migrate to openai/gpt-oss-120b or qwen/qwen3.6-27b. Source: https://console.groq.com/docs/deprecations",
+		Description:                 "Meta's 70B Llama 3.3 instruct model served on Groq's LPU with 131K context and tool/JSON support. RETIRED from free and developer plans on 2026-08-16; committed-spend enterprise access may continue. Migrate to openai/gpt-oss-120b or qwen/qwen3.6-27b.",
 	},
 	"llama-3.1-8b-instant": {
 		Ratio:                       0.05 * ratio.MilliTokensUsd,
@@ -88,8 +103,9 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		SupportedFeatures:           []string{"tools", "json_mode", "structured_outputs"},
 		SupportedSamplingParameters: groqChatSamplingParams,
 		HuggingFaceID:               "meta-llama/Llama-3.1-8B-Instruct",
-		Description:                 "Meta's compact 8B Llama 3.1 instruct model with 131K context, optimized for low-latency chat. DEPRECATED: Groq is shutting down this model on 2026-08-16; migrate to openai/gpt-oss-20b. Source: https://console.groq.com/docs/deprecations",
+		Description:                 "Meta's compact 8B Llama 3.1 instruct model with 131K context, optimized for low-latency chat. RETIRED from free and developer plans on 2026-08-16; committed-spend enterprise access may continue. Migrate to openai/gpt-oss-20b.",
 	},
+	// Current production models.
 	"whisper-large-v3": {
 		Ratio:                       0,
 		CompletionRatio:             1,
@@ -149,7 +165,8 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		Description:               "OpenAI's 20B open-weight MoE reasoning model with browser search and code execution support.",
 	},
 
-	// Preview Models
+	// Retired preview ID. Groq removed it from free and developer plans on
+	// 2026-07-17; committed-spend enterprise access may continue.
 	"meta-llama/llama-4-scout-17b-16e-instruct": {
 		Ratio:                       0.11 * ratio.MilliTokensUsd,
 		CompletionRatio:             0.34 / 0.11,
@@ -160,8 +177,9 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		SupportedFeatures:           []string{"tools", "json_mode", "structured_outputs"},
 		SupportedSamplingParameters: groqChatSamplingParams,
 		HuggingFaceID:               "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-		Description:                 "Meta Llama 4 Scout (17B activated MoE) multimodal model with early-fusion image understanding. DEPRECATED: Groq is shutting down this model on 2026-07-17; migrate to openai/gpt-oss-120b or qwen/qwen3.6-27b. Source: https://console.groq.com/docs/deprecations",
+		Description:                 "Meta Llama 4 Scout (17B activated MoE) multimodal model with early-fusion image understanding. RETIRED from free and developer plans on 2026-07-17; committed-spend enterprise access may continue. Migrate to openai/gpt-oss-120b or qwen/qwen3.6-27b.",
 	},
+	// Current preview models.
 	"meta-llama/llama-prompt-guard-2-22m": {
 		Ratio:                       0.03 * ratio.MilliTokensUsd,
 		CompletionRatio:             1,
@@ -186,19 +204,21 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 	},
 	"openai/gpt-oss-safeguard-20b": {
 		Ratio:                       0.075 * ratio.MilliTokensUsd,
+		CachedInputRatio:            0.0375 * ratio.MilliTokensUsd,
 		CompletionRatio:             0.30 / 0.075,
 		ContextLength:               131072,
 		MaxOutputTokens:             65536,
 		InputModalities:             groqTextOnlyModalities,
 		OutputModalities:            groqTextOnlyModalities,
-		SupportedFeatures:           []string{"tools", "json_mode", "structured_outputs", "reasoning"},
+		SupportedFeatures:           []string{"tools", "json_mode", "structured_outputs", "reasoning", "web_search"},
 		SupportedSamplingParameters: groqReasoningSamplingParams,
-		// Inherits the gpt-oss reasoning_effort surface (low/medium/high).
-		// Source: https://console.groq.com/docs/reasoning
+		// The safeguard model card recommends low/high effort for simple versus
+		// nuanced classifications.
+		// Source: https://console.groq.com/docs/model/openai/gpt-oss-safeguard-20b
 		SupportedReasoningEfforts: []string{"low", "medium", "high"},
 		DefaultReasoningEffort:    "medium",
 		HuggingFaceID:             "openai/gpt-oss-safeguard-20b",
-		Description:               "20B GPT-OSS variant fine-tuned for policy-following safety classification with custom taxonomies.",
+		Description:               "20B GPT-OSS variant for policy-following safety classification with custom taxonomies, prompt caching, browser search, and code execution.",
 	},
 	"qwen/qwen3-32b": {
 		Ratio:                       0.29 * ratio.MilliTokensUsd,
@@ -209,12 +229,12 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		OutputModalities:            groqTextOnlyModalities,
 		SupportedFeatures:           []string{"tools", "json_mode", "structured_outputs", "reasoning"},
 		SupportedSamplingParameters: groqReasoningSamplingParams,
-		// Groq's qwen3 reasoning docs enumerate none/default (null also reasons by default).
-		// Source: https://console.groq.com/docs/model/openai/gpt-oss-safeguard-20b
+		// Groq's legacy Qwen3 reasoning docs enumerate none/default.
+		// Source: https://console.groq.com/docs/reasoning
 		SupportedReasoningEfforts: []string{"none", "default"},
 		DefaultReasoningEffort:    "default",
 		HuggingFaceID:             "Qwen/Qwen3-32B",
-		Description:               "Alibaba Qwen3-32B with switchable thinking/non-thinking modes for reasoning and general dialog. DEPRECATED: Groq is shutting down this model on 2026-07-17; migrate to openai/gpt-oss-120b. Source: https://console.groq.com/docs/deprecations",
+		Description:               "Alibaba Qwen3-32B with switchable thinking/non-thinking modes for reasoning and general dialog. RETIRED from free and developer plans on 2026-07-17; committed-spend enterprise access may continue. Migrate to openai/gpt-oss-120b.",
 	},
 	"qwen/qwen3.6-27b": {
 		Ratio:                       0.60 * ratio.MilliTokensUsd,
@@ -225,9 +245,9 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		OutputModalities:            groqTextOnlyModalities,
 		SupportedFeatures:           []string{"tools", "json_mode", "reasoning"},
 		SupportedSamplingParameters: groqReasoningSamplingParams,
-		// Groq's Qwen 3.6 API accepts none/default plus low/medium/high.
-		// Source: https://console.groq.com/docs/model/qwen/qwen3.6-27b
-		SupportedReasoningEfforts: []string{"none", "default", "low", "medium", "high"},
+		// Groq publishes only none/default for Qwen 3.6 reasoning_effort.
+		// Source: https://console.groq.com/docs/reasoning
+		SupportedReasoningEfforts: []string{"none", "default"},
 		DefaultReasoningEffort:    "default",
 		HuggingFaceID:             "Qwen/Qwen3.6-27B",
 		Description:               "Alibaba Qwen3.6-27B multimodal model (text + image input) with switchable thinking/non-thinking modes via reasoning_effort.",
@@ -239,14 +259,12 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		MaxOutputTokens:             131072,
 		InputModalities:             groqTextOnlyModalities,
 		OutputModalities:            groqTextOnlyModalities,
-		SupportedFeatures:           []string{"tools", "json_mode", "structured_outputs", "reasoning"},
-		SupportedSamplingParameters: groqReasoningSamplingParams,
-		SupportedReasoningEfforts:   []string{"low", "medium", "high"},
-		DefaultReasoningEffort:      "medium",
-		Description:                 "MiniMax M2.7 enterprise preview model with 196K context and 131K maximum output. Pricing is contact-sales only.",
+		SupportedFeatures:           []string{"tools", "json_mode", "reasoning"},
+		SupportedSamplingParameters: groqReasoningNoEffortSamplingParams,
+		Description:                 "MiniMax M2.7 enterprise preview reasoning model with 196K context and 131K maximum output. Pricing is contact-sales only.",
 	},
 
-	// New Models (Jan 2026)
+	// Current preview text-to-speech models.
 	"canopylabs/orpheus-arabic-saudi": {
 		Ratio:            40.0 * ratio.MilliTokensUsd, // per 1M characters
 		CompletionRatio:  1,
@@ -266,6 +284,7 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 		HuggingFaceID:    "canopylabs/orpheus-3b-0.1-ft",
 		Description:      "Canopy Labs Orpheus v1 English text-to-speech (Llama-3.2-3B backbone) with bracketed vocal direction tags.",
 	},
+	// Current production systems.
 	"groq/compound": {
 		Ratio:                       0,
 		CompletionRatio:             1,
@@ -290,8 +309,22 @@ var ModelRatios = map[string]adaptor.ModelConfig{
 	},
 }
 
-// ModelList derived from ModelRatios for backward compatibility.
-var ModelList = adaptor.GetModelListFromPricing(ModelRatios)
+// ModelList mirrors the active model IDs published by Groq on 2026-08-18.
+var ModelList = []string{
+	"openai/gpt-oss-120b",
+	"openai/gpt-oss-20b",
+	"whisper-large-v3",
+	"whisper-large-v3-turbo",
+	"groq/compound",
+	"groq/compound-mini",
+	"canopylabs/orpheus-arabic-saudi",
+	"canopylabs/orpheus-v1-english",
+	"meta-llama/llama-prompt-guard-2-22m",
+	"meta-llama/llama-prompt-guard-2-86m",
+	"minimaxai/minimax-m2.7",
+	"openai/gpt-oss-safeguard-20b",
+	"qwen/qwen3.6-27b",
+}
 
 // GroqToolingDefaults records no fixed tool tariff because the current Groq
 // documentation lists the available Compound tools but does not publish a

--- a/relay/adaptor/groq/models_catalog_test.go
+++ b/relay/adaptor/groq/models_catalog_test.go
@@ -1,0 +1,107 @@
+package groq
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+func TestCurrentGroqTokenPricing(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		inputUSDPerMillion  float64
+		cachedUSDPerMillion float64
+		outputUSDPerMillion float64
+		contextLength       int32
+		maxOutputTokens     int32
+	}{
+		"openai/gpt-oss-120b": {
+			inputUSDPerMillion:  0.15,
+			cachedUSDPerMillion: 0.075,
+			outputUSDPerMillion: 0.60,
+			contextLength:       131_072,
+			maxOutputTokens:     65_536,
+		},
+		"openai/gpt-oss-20b": {
+			inputUSDPerMillion:  0.075,
+			cachedUSDPerMillion: 0.0375,
+			outputUSDPerMillion: 0.30,
+			contextLength:       131_072,
+			maxOutputTokens:     65_536,
+		},
+		"meta-llama/llama-prompt-guard-2-22m": {
+			inputUSDPerMillion:  0.03,
+			outputUSDPerMillion: 0.03,
+			contextLength:       512,
+			maxOutputTokens:     512,
+		},
+		"meta-llama/llama-prompt-guard-2-86m": {
+			inputUSDPerMillion:  0.04,
+			outputUSDPerMillion: 0.04,
+			contextLength:       512,
+			maxOutputTokens:     512,
+		},
+		"openai/gpt-oss-safeguard-20b": {
+			inputUSDPerMillion:  0.075,
+			cachedUSDPerMillion: 0.0375,
+			outputUSDPerMillion: 0.30,
+			contextLength:       131_072,
+			maxOutputTokens:     65_536,
+		},
+		"qwen/qwen3.6-27b": {
+			inputUSDPerMillion:  0.60,
+			outputUSDPerMillion: 3.00,
+			contextLength:       131_072,
+			maxOutputTokens:     16_384,
+		},
+	}
+
+	for modelID, want := range tests {
+		modelID, want := modelID, want
+		t.Run(modelID, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := ModelRatios[modelID]
+			require.True(t, ok)
+			require.InDelta(t, want.inputUSDPerMillion, got.Ratio/ratio.MilliTokensUsd, 1e-12)
+			require.InDelta(t, want.cachedUSDPerMillion, got.CachedInputRatio/ratio.MilliTokensUsd, 1e-12)
+			require.InDelta(t, want.outputUSDPerMillion, got.Ratio*got.CompletionRatio/ratio.MilliTokensUsd, 1e-12)
+			require.Equal(t, want.contextLength, got.ContextLength)
+			require.Equal(t, want.maxOutputTokens, got.MaxOutputTokens)
+			require.NotEmpty(t, got.Description)
+		})
+	}
+}
+
+func TestCurrentGroqNonTokenPricing(t *testing.T) {
+	t.Parallel()
+
+	whisper, ok := ModelRatios["whisper-large-v3"]
+	require.True(t, ok)
+	require.NotNil(t, whisper.Audio)
+	require.InDelta(t, 0.111/3600, whisper.Audio.UsdPerSecond, 1e-12)
+
+	whisperTurbo, ok := ModelRatios["whisper-large-v3-turbo"]
+	require.True(t, ok)
+	require.NotNil(t, whisperTurbo.Audio)
+	require.InDelta(t, 0.04/3600, whisperTurbo.Audio.UsdPerSecond, 1e-12)
+
+	require.InDelta(t, 40.0, ModelRatios["canopylabs/orpheus-arabic-saudi"].Ratio/ratio.MilliTokensUsd, 1e-12)
+	require.InDelta(t, 22.0, ModelRatios["canopylabs/orpheus-v1-english"].Ratio/ratio.MilliTokensUsd, 1e-12)
+
+	for _, modelID := range []string{"groq/compound", "groq/compound-mini", "minimaxai/minimax-m2.7"} {
+		require.Zero(t, ModelRatios[modelID].Ratio)
+	}
+}
+
+func TestSafeguardCapabilities(t *testing.T) {
+	t.Parallel()
+
+	safeguard := ModelRatios["openai/gpt-oss-safeguard-20b"]
+	require.Contains(t, safeguard.SupportedFeatures, "web_search")
+	require.Contains(t, safeguard.SupportedFeatures, "structured_outputs")
+	require.Equal(t, []string{"low", "medium", "high"}, safeguard.SupportedReasoningEfforts)
+}

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -74,9 +74,10 @@ type GeneralOpenAIRequest struct {
 	N *int `json:"n,omitempty" binding:"omitempty,min=0"`
 	// ReasoningEffort constrains effort on reasoning for reasoning models, reasoning models only.
 	// The binding is the union of effort vocabularies across providers; per-model
-	// validation narrows it downstream (e.g. the GPT-5.6 family adds "xhigh"/"max",
-	// grok/gemini use "none", GPT-5 advertises the legacy "minimal" alias).
-	ReasoningEffort *string `json:"reasoning_effort,omitempty" binding:"omitempty,oneof=none minimal low medium high xhigh max"`
+	// validation narrows it downstream (e.g. Qwen uses "default", the GPT-5.6
+	// family adds "xhigh"/"max", grok/gemini use "none", and GPT-5 advertises
+	// the legacy "minimal" alias).
+	ReasoningEffort *string `json:"reasoning_effort,omitempty" binding:"omitempty,oneof=none default minimal low medium high xhigh max"`
 	// Verbosity hints the model to be more or less expansive in its replies (GPT-5 series).
 	// Supported values: low, medium, high
 	Verbosity *string `json:"verbosity,omitempty" binding:"omitempty,oneof=low medium high"`
@@ -85,7 +86,8 @@ type GeneralOpenAIRequest struct {
 	Prediction any      `json:"prediction,omitempty"`
 	Audio      *Audio   `json:"audio,omitempty"`
 	// PresencePenalty is a number between -2.0 and 2.0 that penalizes
-	// new tokens based on whether they appear in the text so far, default is 0.
+	// new tokens based on whether they appear in the text so far,
+	// default is 0.
 	PresencePenalty  *float64        `json:"presence_penalty,omitempty" binding:"omitempty,min=-2,max=2"`
 	ResponseFormat   *ResponseFormat `json:"response_format,omitempty"`
 	Seed             float64         `json:"seed,omitempty"`
@@ -135,9 +137,9 @@ type GeneralOpenAIRequest struct {
 
 type OpenAIResponseReasoning struct {
 	// Effort defines the reasoning effort level. The binding is the union across
-	// providers; per-model validation narrows it downstream (the GPT-5.6 family
-	// adds "xhigh"/"max").
-	Effort *string `json:"effort,omitempty" binding:"omitempty,oneof=none minimal low medium high xhigh max"`
+	// providers; per-model validation narrows it downstream (Qwen uses
+	// "default", while the GPT-5.6 family adds "xhigh"/"max").
+	Effort *string `json:"effort,omitempty" binding:"omitempty,oneof=none default minimal low medium high xhigh max"`
 	// Summary defines whether to include a summary of the reasoning
 	Summary *string `json:"summary,omitempty" binding:"omitempty,oneof=auto concise detailed"`
 }

--- a/relay/model/general_reasoning_test.go
+++ b/relay/model/general_reasoning_test.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin/binding"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReasoningEffortBindingAcceptsDefault(t *testing.T) {
+	t.Parallel()
+
+	effort := "default"
+	require.NoError(t, binding.Validator.ValidateStruct(&GeneralOpenAIRequest{
+		ReasoningEffort: &effort,
+	}))
+	require.NoError(t, binding.Validator.ValidateStruct(&OpenAIResponseReasoning{
+		Effort: &effort,
+	}))
+}
+
+func TestReasoningEffortBindingRejectsUnknownValue(t *testing.T) {
+	t.Parallel()
+
+	effort := "unexpected"
+	require.Error(t, binding.Validator.ValidateStruct(&GeneralOpenAIRequest{
+		ReasoningEffort: &effort,
+	}))
+	require.Error(t, binding.Validator.ValidateStruct(&OpenAIResponseReasoning{
+		Effort: &effort,
+	}))
+}


### PR DESCRIPTION
## Summary

Refresh the Groq adapter against the official model catalog and model cards audited on 2026-08-18.

- Advertise the 13 model IDs currently published by Groq.
- Stop advertising four retired free/developer-plan IDs while retaining their pricing metadata for committed-spend enterprise compatibility and historical billing.
- Correct Qwen 3.6 reasoning metadata to the published `none` / `default` vocabulary.
- Remove unpublished discrete reasoning-effort levels and JSON Schema capability from MiniMax M2.7.
- Add GPT-OSS Safeguard cached-input pricing and web-search metadata.
- Allow the provider-standard `reasoning_effort: "default"` value in shared request validation.
- Add regression coverage for the active catalog, pricing, context/output limits, non-token rates, capabilities, and reasoning validation.

## Compatibility

Retired model IDs remain in `ModelRatios`, so explicitly configured committed-spend enterprise channels and historical billing records continue to resolve. `GetModelList()` now returns only the current public Groq catalog and clones the slice to prevent caller mutation.

## Official sources

- https://console.groq.com/docs/models
- https://console.groq.com/docs/deprecations
- https://console.groq.com/docs/reasoning
- https://console.groq.com/docs/prompt-caching
- https://console.groq.com/docs/model/qwen/qwen3.6-27b
- https://console.groq.com/docs/model/minimaxai/minimax-m2.7
- https://console.groq.com/docs/model/openai/gpt-oss-safeguard-20b

## Validation

- `gofmt` applied to all changed Go files.
- GitHub `pr-check` runs `go vet ./...` followed by `go test -race -v ./...` with the repository's MySQL/PostgreSQL services.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `default` reasoning-effort value.
  * Updated the Groq model catalog with current models, pricing, capabilities, and model-specific reasoning options.
  * Improved metadata for Qwen, MiniMax, safeguard, and structured-output models.

* **Bug Fixes**
  * Retired Groq models are no longer shown in active model listings.
  * Known models without supported reasoning-effort options now reject unsupported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->