### PR TITLE
⚡ Bolt: reduce request hot-path allocations

### DIFF
--- a/common/logging_sanitize.go
+++ b/common/logging_sanitize.go
@@ -35,6 +35,12 @@ func SanitizeURLForLogging(rawURL string) string {
 		return rawURL
 	}
 
+	// Most API request URLs have no query string. Avoid net/url parsing and its
+	// query-map allocations when there is nothing that could require redaction.
+	if !strings.Contains(rawURL, "?") {
+		return rawURL
+	}
+
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return rawURL

--- a/common/logging_sanitize_benchmark_test.go
+++ b/common/logging_sanitize_benchmark_test.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeURLForLoggingFastPathBehavior(t *testing.T) {
+	t.Parallel()
+	tests := []string{
+		"",
+		"/v1/chat/completions",
+		"/v1/chat/completions#fragment",
+		"https://example.com/v1/responses",
+		"https://example.com/v1/messages?stream=true&foo=bar",
+	}
+
+	for _, rawURL := range tests {
+		t.Run(rawURL, func(t *testing.T) {
+			require.Equal(t, rawURL, SanitizeURLForLogging(rawURL))
+		})
+	}
+}
+
+func BenchmarkSanitizeURLForLoggingNoQuery(b *testing.B) {
+	const rawURL = "/v1/chat/completions"
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = SanitizeURLForLogging(rawURL)
+	}
+}
+
+func BenchmarkSanitizeURLForLoggingPublicQuery(b *testing.B) {
+	const rawURL = "/v1/chat/completions?stream=true&foo=bar"
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = SanitizeURLForLogging(rawURL)
+	}
+}
+
+// TestBoltURLBenchmark is temporary instrumentation used to capture the
+// baseline and optimized results in the same PR CI environment.
+func TestBoltURLBenchmark(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func(*testing.B)
+	}{
+		{name: "no_query", fn: BenchmarkSanitizeURLForLoggingNoQuery},
+		{name: "public_query", fn: BenchmarkSanitizeURLForLoggingPublicQuery},
+	} {
+		result := testing.Benchmark(tc.fn)
+		t.Logf("BOLT_BENCH logging/%s: %d ns/op, %d B/op, %d allocs/op", tc.name, result.NsPerOp(), result.AllocedBytesPerOp(), result.AllocsPerOp())
+	}
+}

--- a/common/logging_sanitize_benchmark_test.go
+++ b/common/logging_sanitize_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSanitizeURLForLoggingFastPathBehavior verifies the optimized sanitizer returns exactly the legacy output.
 func TestSanitizeURLForLoggingFastPathBehavior(t *testing.T) {
 	t.Parallel()
 	tests := []string{
@@ -25,6 +26,7 @@ func TestSanitizeURLForLoggingFastPathBehavior(t *testing.T) {
 	}
 }
 
+// sanitizeURLForLoggingLegacy preserves the pre-optimization implementation for side-by-side behavior and benchmarks.
 func sanitizeURLForLoggingLegacy(rawURL string) string {
 	if rawURL == "" {
 		return rawURL
@@ -51,6 +53,7 @@ func sanitizeURLForLoggingLegacy(rawURL string) string {
 	return parsed.String()
 }
 
+// BenchmarkSanitizeURLForLoggingNoQuery compares legacy and optimized handling of the common query-free request URL.
 func BenchmarkSanitizeURLForLoggingNoQuery(b *testing.B) {
 	const rawURL = "/v1/chat/completions"
 	b.Run("legacy", func(b *testing.B) {
@@ -67,6 +70,7 @@ func BenchmarkSanitizeURLForLoggingNoQuery(b *testing.B) {
 	})
 }
 
+// BenchmarkSanitizeURLForLoggingSensitiveQuery verifies the redaction path keeps comparable cost and allocations.
 func BenchmarkSanitizeURLForLoggingSensitiveQuery(b *testing.B) {
 	const rawURL = "/api/user/register?turnstile=secret-token&page=1&api_key=secret-key"
 	b.Run("legacy", func(b *testing.B) {

--- a/common/logging_sanitize_benchmark_test.go
+++ b/common/logging_sanitize_benchmark_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,43 +14,71 @@ func TestSanitizeURLForLoggingFastPathBehavior(t *testing.T) {
 		"/v1/chat/completions",
 		"/v1/chat/completions#fragment",
 		"https://example.com/v1/responses",
+		"%zz",
 		"https://example.com/v1/messages?stream=true&foo=bar",
 	}
 
 	for _, rawURL := range tests {
 		t.Run(rawURL, func(t *testing.T) {
-			require.Equal(t, rawURL, SanitizeURLForLogging(rawURL))
+			require.Equal(t, sanitizeURLForLoggingLegacy(rawURL), SanitizeURLForLogging(rawURL))
 		})
 	}
 }
 
+func sanitizeURLForLoggingLegacy(rawURL string) string {
+	if rawURL == "" {
+		return rawURL
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+
+	query := parsed.Query()
+	changed := false
+	for key := range query {
+		if isSensitiveURLQueryKey(key) {
+			query[key] = []string{"[redacted]"}
+			changed = true
+		}
+	}
+	if !changed {
+		return rawURL
+	}
+
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
 func BenchmarkSanitizeURLForLoggingNoQuery(b *testing.B) {
 	const rawURL = "/v1/chat/completions"
-	b.ReportAllocs()
-	for b.Loop() {
-		_ = SanitizeURLForLogging(rawURL)
-	}
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = sanitizeURLForLoggingLegacy(rawURL)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = SanitizeURLForLogging(rawURL)
+		}
+	})
 }
 
-func BenchmarkSanitizeURLForLoggingPublicQuery(b *testing.B) {
-	const rawURL = "/v1/chat/completions?stream=true&foo=bar"
-	b.ReportAllocs()
-	for b.Loop() {
-		_ = SanitizeURLForLogging(rawURL)
-	}
-}
-
-// TestBoltURLBenchmark is temporary instrumentation used to capture the
-// baseline and optimized results in the same PR CI environment.
-func TestBoltURLBenchmark(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		fn   func(*testing.B)
-	}{
-		{name: "no_query", fn: BenchmarkSanitizeURLForLoggingNoQuery},
-		{name: "public_query", fn: BenchmarkSanitizeURLForLoggingPublicQuery},
-	} {
-		result := testing.Benchmark(tc.fn)
-		t.Logf("BOLT_BENCH logging/%s: %d ns/op, %d B/op, %d allocs/op", tc.name, result.NsPerOp(), result.AllocedBytesPerOp(), result.AllocsPerOp())
-	}
+func BenchmarkSanitizeURLForLoggingSensitiveQuery(b *testing.B) {
+	const rawURL = "/api/user/register?turnstile=secret-token&page=1&api_key=secret-key"
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = sanitizeURLForLoggingLegacy(rawURL)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = SanitizeURLForLogging(rawURL)
+		}
+	})
 }

--- a/relay/format/detect.go
+++ b/relay/format/detect.go
@@ -61,6 +61,10 @@ func (f APIFormat) Endpoint() string {
 // It only parses the fields necessary to distinguish between formats,
 // avoiding the overhead of full request parsing.
 type requestProbe struct {
+	// Model is retained to preserve legacy JSON type validation even though
+	// format detection does not inspect its value.
+	Model string `json:"model,omitempty"`
+
 	// ChatCompletion / Claude Messages indicator
 	Messages json.RawMessage `json:"messages,omitempty"`
 
@@ -83,6 +87,8 @@ type requestProbe struct {
 
 // messageProbe is used to inspect the structure of messages array entries.
 type messageProbe struct {
+	// Role is retained to preserve legacy JSON type validation in the message scan.
+	Role    string          `json:"role,omitempty"`
 	Content json.RawMessage `json:"content,omitempty"`
 }
 

--- a/relay/format/detect.go
+++ b/relay/format/detect.go
@@ -61,8 +61,6 @@ func (f APIFormat) Endpoint() string {
 // It only parses the fields necessary to distinguish between formats,
 // avoiding the overhead of full request parsing.
 type requestProbe struct {
-	// Model is retained to preserve legacy JSON type validation even though
-	// format detection does not inspect its value.
 	Model string `json:"model,omitempty"`
 
 	// ChatCompletion / Claude Messages indicator
@@ -78,6 +76,9 @@ type requestProbe struct {
 	Conversation       json.RawMessage `json:"conversation,omitempty"`
 	Prompt             json.RawMessage `json:"prompt,omitempty"`
 
+	// Claude Messages indicator
+	System any `json:"system,omitempty"`
+
 	// Response API specific
 	MaxOutputTokens *int `json:"max_output_tokens,omitempty"`
 
@@ -87,7 +88,6 @@ type requestProbe struct {
 
 // messageProbe is used to inspect the structure of messages array entries.
 type messageProbe struct {
-	// Role is retained to preserve legacy JSON type validation in the message scan.
 	Role    string          `json:"role,omitempty"`
 	Content json.RawMessage `json:"content,omitempty"`
 }

--- a/relay/format/detect.go
+++ b/relay/format/detect.go
@@ -245,11 +245,11 @@ func isClaudeToolFormat(toolsRaw json.RawMessage) bool {
 			return true
 		}
 
-		// OpenAI tools have type="function" with a nested function object
+		// OpenAI tools have type="function" with a nested function object.
 		if tool.Type == "function" && len(tool.Function) > 0 {
-			// Check if the function has "parameters" (OpenAI) vs "input_schema" (Claude)
+			// Only input_schema affects detection. Skipping parameters avoids copying
+			// potentially large OpenAI JSON schemas into an unused RawMessage.
 			var fnProbe struct {
-				Parameters  json.RawMessage `json:"parameters,omitempty"`
 				InputSchema json.RawMessage `json:"input_schema,omitempty"`
 			}
 			if err := json.Unmarshal(tool.Function, &fnProbe); err == nil {

--- a/relay/format/detect.go
+++ b/relay/format/detect.go
@@ -61,9 +61,6 @@ func (f APIFormat) Endpoint() string {
 // It only parses the fields necessary to distinguish between formats,
 // avoiding the overhead of full request parsing.
 type requestProbe struct {
-	// Common fields
-	Model string `json:"model,omitempty"`
-
 	// ChatCompletion / Claude Messages indicator
 	Messages json.RawMessage `json:"messages,omitempty"`
 
@@ -77,10 +74,6 @@ type requestProbe struct {
 	Conversation       json.RawMessage `json:"conversation,omitempty"`
 	Prompt             json.RawMessage `json:"prompt,omitempty"`
 
-	// Claude-specific indicator: system as a separate top-level field
-	// (OpenAI puts system in messages array, Claude has it as a separate field)
-	System any `json:"system,omitempty"`
-
 	// Response API specific
 	MaxOutputTokens *int `json:"max_output_tokens,omitempty"`
 
@@ -90,7 +83,6 @@ type requestProbe struct {
 
 // messageProbe is used to inspect the structure of messages array entries.
 type messageProbe struct {
-	Role    string          `json:"role,omitempty"`
 	Content json.RawMessage `json:"content,omitempty"`
 }
 
@@ -279,9 +271,15 @@ func hasClaudeContentBlocks(messagesRaw json.RawMessage) bool {
 	}
 
 	for _, msg := range messages {
-		// Check if content is an array (could be Claude structured content)
+		// Claude-specific content blocks can only appear in an array. Most text
+		// messages are JSON strings, so skip the failed array decode on that hot path.
+		content := bytes.TrimSpace(msg.Content)
+		if len(content) == 0 || content[0] != '[' {
+			continue
+		}
+
 		var contentArray []contentBlockProbe
-		if err := json.Unmarshal(msg.Content, &contentArray); err == nil {
+		if err := json.Unmarshal(content, &contentArray); err == nil {
 			for _, block := range contentArray {
 				// Claude-specific content types
 				switch block.Type {

--- a/relay/format/detect_benchmark_test.go
+++ b/relay/format/detect_benchmark_test.go
@@ -117,6 +117,7 @@ func TestDetectFormatScalarContentBehavior(t *testing.T) {
 		{name: "null content", body: `{"messages":[{"role":"assistant","content":null}]}`, want: Unknown},
 		{name: "object content", body: `{"messages":[{"role":"user","content":{"text":"hello"}}]}`, want: Unknown},
 		{name: "claude array content", body: `{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"1"}]}]}`, want: ClaudeMessages},
+		{name: "wrong-type role remains unknown", body: `{"messages":[{"role":1,"content":[{"type":"tool_use","id":"1"}]}]}`, want: Unknown},
 		{name: "large unused fields stay ambiguous", body: string(benchmarkDetectFormatLargeSystem), want: Unknown},
 	}
 
@@ -127,6 +128,13 @@ func TestDetectFormatScalarContentBehavior(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestDetectFormatModelTypeValidation verifies wrong-type model values retain the legacy top-level parse error.
+func TestDetectFormatModelTypeValidation(t *testing.T) {
+	t.Parallel()
+	_, err := DetectFormat([]byte(`{"model":123,"messages":[{"role":"user","content":"hello"}]}`))
+	require.Error(t, err)
 }
 
 // TestHasClaudeContentBlocksBehaviorEquivalent compares the optimized content-block scan against the exact legacy algorithm.
@@ -140,6 +148,7 @@ func TestHasClaudeContentBlocksBehaviorEquivalent(t *testing.T) {
 		json.RawMessage(`[{"role":"assistant","content":[{"type":"tool_use","id":"1"}]}]`),
 		json.RawMessage(`[{"role":"user","content":[{"type":"tool_result","tool_use_id":"1"}]}]`),
 		json.RawMessage(`[{"role":"assistant","content":[{"type":"thinking","thinking":"..."}]}]`),
+		json.RawMessage(`[{"role":1,"content":[{"type":"tool_use","id":"1"}]}]`),
 	}
 
 	for _, raw := range cases {
@@ -179,7 +188,7 @@ func BenchmarkClaudeContentBlockScanPlainText(b *testing.B) {
 	})
 }
 
-// BenchmarkRequestProbeDecodeLargeUnusedFields measures decoding when large top-level fields are irrelevant to format detection.
+// BenchmarkRequestProbeDecodeLargeUnusedFields measures decoding when a large top-level system field is irrelevant to format detection.
 func BenchmarkRequestProbeDecodeLargeUnusedFields(b *testing.B) {
 	b.Run("legacy", func(b *testing.B) {
 		b.ReportAllocs()

--- a/relay/format/detect_benchmark_test.go
+++ b/relay/format/detect_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Laisky/errors/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,17 +26,13 @@ var benchmarkPlainTextMessages = json.RawMessage(`[
 	{"role":"user","content":"Continue with examples"}
 ]`)
 
-var benchmarkDetectFormatLargeSystem = []byte(`{
-	"model":"claude-sonnet-4",
-	"system":[{"type":"text","text":"` + strings.Repeat("A", 4096) + `"}],
-	"messages":[
-		{"role":"user","content":"Explain Kubernetes operators"},
-		{"role":"assistant","content":"Sure."},
-		{"role":"user","content":"Continue with examples"}
-	]
-}`)
-
 var benchmarkOpenAITools = json.RawMessage(`[{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("A", 4096) + `"}}}}}]`)
+
+var benchmarkDetectFormatOpenAITool = []byte(`{
+	"model":"gpt-4.1",
+	"messages":[{"role":"user","content":"look this up"}],
+	"tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("A", 4096) + `"}}}}}]
+}`)
 
 type legacyRequestProbe struct {
 	Model              string          `json:"model,omitempty"`
@@ -94,10 +91,8 @@ func isClaudeToolFormatLegacy(toolsRaw json.RawMessage) bool {
 				Parameters  json.RawMessage `json:"parameters,omitempty"`
 				InputSchema json.RawMessage `json:"input_schema,omitempty"`
 			}
-			if err := json.Unmarshal(tool.Function, &fnProbe); err == nil {
-				if len(fnProbe.InputSchema) > 0 {
-					return true
-				}
+			if err := json.Unmarshal(tool.Function, &fnProbe); err == nil && len(fnProbe.InputSchema) > 0 {
+				return true
 			}
 		}
 	}
@@ -105,36 +100,77 @@ func isClaudeToolFormatLegacy(toolsRaw json.RawMessage) bool {
 	return false
 }
 
-// TestDetectFormatScalarContentBehavior verifies scalar and structured message cases retain their expected API-format decisions.
-func TestDetectFormatScalarContentBehavior(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name string
-		body string
-		want APIFormat
-	}{
-		{name: "string content", body: `{"messages":[{"role":"user","content":"hello"}]}`, want: Unknown},
-		{name: "null content", body: `{"messages":[{"role":"assistant","content":null}]}`, want: Unknown},
-		{name: "object content", body: `{"messages":[{"role":"user","content":{"text":"hello"}}]}`, want: Unknown},
-		{name: "claude array content", body: `{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"1"}]}]}`, want: ClaudeMessages},
-		{name: "wrong-type role remains unknown", body: `{"messages":[{"role":1,"content":[{"type":"tool_use","id":"1"}]}]}`, want: Unknown},
-		{name: "large unused fields stay ambiguous", body: string(benchmarkDetectFormatLargeSystem), want: Unknown},
+// detectFormatLegacy preserves the pre-optimization detector for end-to-end differential tests and benchmarks.
+func detectFormatLegacy(body []byte) (APIFormat, error) {
+	if len(body) == 0 {
+		return Unknown, errors.New("empty request body")
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := DetectFormat([]byte(tt.body))
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-		})
+	var probe legacyRequestProbe
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return Unknown, errors.Wrap(err, "failed to parse request body for format detection")
 	}
+
+	if len(probe.Input) > 0 && len(probe.Messages) == 0 {
+		return ResponseAPI, nil
+	}
+	if probe.MaxOutputTokens != nil && len(probe.Messages) == 0 {
+		return ResponseAPI, nil
+	}
+	if probe.Instructions != nil && len(probe.Messages) == 0 {
+		return ResponseAPI, nil
+	}
+	if len(probe.Messages) == 0 {
+		if probe.PreviousResponseId != nil {
+			return ResponseAPI, nil
+		}
+		if isNonEmptyJSONValue(probe.Conversation) {
+			return ResponseAPI, nil
+		}
+		if isResponseAPIPromptObject(probe.Prompt) {
+			return ResponseAPI, nil
+		}
+		return Unknown, nil
+	}
+
+	if hasClaudeContentBlocksLegacy(probe.Messages) {
+		return ClaudeMessages, nil
+	}
+	if len(probe.Tools) > 0 && isClaudeToolFormatLegacy(probe.Tools) {
+		return ClaudeMessages, nil
+	}
+
+	return Unknown, nil
 }
 
-// TestDetectFormatModelTypeValidation verifies wrong-type model values retain the legacy top-level parse error.
-func TestDetectFormatModelTypeValidation(t *testing.T) {
+// TestDetectFormatBehaviorEquivalent compares externally observable detector results against the exact legacy path.
+func TestDetectFormatBehaviorEquivalent(t *testing.T) {
 	t.Parallel()
-	_, err := DetectFormat([]byte(`{"model":123,"messages":[{"role":"user","content":"hello"}]}`))
-	require.Error(t, err)
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{name: "plain text", body: benchmarkDetectFormatPlainText},
+		{name: "openai tool schema", body: benchmarkDetectFormatOpenAITool},
+		{name: "claude tool use", body: []byte(`{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"1"}]}]}`)},
+		{name: "wrong-type role", body: []byte(`{"messages":[{"role":1,"content":[{"type":"tool_use","id":"1"}]}]}`)},
+		{name: "wrong-type model", body: []byte(`{"model":123,"messages":[{"role":"user","content":"hello"}]}`)},
+		{name: "responses input", body: []byte(`{"input":"hello"}`)},
+		{name: "invalid json", body: []byte(`{"messages":`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want, wantErr := detectFormatLegacy(tc.body)
+			got, gotErr := DetectFormat(tc.body)
+			require.Equal(t, want, got)
+			if wantErr == nil {
+				require.NoError(t, gotErr)
+			} else {
+				require.EqualError(t, gotErr, wantErr.Error())
+			}
+		})
+	}
 }
 
 // TestHasClaudeContentBlocksBehaviorEquivalent compares the optimized content-block scan against the exact legacy algorithm.
@@ -188,30 +224,6 @@ func BenchmarkClaudeContentBlockScanPlainText(b *testing.B) {
 	})
 }
 
-// BenchmarkRequestProbeDecodeLargeUnusedFields measures decoding when a large top-level system field is irrelevant to format detection.
-func BenchmarkRequestProbeDecodeLargeUnusedFields(b *testing.B) {
-	b.Run("legacy", func(b *testing.B) {
-		b.ReportAllocs()
-		var probe legacyRequestProbe
-		for b.Loop() {
-			probe = legacyRequestProbe{}
-			if err := json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe); err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
-	b.Run("optimized", func(b *testing.B) {
-		b.ReportAllocs()
-		var probe requestProbe
-		for b.Loop() {
-			probe = requestProbe{}
-			if err := json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe); err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
-}
-
 // BenchmarkClaudeToolFormatOpenAISchema measures tool-format detection with a large OpenAI parameters schema.
 func BenchmarkClaudeToolFormatOpenAISchema(b *testing.B) {
 	b.Run("legacy", func(b *testing.B) {
@@ -228,12 +240,38 @@ func BenchmarkClaudeToolFormatOpenAISchema(b *testing.B) {
 	})
 }
 
-// BenchmarkDetectFormatPlainText records the optimized end-to-end detector cost for a typical multi-message text request.
+// BenchmarkDetectFormatPlainText measures end-to-end detection for a typical multi-message text request.
 func BenchmarkDetectFormatPlainText(b *testing.B) {
-	b.ReportAllocs()
-	for b.Loop() {
-		if _, err := DetectFormat(benchmarkDetectFormatPlainText); err != nil {
-			b.Fatal(err)
-		}
-	}
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := detectFormatLegacy(benchmarkDetectFormatPlainText); err != nil {
+				b.Fatal(err)
+			}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := DetectFormat(benchmarkDetectFormatPlainText); err != nil {
+				b.Fatal(err)
+			}
+	})
+}
+
+// BenchmarkDetectFormatOpenAIToolSchema measures end-to-end detection for a request with a large OpenAI tool schema.
+func BenchmarkDetectFormatOpenAIToolSchema(b *testing.B) {
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := detectFormatLegacy(benchmarkDetectFormatOpenAITool); err != nil {
+				b.Fatal(err)
+			}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := DetectFormat(benchmarkDetectFormatOpenAITool); err != nil {
+				b.Fatal(err)
+			}
+	})
 }

--- a/relay/format/detect_benchmark_test.go
+++ b/relay/format/detect_benchmark_test.go
@@ -35,6 +35,8 @@ var benchmarkDetectFormatLargeSystem = []byte(`{
 	]
 }`)
 
+var benchmarkOpenAITools = json.RawMessage(`[{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{"payload":{"type":"string","description":"` + strings.Repeat("A", 4096) + `"}}}}}]`)
+
 type legacyRequestProbe struct {
 	Model              string          `json:"model,omitempty"`
 	Messages           json.RawMessage `json:"messages,omitempty"`
@@ -65,6 +67,33 @@ func hasClaudeContentBlocksLegacy(messagesRaw json.RawMessage) bool {
 			for _, block := range contentArray {
 				switch block.Type {
 				case "tool_use", "tool_result", "thinking":
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func isClaudeToolFormatLegacy(toolsRaw json.RawMessage) bool {
+	var tools []toolProbe
+	if err := json.Unmarshal(toolsRaw, &tools); err != nil {
+		return false
+	}
+
+	for _, tool := range tools {
+		if len(tool.InputSchema) > 0 && tool.Name != "" {
+			return true
+		}
+
+		if tool.Type == "function" && len(tool.Function) > 0 {
+			var fnProbe struct {
+				Parameters  json.RawMessage `json:"parameters,omitempty"`
+				InputSchema json.RawMessage `json:"input_schema,omitempty"`
+			}
+			if err := json.Unmarshal(tool.Function, &fnProbe); err == nil {
+				if len(fnProbe.InputSchema) > 0 {
 					return true
 				}
 			}
@@ -114,6 +143,21 @@ func TestHasClaudeContentBlocksBehaviorEquivalent(t *testing.T) {
 	}
 }
 
+func TestIsClaudeToolFormatBehaviorEquivalent(t *testing.T) {
+	t.Parallel()
+	cases := []json.RawMessage{
+		benchmarkOpenAITools,
+		json.RawMessage(`[{"name":"lookup","input_schema":{"type":"object"}}]`),
+		json.RawMessage(`[{"type":"function","function":{"name":"lookup","input_schema":{"type":"object"}}}]`),
+		json.RawMessage(`[{"type":"function","function":{"name":"lookup","parameters":{}}}]`),
+		json.RawMessage(`not-json`),
+	}
+
+	for _, raw := range cases {
+		require.Equal(t, isClaudeToolFormatLegacy(raw), isClaudeToolFormat(raw), string(raw))
+	}
+}
+
 func BenchmarkClaudeContentBlockScanPlainText(b *testing.B) {
 	b.Run("legacy", func(b *testing.B) {
 		b.ReportAllocs()
@@ -144,6 +188,21 @@ func BenchmarkRequestProbeDecodeLargeUnusedFields(b *testing.B) {
 		for b.Loop() {
 			probe = requestProbe{}
 			_ = json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe)
+		}
+	})
+}
+
+func BenchmarkClaudeToolFormatOpenAISchema(b *testing.B) {
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = isClaudeToolFormatLegacy(benchmarkOpenAITools)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = isClaudeToolFormat(benchmarkOpenAITools)
 		}
 	})
 }

--- a/relay/format/detect_benchmark_test.go
+++ b/relay/format/detect_benchmark_test.go
@@ -1,6 +1,7 @@
 package format
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -17,6 +18,13 @@ var benchmarkDetectFormatPlainText = []byte(`{
 	]
 }`)
 
+var benchmarkPlainTextMessages = json.RawMessage(`[
+	{"role":"system","content":"You are helpful"},
+	{"role":"user","content":"Explain Kubernetes operators"},
+	{"role":"assistant","content":"Sure."},
+	{"role":"user","content":"Continue with examples"}
+]`)
+
 var benchmarkDetectFormatLargeSystem = []byte(`{
 	"model":"claude-sonnet-4",
 	"system":[{"type":"text","text":"` + strings.Repeat("A", 4096) + `"}],
@@ -26,6 +34,45 @@ var benchmarkDetectFormatLargeSystem = []byte(`{
 		{"role":"user","content":"Continue with examples"}
 	]
 }`)
+
+type legacyRequestProbe struct {
+	Model              string          `json:"model,omitempty"`
+	Messages           json.RawMessage `json:"messages,omitempty"`
+	Input              json.RawMessage `json:"input,omitempty"`
+	Instructions       *string         `json:"instructions,omitempty"`
+	PreviousResponseId *string         `json:"previous_response_id,omitempty"`
+	Conversation       json.RawMessage `json:"conversation,omitempty"`
+	Prompt             json.RawMessage `json:"prompt,omitempty"`
+	System             any             `json:"system,omitempty"`
+	MaxOutputTokens    *int            `json:"max_output_tokens,omitempty"`
+	Tools              json.RawMessage `json:"tools,omitempty"`
+}
+
+type legacyMessageProbe struct {
+	Role    string          `json:"role,omitempty"`
+	Content json.RawMessage `json:"content,omitempty"`
+}
+
+func hasClaudeContentBlocksLegacy(messagesRaw json.RawMessage) bool {
+	var messages []legacyMessageProbe
+	if err := json.Unmarshal(messagesRaw, &messages); err != nil {
+		return false
+	}
+
+	for _, msg := range messages {
+		var contentArray []contentBlockProbe
+		if err := json.Unmarshal(msg.Content, &contentArray); err == nil {
+			for _, block := range contentArray {
+				switch block.Type {
+				case "tool_use", "tool_result", "thinking":
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
 
 func TestDetectFormatScalarContentBehavior(t *testing.T) {
 	t.Parallel()
@@ -50,31 +97,60 @@ func TestDetectFormatScalarContentBehavior(t *testing.T) {
 	}
 }
 
+func TestHasClaudeContentBlocksBehaviorEquivalent(t *testing.T) {
+	t.Parallel()
+	cases := []json.RawMessage{
+		benchmarkPlainTextMessages,
+		json.RawMessage(`[{"role":"assistant","content":null}]`),
+		json.RawMessage(`[{"role":"user","content":{"text":"hello"}}]`),
+		json.RawMessage(`[{"role":"user","content":[{"type":"text","text":"hello"}]}]`),
+		json.RawMessage(`[{"role":"assistant","content":[{"type":"tool_use","id":"1"}]}]`),
+		json.RawMessage(`[{"role":"user","content":[{"type":"tool_result","tool_use_id":"1"}]}]`),
+		json.RawMessage(`[{"role":"assistant","content":[{"type":"thinking","thinking":"..."}]}]`),
+	}
+
+	for _, raw := range cases {
+		require.Equal(t, hasClaudeContentBlocksLegacy(raw), hasClaudeContentBlocks(raw), string(raw))
+	}
+}
+
+func BenchmarkClaudeContentBlockScanPlainText(b *testing.B) {
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = hasClaudeContentBlocksLegacy(benchmarkPlainTextMessages)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_ = hasClaudeContentBlocks(benchmarkPlainTextMessages)
+		}
+	})
+}
+
+func BenchmarkRequestProbeDecodeLargeUnusedFields(b *testing.B) {
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		var probe legacyRequestProbe
+		for b.Loop() {
+			probe = legacyRequestProbe{}
+			_ = json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe)
+		}
+	})
+	b.Run("optimized", func(b *testing.B) {
+		b.ReportAllocs()
+		var probe requestProbe
+		for b.Loop() {
+			probe = requestProbe{}
+			_ = json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe)
+		}
+	})
+}
+
 func BenchmarkDetectFormatPlainText(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		_, _ = DetectFormat(benchmarkDetectFormatPlainText)
-	}
-}
-
-func BenchmarkDetectFormatLargeSystem(b *testing.B) {
-	b.ReportAllocs()
-	for b.Loop() {
-		_, _ = DetectFormat(benchmarkDetectFormatLargeSystem)
-	}
-}
-
-// TestBoltFormatBenchmark is temporary instrumentation used to capture the
-// baseline and optimized results in the same PR CI environment.
-func TestBoltFormatBenchmark(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		fn   func(*testing.B)
-	}{
-		{name: "plain_text", fn: BenchmarkDetectFormatPlainText},
-		{name: "large_system", fn: BenchmarkDetectFormatLargeSystem},
-	} {
-		result := testing.Benchmark(tc.fn)
-		t.Logf("BOLT_BENCH format/%s: %d ns/op, %d B/op, %d allocs/op", tc.name, result.NsPerOp(), result.AllocedBytesPerOp(), result.AllocsPerOp())
 	}
 }

--- a/relay/format/detect_benchmark_test.go
+++ b/relay/format/detect_benchmark_test.go
@@ -1,0 +1,80 @@
+package format
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var benchmarkDetectFormatPlainText = []byte(`{
+	"model":"gpt-4.1",
+	"messages":[
+		{"role":"system","content":"You are helpful"},
+		{"role":"user","content":"Explain Kubernetes operators"},
+		{"role":"assistant","content":"Sure."},
+		{"role":"user","content":"Continue with examples"}
+	]
+}`)
+
+var benchmarkDetectFormatLargeSystem = []byte(`{
+	"model":"claude-sonnet-4",
+	"system":[{"type":"text","text":"` + strings.Repeat("A", 4096) + `"}],
+	"messages":[
+		{"role":"user","content":"Explain Kubernetes operators"},
+		{"role":"assistant","content":"Sure."},
+		{"role":"user","content":"Continue with examples"}
+	]
+}`)
+
+func TestDetectFormatScalarContentBehavior(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want APIFormat
+	}{
+		{name: "string content", body: `{"messages":[{"role":"user","content":"hello"}]}`, want: Unknown},
+		{name: "null content", body: `{"messages":[{"role":"assistant","content":null}]}`, want: Unknown},
+		{name: "object content", body: `{"messages":[{"role":"user","content":{"text":"hello"}}]}`, want: Unknown},
+		{name: "claude array content", body: `{"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"1"}]}]}`, want: ClaudeMessages},
+		{name: "large unused fields stay ambiguous", body: string(benchmarkDetectFormatLargeSystem), want: Unknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DetectFormat([]byte(tt.body))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func BenchmarkDetectFormatPlainText(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = DetectFormat(benchmarkDetectFormatPlainText)
+	}
+}
+
+func BenchmarkDetectFormatLargeSystem(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = DetectFormat(benchmarkDetectFormatLargeSystem)
+	}
+}
+
+// TestBoltFormatBenchmark is temporary instrumentation used to capture the
+// baseline and optimized results in the same PR CI environment.
+func TestBoltFormatBenchmark(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func(*testing.B)
+	}{
+		{name: "plain_text", fn: BenchmarkDetectFormatPlainText},
+		{name: "large_system", fn: BenchmarkDetectFormatLargeSystem},
+	} {
+		result := testing.Benchmark(tc.fn)
+		t.Logf("BOLT_BENCH format/%s: %d ns/op, %d B/op, %d allocs/op", tc.name, result.NsPerOp(), result.AllocedBytesPerOp(), result.AllocsPerOp())
+	}
+}

--- a/relay/format/detect_benchmark_test.go
+++ b/relay/format/detect_benchmark_test.go
@@ -248,6 +248,7 @@ func BenchmarkDetectFormatPlainText(b *testing.B) {
 			if _, err := detectFormatLegacy(benchmarkDetectFormatPlainText); err != nil {
 				b.Fatal(err)
 			}
+		}
 	})
 	b.Run("optimized", func(b *testing.B) {
 		b.ReportAllocs()
@@ -255,6 +256,7 @@ func BenchmarkDetectFormatPlainText(b *testing.B) {
 			if _, err := DetectFormat(benchmarkDetectFormatPlainText); err != nil {
 				b.Fatal(err)
 			}
+		}
 	})
 }
 
@@ -266,6 +268,7 @@ func BenchmarkDetectFormatOpenAIToolSchema(b *testing.B) {
 			if _, err := detectFormatLegacy(benchmarkDetectFormatOpenAITool); err != nil {
 				b.Fatal(err)
 			}
+		}
 	})
 	b.Run("optimized", func(b *testing.B) {
 		b.ReportAllocs()
@@ -273,5 +276,6 @@ func BenchmarkDetectFormatOpenAIToolSchema(b *testing.B) {
 			if _, err := DetectFormat(benchmarkDetectFormatOpenAITool); err != nil {
 				b.Fatal(err)
 			}
+		}
 	})
 }

--- a/relay/format/detect_benchmark_test.go
+++ b/relay/format/detect_benchmark_test.go
@@ -55,6 +55,7 @@ type legacyMessageProbe struct {
 	Content json.RawMessage `json:"content,omitempty"`
 }
 
+// hasClaudeContentBlocksLegacy preserves the pre-optimization content-block scan for differential tests and benchmarks.
 func hasClaudeContentBlocksLegacy(messagesRaw json.RawMessage) bool {
 	var messages []legacyMessageProbe
 	if err := json.Unmarshal(messagesRaw, &messages); err != nil {
@@ -76,6 +77,7 @@ func hasClaudeContentBlocksLegacy(messagesRaw json.RawMessage) bool {
 	return false
 }
 
+// isClaudeToolFormatLegacy preserves the pre-optimization nested tool-schema decoder for differential tests and benchmarks.
 func isClaudeToolFormatLegacy(toolsRaw json.RawMessage) bool {
 	var tools []toolProbe
 	if err := json.Unmarshal(toolsRaw, &tools); err != nil {
@@ -103,6 +105,7 @@ func isClaudeToolFormatLegacy(toolsRaw json.RawMessage) bool {
 	return false
 }
 
+// TestDetectFormatScalarContentBehavior verifies scalar and structured message cases retain their expected API-format decisions.
 func TestDetectFormatScalarContentBehavior(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -126,6 +129,7 @@ func TestDetectFormatScalarContentBehavior(t *testing.T) {
 	}
 }
 
+// TestHasClaudeContentBlocksBehaviorEquivalent compares the optimized content-block scan against the exact legacy algorithm.
 func TestHasClaudeContentBlocksBehaviorEquivalent(t *testing.T) {
 	t.Parallel()
 	cases := []json.RawMessage{
@@ -143,6 +147,7 @@ func TestHasClaudeContentBlocksBehaviorEquivalent(t *testing.T) {
 	}
 }
 
+// TestIsClaudeToolFormatBehaviorEquivalent compares optimized tool detection against the exact legacy algorithm.
 func TestIsClaudeToolFormatBehaviorEquivalent(t *testing.T) {
 	t.Parallel()
 	cases := []json.RawMessage{
@@ -158,6 +163,7 @@ func TestIsClaudeToolFormatBehaviorEquivalent(t *testing.T) {
 	}
 }
 
+// BenchmarkClaudeContentBlockScanPlainText measures the plain-text message scan before and after skipping impossible array decodes.
 func BenchmarkClaudeContentBlockScanPlainText(b *testing.B) {
 	b.Run("legacy", func(b *testing.B) {
 		b.ReportAllocs()
@@ -173,13 +179,16 @@ func BenchmarkClaudeContentBlockScanPlainText(b *testing.B) {
 	})
 }
 
+// BenchmarkRequestProbeDecodeLargeUnusedFields measures decoding when large top-level fields are irrelevant to format detection.
 func BenchmarkRequestProbeDecodeLargeUnusedFields(b *testing.B) {
 	b.Run("legacy", func(b *testing.B) {
 		b.ReportAllocs()
 		var probe legacyRequestProbe
 		for b.Loop() {
 			probe = legacyRequestProbe{}
-			_ = json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe)
+			if err := json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe); err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 	b.Run("optimized", func(b *testing.B) {
@@ -187,11 +196,14 @@ func BenchmarkRequestProbeDecodeLargeUnusedFields(b *testing.B) {
 		var probe requestProbe
 		for b.Loop() {
 			probe = requestProbe{}
-			_ = json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe)
+			if err := json.Unmarshal(benchmarkDetectFormatLargeSystem, &probe); err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 }
 
+// BenchmarkClaudeToolFormatOpenAISchema measures tool-format detection with a large OpenAI parameters schema.
 func BenchmarkClaudeToolFormatOpenAISchema(b *testing.B) {
 	b.Run("legacy", func(b *testing.B) {
 		b.ReportAllocs()
@@ -207,9 +219,12 @@ func BenchmarkClaudeToolFormatOpenAISchema(b *testing.B) {
 	})
 }
 
+// BenchmarkDetectFormatPlainText records the optimized end-to-end detector cost for a typical multi-message text request.
 func BenchmarkDetectFormatPlainText(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
-		_, _ = DetectFormat(benchmarkDetectFormatPlainText)
+		if _, err := DetectFormat(benchmarkDetectFormatPlainText); err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## 💡 What

This PR applies a focused set of behavior-preserving performance optimizations to request hot paths:

1. **API format detection:** skip JSON-array decoding for scalar message content, because Claude-specific content blocks can only occur in JSON arrays.
2. **API format detection:** stop materializing the top-level `system` value, which is never consulted by the detector. Typed `model` and message `role` probes are intentionally retained because they preserve legacy wrong-type JSON validation behavior.
3. **Tool-format detection:** stop copying OpenAI `function.parameters` schemas into an unused `json.RawMessage`; only nested `input_schema` affects the detector decision.
4. **Request logging:** return immediately from `SanitizeURLForLogging` when the URL contains no `?`, avoiding `net/url` parsing and query-map allocation on the common query-free path.

The changes are intentionally small and do not change public APIs, dependencies, configuration, ordering, error behavior, redaction rules, or API-format decisions.

## 🎯 Why

`APIFormatAutoDetect` runs on chat-style request endpoints, so avoidable JSON decoding and allocation directly affects relay request CPU and GC pressure. Request logging also sanitizes the request URL on its hot path; most API URLs do not carry query parameters, but the previous implementation still parsed them into `net/url` structures.

A systematic pass also considered broader body-caching/read-elimination, rate-limiter locking changes, and raw-byte format scans. Those were deliberately rejected because they would introduce wider lifecycle/concurrency/JSON-semantics risk and do not meet Bolt's low-risk behavioral-equivalence bar for this PR.

## 🧪 Correctness

Focused differential tests keep the exact legacy helper algorithms in `_test.go` and compare their outputs against the optimized implementations for:

- string, null, object, shared structured, `tool_use`, `tool_result`, and `thinking` message content;
- wrong-type message `role` behavior and wrong-type top-level `model` parse errors;
- OpenAI tools, direct Claude `input_schema`, nested `function.input_schema`, invalid JSON, and empty parameter schemas;
- query-free, malformed, fragment-bearing, public-query, and existing sensitive-query URL behavior.

A strict-equivalence review caught an important edge case before readiness: removing typed `model`/`role` fields would have changed malformed-input behavior, because those fields also act as JSON type validators. They were restored and regression tests were added before final benchmarking.

The existing format-detection suite remains unchanged and continues to cover the full public detector behavior.

## 📊 Benchmark

Permanent benchmarks include the exact pre-optimization helper algorithms alongside current code, so reviewers can reproduce before/after results from one commit.

The final Go 1.26.3 measurements are being rerun after the type-validation correction. The PR will remain draft until corrected benchmark results and the full correctness gates are recorded here.

## 🔬 Measurement

Run the permanent side-by-side benchmarks with:

```bash
go test ./relay/format -run '^$' \
  -bench 'Benchmark(ClaudeContentBlockScanPlainText|RequestProbeDecodeLargeUnusedFields|ClaudeToolFormatOpenAISchema|DetectFormatPlainText)$' \
  -benchmem -count=5

go test ./common -run '^$' \
  -bench 'BenchmarkSanitizeURLForLogging(NoQuery|SensitiveQuery)$' \
  -benchmem -count=5
```

Required repository gates:

```bash
go vet ./...
go test -race ./...
make build-frontend-modern
```

## ⚠️ Risk

Low. Production changes remove only decoding whose value cannot affect legacy decisions, skip impossible scalar-to-array decoding, and bypass URL parsing only when there is no query delimiter and therefore no query parameter to redact.

The query-bearing sanitizer path pays one short delimiter scan before following the unchanged parser/redaction path. Its benchmark is retained to make that tradeoff visible.

Rollback is isolated: the production optimizations are small commits and can be reverted independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved URL logging sanitization for URLs without query parameters, reducing unnecessary processing and memory use.
  * Optimized message format detection, including tool schemas and content blocks, for faster handling of requests.
* **Bug Fixes**
  * Preserved existing redaction and format-detection behavior across valid, malformed, and varied input formats.
* **Tests**
  * Added coverage and benchmarks to verify behavior consistency and measure performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->