### PR TITLE
fix(cloudflare): align Workers AI API support

### DIFF
--- a/relay/adaptor/cloudflare/adaptor.go
+++ b/relay/adaptor/cloudflare/adaptor.go
@@ -1,279 +1,271 @@
 package cloudflare
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Laisky/errors/v2"
 	"github.com/gin-gonic/gin"
 
-	"github.com/Laisky/one-api/common/ctxkey"
 	"github.com/Laisky/one-api/relay/adaptor"
-	openai_compatible "github.com/Laisky/one-api/relay/adaptor/openai_compatible"
+	openaiadaptor "github.com/Laisky/one-api/relay/adaptor/openai"
+	openaicompatible "github.com/Laisky/one-api/relay/adaptor/openai_compatible"
 	"github.com/Laisky/one-api/relay/billing/ratio"
 	"github.com/Laisky/one-api/relay/meta"
 	"github.com/Laisky/one-api/relay/model"
 	"github.com/Laisky/one-api/relay/relaymode"
 )
 
-type Adaptor struct {
-	meta *meta.Meta
-}
+const (
+	legacyAIGatewayHost       = "gateway.ai.cloudflare.com"
+	legacyAIGatewayPathSuffix = "/workers-ai"
+)
 
-// ConvertImageRequest implements adaptor.Adaptor.
-func (*Adaptor) ConvertImageRequest(_ *gin.Context, request *model.ImageRequest) (any, error) {
-	return nil, errors.New("not implemented")
-}
+// Adaptor implements the Cloudflare Workers AI relay using Cloudflare's
+// OpenAI-compatible HTTP endpoints.
+type Adaptor struct{}
 
-// ConvertImageRequest implements adaptor.Adaptor.
+// Init initializes the adaptor for a request. Cloudflare does not require
+// request-local adaptor state.
+func (a *Adaptor) Init(_ *meta.Meta) {}
 
-func (a *Adaptor) Init(meta *meta.Meta) {
-	a.meta = meta
-}
-
-// WorkerAI cannot be used across accounts with AIGateWay
-// https://developers.cloudflare.com/ai-gateway/providers/workersai/#openai-compatible-endpoints
-// https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/workers-ai
-func (a *Adaptor) isAIGateWay(baseURL string) bool {
-	return strings.HasPrefix(baseURL, "https://gateway.ai.cloudflare.com") && strings.HasSuffix(baseURL, "/workers-ai")
-}
-
-func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
-	isAIGateWay := a.isAIGateWay(meta.BaseURL)
-	var urlPrefix string
-	if isAIGateWay {
-		urlPrefix = meta.BaseURL
-	} else {
-		urlPrefix = fmt.Sprintf("%s/client/v4/accounts/%s/ai", meta.BaseURL, meta.Config.UserID)
+// GetRequestURL returns the Cloudflare endpoint that matches the incoming relay
+// mode. Requests converted from legacy Completions or Claude Messages use the
+// Chat Completions endpoint so their request and response schemas remain paired.
+func (a *Adaptor) GetRequestURL(metaInfo *meta.Meta) (string, error) {
+	if metaInfo == nil {
+		return "", errors.New("cloudflare meta is nil")
 	}
 
-	switch meta.Mode {
-	case relaymode.ChatCompletions:
-		return fmt.Sprintf("%s/v1/chat/completions", urlPrefix), nil
-	case relaymode.Embeddings:
-		return fmt.Sprintf("%s/v1/embeddings", urlPrefix), nil
-	default:
-		if isAIGateWay {
-			return fmt.Sprintf("%s/%s", urlPrefix, meta.ActualModelName), nil
-		}
-		return fmt.Sprintf("%s/run/%s", urlPrefix, meta.ActualModelName), nil
+	apiBaseURL, err := cloudflareAPIBaseURL(metaInfo.BaseURL, metaInfo.Config.UserID)
+	if err != nil {
+		return "", errors.Wrap(err, "build cloudflare API base URL")
 	}
+
+	endpoint, err := cloudflareOpenAIEndpoint(metaInfo.Mode)
+	if err != nil {
+		return "", err
+	}
+	return apiBaseURL + endpoint, nil
 }
 
-func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, meta *meta.Meta) error {
-	adaptor.SetupCommonRequestHeader(c, req, meta)
-	req.Header.Set("Authorization", "Bearer "+meta.APIKey)
+// SetupRequestHeader configures authentication and content negotiation for a
+// Cloudflare Workers AI request.
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, metaInfo *meta.Meta) error {
+	adaptor.SetupCommonRequestHeader(c, req, metaInfo)
+	req.Header.Set("Authorization", "Bearer "+metaInfo.APIKey)
+	req.Header.Set("Content-Type", "application/json")
 	return nil
 }
 
-func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+// ConvertRequest converts supported OpenAI request modes to the schema accepted
+// by the selected Cloudflare OpenAI-compatible endpoint.
+func (a *Adaptor) ConvertRequest(_ *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
 	if request == nil {
-		return nil, errors.New("request is nil")
+		return nil, errors.New("cloudflare request is nil")
 	}
+
 	switch relayMode {
-	case relaymode.Completions:
-		return ConvertCompletionsRequest(*request), nil
-	case relaymode.ChatCompletions, relaymode.Embeddings:
+	case relaymode.ChatCompletions, relaymode.Embeddings, relaymode.ResponseAPI:
 		return request, nil
+	case relaymode.Completions:
+		return convertCompletionToChatRequest(request)
 	default:
-		return nil, errors.New("not implemented")
+		return nil, errors.Errorf("cloudflare relay mode %d is not supported", relayMode)
 	}
 }
 
+// ConvertImageRequest reports that image multipart requests are not implemented
+// by this text-focused Cloudflare adaptor.
+func (a *Adaptor) ConvertImageRequest(_ *gin.Context, _ *model.ImageRequest) (any, error) {
+	return nil, errors.New("cloudflare image requests are not supported")
+}
+
+// ConvertClaudeRequest converts Anthropic Claude Messages input into an OpenAI
+// Chat Completions request while preserving tools, structured content, streaming,
+// and the context markers needed for response conversion.
 func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, request *model.ClaudeRequest) (any, error) {
-	if request == nil {
-		return nil, errors.New("request is nil")
+	converted, err := openaicompatible.ConvertClaudeRequest(c, request)
+	if err != nil {
+		return nil, errors.Wrap(err, "convert Claude Messages request for Cloudflare")
 	}
-
-	// Convert Claude Messages API request to OpenAI format first
-	openaiRequest := &model.GeneralOpenAIRequest{
-		Model:       request.Model,
-		MaxTokens:   request.MaxTokens,
-		Temperature: request.Temperature,
-		TopP:        request.TopP,
-		Stream:      request.Stream != nil && *request.Stream,
-		Stop:        request.StopSequences,
-	}
-
-	// Convert system prompt
-	if request.System != nil {
-		switch system := request.System.(type) {
-		case string:
-			if system != "" {
-				openaiRequest.Messages = append(openaiRequest.Messages, model.Message{
-					Role:    "system",
-					Content: system,
-				})
-			}
-		case []any:
-			// For structured system content, extract text parts
-			var systemParts []string
-			for _, block := range system {
-				if blockMap, ok := block.(map[string]any); ok {
-					if text, exists := blockMap["text"]; exists {
-						if textStr, ok := text.(string); ok {
-							systemParts = append(systemParts, textStr)
-						}
-					}
-				}
-			}
-			if len(systemParts) > 0 {
-				systemText := strings.Join(systemParts, "\n")
-				openaiRequest.Messages = append(openaiRequest.Messages, model.Message{
-					Role:    "system",
-					Content: systemText,
-				})
-			}
-		}
-	}
-
-	// Convert messages
-	for _, msg := range request.Messages {
-		openaiMessage := model.Message{
-			Role: msg.Role,
-		}
-
-		// Convert content based on type
-		switch content := msg.Content.(type) {
-		case string:
-			// Simple string content
-			openaiMessage.Content = content
-		case []any:
-			// Structured content blocks - convert to OpenAI format
-			var contentParts []model.MessageContent
-			for _, block := range content {
-				if blockMap, ok := block.(map[string]any); ok {
-					if blockType, exists := blockMap["type"]; exists {
-						switch blockType {
-						case "text":
-							if text, exists := blockMap["text"]; exists {
-								if textStr, ok := text.(string); ok {
-									contentParts = append(contentParts, model.MessageContent{
-										Type: "text",
-										Text: &textStr,
-									})
-								}
-							}
-						case "image":
-							if source, exists := blockMap["source"]; exists {
-								if sourceMap, ok := source.(map[string]any); ok {
-									imageURL := model.ImageURL{}
-									if mediaType, exists := sourceMap["media_type"]; exists {
-										if data, exists := sourceMap["data"]; exists {
-											if dataStr, ok := data.(string); ok {
-												// Convert to data URL format
-												imageURL.Url = fmt.Sprintf("data:%s;base64,%s", mediaType, dataStr)
-											}
-										}
-									}
-									contentParts = append(contentParts, model.MessageContent{
-										Type:     "image_url",
-										ImageURL: &imageURL,
-									})
-								}
-							}
-						}
-					}
-				}
-			}
-			if len(contentParts) > 0 {
-				openaiMessage.Content = contentParts
-			}
-		default:
-			// Fallback: convert to string
-			if contentBytes, err := json.Marshal(content); err == nil {
-				openaiMessage.Content = string(contentBytes)
-			}
-		}
-
-		openaiRequest.Messages = append(openaiRequest.Messages, openaiMessage)
-	}
-
-	// Convert tools
-	for _, tool := range request.Tools {
-		openaiTool := model.Tool{
-			Type: "function",
-			Function: &model.Function{
-				Name:        tool.Name,
-				Description: tool.Description,
-			},
-		}
-
-		// Convert input schema
-		if tool.InputSchema != nil {
-			if schemaMap, ok := tool.InputSchema.(map[string]any); ok {
-				openaiTool.Function.Parameters = schemaMap
-			}
-		}
-
-		openaiRequest.Tools = append(openaiRequest.Tools, openaiTool)
-	}
-
-	// Convert tool choice
-	if request.ToolChoice != nil {
-		openaiRequest.ToolChoice = request.ToolChoice
-	}
-
-	// Mark this as a Claude Messages conversion for response handling
-	c.Set(ctxkey.ClaudeMessagesConversion, true)
-	c.Set(ctxkey.OriginalClaudeRequest, request)
-
-	// Now convert using Cloudflare's existing logic
-	return a.ConvertRequest(c, relaymode.ChatCompletions, openaiRequest)
+	return converted, nil
 }
 
-func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Reader) (*http.Response, error) {
-	return adaptor.DoRequestHelper(a, c, meta, requestBody)
+// DoRequest sends a Cloudflare request using the common adaptor transport.
+func (a *Adaptor) DoRequest(c *gin.Context, metaInfo *meta.Meta, requestBody io.Reader) (*http.Response, error) {
+	return adaptor.DoRequestHelper(a, c, metaInfo, requestBody)
 }
 
-func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
-	if meta.IsStream {
-		// Use unified OpenAI-compatible streaming handler to enable consistent behavior and thinking support
-		err, usage = openai_compatible.StreamHandler(c, resp, meta.PromptTokens, meta.ActualModelName)
-	} else {
-		// Use unified OpenAI-compatible non-stream handler
-		err, usage = openai_compatible.Handler(c, resp, meta.PromptTokens, meta.ActualModelName)
-	}
-	return
+// DoResponse handles Cloudflare's OpenAI-compatible responses, including native
+// Responses API output and conversion back to Claude Messages when requested.
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, metaInfo *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	return (&openaiadaptor.Adaptor{}).DoResponse(c, resp, metaInfo)
 }
 
+// GetModelList returns the currently supported Cloudflare model identifiers.
 func (a *Adaptor) GetModelList() []string {
-	return adaptor.GetModelListFromPricing(ModelRatios)
+	return ModelList
 }
 
+// GetChannelName returns the human-readable provider name.
 func (a *Adaptor) GetChannelName() string {
 	return "cloudflare"
 }
 
-// Pricing methods - Cloudflare adapter manages its own model pricing
+// GetDefaultModelPricing returns Cloudflare's built-in model metadata and
+// pricing table.
 func (a *Adaptor) GetDefaultModelPricing() map[string]adaptor.ModelConfig {
-	// Use the constants.go ModelRatios which already use ratio.MilliTokensUsd correctly
 	return ModelRatios
 }
 
+// GetModelRatio returns the configured input-token price ratio for a model.
 func (a *Adaptor) GetModelRatio(modelName string) float64 {
-	pricing := a.GetDefaultModelPricing()
-	if price, exists := pricing[modelName]; exists {
+	if price, ok := ModelRatios[modelName]; ok {
 		return price.Ratio
 	}
-
-	// Default Cloudflare pricing - use global constant for consistency
-	return 5 * ratio.MilliTokensUsd // Default quota-based pricing
+	return 5 * ratio.MilliTokensUsd
 }
 
+// GetCompletionRatio returns the output-to-input price ratio for a model.
 func (a *Adaptor) GetCompletionRatio(modelName string) float64 {
-	pricing := a.GetDefaultModelPricing()
-	if price, exists := pricing[modelName]; exists {
+	if price, ok := ModelRatios[modelName]; ok {
 		return price.CompletionRatio
 	}
-	// Default completion ratio for Cloudflare
-	return 1.0
+	return 1
 }
 
-// DefaultToolingConfig returns Cloudflare tooling defaults (no published server-side tool fees as of 2025-11-12).
+// DefaultToolingConfig returns the provider-level tool capabilities. Per-model
+// metadata remains authoritative for whether a particular model supports tools.
 func (a *Adaptor) DefaultToolingConfig() adaptor.ChannelToolConfig {
 	return CloudflareToolingDefaults
+}
+
+// cloudflareOpenAIEndpoint maps one-api relay modes to Cloudflare's supported
+// OpenAI-compatible endpoints.
+func cloudflareOpenAIEndpoint(relayMode int) (string, error) {
+	switch relayMode {
+	case relaymode.ChatCompletions, relaymode.Completions, relaymode.ClaudeMessages:
+		return "/v1/chat/completions", nil
+	case relaymode.Embeddings:
+		return "/v1/embeddings", nil
+	case relaymode.ResponseAPI:
+		return "/v1/responses", nil
+	default:
+		return "", errors.Errorf("cloudflare relay mode %d has no OpenAI-compatible endpoint", relayMode)
+	}
+}
+
+// cloudflareAPIBaseURL normalizes either the standard Workers AI base URL, a
+// full account-scoped Workers AI URL, or the legacy AI Gateway workers-ai URL.
+func cloudflareAPIBaseURL(rawBaseURL, accountID string) (string, error) {
+	rawBaseURL = strings.TrimSpace(rawBaseURL)
+	if rawBaseURL == "" {
+		return "", errors.New("cloudflare base URL is empty")
+	}
+
+	parsed, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return "", errors.Wrap(err, "parse cloudflare base URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", errors.Errorf("cloudflare base URL must use http or https, got %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", errors.New("cloudflare base URL must include a host")
+	}
+	if parsed.User != nil {
+		return "", errors.New("cloudflare base URL must not include credentials")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("cloudflare base URL must not include a query or fragment")
+	}
+
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	parsed.RawPath = ""
+	normalized := strings.TrimRight(parsed.String(), "/")
+
+	segments := splitURLPath(parsed.Path)
+	if strings.EqualFold(parsed.Hostname(), legacyAIGatewayHost) {
+		switch {
+		case hasPathSuffix(segments, "workers-ai", "v1"):
+			return strings.TrimSuffix(normalized, "/v1"), nil
+		case hasPathSuffix(segments, "workers-ai"):
+			return normalized, nil
+		default:
+			return "", errors.Errorf("legacy Cloudflare AI Gateway URL must end with %s or %s/v1", legacyAIGatewayPathSuffix, legacyAIGatewayPathSuffix)
+		}
+	}
+
+	if hasPathSuffix(segments, "client", "v4", "accounts", "*", "ai", "v1") {
+		return strings.TrimSuffix(normalized, "/v1"), nil
+	}
+	if hasPathSuffix(segments, "client", "v4", "accounts", "*", "ai") {
+		return normalized, nil
+	}
+
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return "", errors.New("cloudflare account ID is required")
+	}
+	if strings.ContainsAny(accountID, "/?#") {
+		return "", errors.New("cloudflare account ID contains invalid path characters")
+	}
+
+	escapedAccountID := url.PathEscape(accountID)
+	switch {
+	case hasPathSuffix(segments, "client", "v4", "accounts", "*"):
+		return normalized + "/ai", nil
+	case hasPathSuffix(segments, "client", "v4"):
+		return normalized + "/accounts/" + escapedAccountID + "/ai", nil
+	default:
+		return normalized + "/client/v4/accounts/" + escapedAccountID + "/ai", nil
+	}
+}
+
+// splitURLPath returns non-empty path segments for suffix matching.
+func splitURLPath(path string) []string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 1 && parts[0] == "" {
+		return nil
+	}
+	return parts
+}
+
+// hasPathSuffix reports whether path segments end with the supplied pattern.
+// The literal "*" matches any non-empty segment.
+func hasPathSuffix(segments []string, pattern ...string) bool {
+	if len(segments) < len(pattern) {
+		return false
+	}
+	start := len(segments) - len(pattern)
+	for i, expected := range pattern {
+		actual := segments[start+i]
+		if expected == "*" {
+			if actual == "" {
+				return false
+			}
+			continue
+		}
+		if !strings.EqualFold(actual, expected) {
+			return false
+		}
+	}
+	return true
+}
+
+// convertCompletionToChatRequest converts a legacy text completion prompt to a
+// single user message while preserving shared sampling and streaming fields.
+func convertCompletionToChatRequest(request *model.GeneralOpenAIRequest) (*model.GeneralOpenAIRequest, error) {
+	prompt := strings.TrimSpace(request.Prompt)
+	if prompt == "" {
+		return nil, errors.New("cloudflare completion prompt is empty")
+	}
+
+	converted := *request
+	converted.Prompt = ""
+	converted.Messages = []model.Message{{Role: "user", Content: request.Prompt}}
+	return &converted, nil
 }

--- a/relay/adaptor/cloudflare/adaptor_test.go
+++ b/relay/adaptor/cloudflare/adaptor_test.go
@@ -1,0 +1,270 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/common/ctxkey"
+	rootmodel "github.com/Laisky/one-api/model"
+	"github.com/Laisky/one-api/relay/meta"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+// TestGetRequestURL verifies that every supported relay mode uses a matching
+// Cloudflare OpenAI-compatible endpoint and that supported base URL forms are
+// normalized without duplicated path segments.
+func TestGetRequestURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		baseURL   string
+		accountID string
+		mode      int
+		want      string
+	}{
+		{
+			name:      "standard chat",
+			baseURL:   "https://api.cloudflare.com",
+			accountID: "account-id",
+			mode:      relaymode.ChatCompletions,
+			want:      "https://api.cloudflare.com/client/v4/accounts/account-id/ai/v1/chat/completions",
+		},
+		{
+			name:      "standard trailing slash",
+			baseURL:   "https://api.cloudflare.com/",
+			accountID: "account-id",
+			mode:      relaymode.Embeddings,
+			want:      "https://api.cloudflare.com/client/v4/accounts/account-id/ai/v1/embeddings",
+		},
+		{
+			name:    "full account base",
+			baseURL: "https://api.cloudflare.com/client/v4/accounts/path-account/ai",
+			mode:    relaymode.ResponseAPI,
+			want:    "https://api.cloudflare.com/client/v4/accounts/path-account/ai/v1/responses",
+		},
+		{
+			name:    "full account OpenAI base",
+			baseURL: "https://api.cloudflare.com/client/v4/accounts/path-account/ai/v1/",
+			mode:    relaymode.ChatCompletions,
+			want:    "https://api.cloudflare.com/client/v4/accounts/path-account/ai/v1/chat/completions",
+		},
+		{
+			name:      "client API base",
+			baseURL:   "https://api.cloudflare.com/client/v4",
+			accountID: "account-id",
+			mode:      relaymode.Completions,
+			want:      "https://api.cloudflare.com/client/v4/accounts/account-id/ai/v1/chat/completions",
+		},
+		{
+			name:    "account base",
+			baseURL: "https://api.cloudflare.com/client/v4/accounts/path-account",
+			mode:    relaymode.ClaudeMessages,
+			want:    "https://api.cloudflare.com/client/v4/accounts/path-account/ai/v1/chat/completions",
+		},
+		{
+			name:    "legacy AI Gateway",
+			baseURL: "https://gateway.ai.cloudflare.com/v1/account/gateway/workers-ai",
+			mode:    relaymode.ChatCompletions,
+			want:    "https://gateway.ai.cloudflare.com/v1/account/gateway/workers-ai/v1/chat/completions",
+		},
+		{
+			name:    "legacy AI Gateway OpenAI base",
+			baseURL: "https://gateway.ai.cloudflare.com/v1/account/gateway/workers-ai/v1",
+			mode:    relaymode.Embeddings,
+			want:    "https://gateway.ai.cloudflare.com/v1/account/gateway/workers-ai/v1/embeddings",
+		},
+		{
+			name:      "gateway lookalike is not trusted as a legacy gateway",
+			baseURL:   "https://gateway.ai.cloudflare.com.example.test/proxy",
+			accountID: "account-id",
+			mode:      relaymode.ChatCompletions,
+			want:      "https://gateway.ai.cloudflare.com.example.test/proxy/client/v4/accounts/account-id/ai/v1/chat/completions",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := (&Adaptor{}).GetRequestURL(&meta.Meta{
+				Mode:    test.mode,
+				BaseURL: test.baseURL,
+				Config:  rootmodel.ChannelConfig{UserID: test.accountID},
+			})
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+// TestGetRequestURLRejectsInvalidConfiguration verifies that malformed base
+// URLs, missing account identifiers, and unsupported relay modes fail closed.
+func TestGetRequestURLRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	adaptor := &Adaptor{}
+	_, err := adaptor.GetRequestURL(nil)
+	require.Error(t, err)
+
+	tests := []struct {
+		name      string
+		baseURL   string
+		accountID string
+		mode      int
+	}{
+		{name: "missing account ID", baseURL: "https://api.cloudflare.com", mode: relaymode.ChatCompletions},
+		{name: "invalid scheme", baseURL: "ftp://api.cloudflare.com", accountID: "account-id", mode: relaymode.ChatCompletions},
+		{name: "embedded credentials", baseURL: "https://user:pass@api.cloudflare.com", accountID: "account-id", mode: relaymode.ChatCompletions},
+		{name: "query string", baseURL: "https://api.cloudflare.com?debug=true", accountID: "account-id", mode: relaymode.ChatCompletions},
+		{name: "invalid account ID", baseURL: "https://api.cloudflare.com", accountID: "bad/id", mode: relaymode.ChatCompletions},
+		{name: "invalid gateway path", baseURL: "https://gateway.ai.cloudflare.com/v1/account/gateway", mode: relaymode.ChatCompletions},
+		{name: "unsupported mode", baseURL: "https://api.cloudflare.com", accountID: "account-id", mode: relaymode.ImagesGenerations},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := adaptor.GetRequestURL(&meta.Meta{
+				Mode:    test.mode,
+				BaseURL: test.baseURL,
+				Config:  rootmodel.ChannelConfig{UserID: test.accountID},
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestConvertCompletionToChatRequest verifies that the legacy Completions input
+// is converted to Chat Completions without mutating the caller or dropping
+// shared sampling and streaming fields.
+func TestConvertCompletionToChatRequest(t *testing.T) {
+	t.Parallel()
+
+	temperature := 0.25
+	topP := 0.9
+	n := 2
+	request := &relaymodel.GeneralOpenAIRequest{
+		Model:       "@cf/qwen/qwen3.8-27b",
+		Prompt:      "  preserve prompt whitespace  ",
+		MaxTokens:   128,
+		Temperature: &temperature,
+		TopP:        &topP,
+		Stop:        []string{"END"},
+		Stream:      true,
+		N:           &n,
+	}
+
+	convertedAny, err := (&Adaptor{}).ConvertRequest(nil, relaymode.Completions, request)
+	require.NoError(t, err)
+	converted, ok := convertedAny.(*relaymodel.GeneralOpenAIRequest)
+	require.True(t, ok)
+	require.NotSame(t, request, converted)
+	require.Empty(t, converted.Prompt)
+	require.Len(t, converted.Messages, 1)
+	require.Equal(t, "user", converted.Messages[0].Role)
+	require.Equal(t, request.Prompt, converted.Messages[0].Content)
+	require.Equal(t, request.MaxTokens, converted.MaxTokens)
+	require.Equal(t, request.Temperature, converted.Temperature)
+	require.Equal(t, request.TopP, converted.TopP)
+	require.Equal(t, request.Stop, converted.Stop)
+	require.Equal(t, request.Stream, converted.Stream)
+	require.Equal(t, request.N, converted.N)
+	require.Equal(t, "  preserve prompt whitespace  ", request.Prompt, "conversion must not mutate the original request")
+
+	_, err = (&Adaptor{}).ConvertRequest(nil, relaymode.Completions, &relaymodel.GeneralOpenAIRequest{Prompt: "   "})
+	require.Error(t, err)
+}
+
+// TestConvertClaudeRequest verifies that Claude Messages input is converted by
+// the shared OpenAI-compatible bridge and records the response-conversion marker.
+func TestConvertClaudeRequest(t *testing.T) {
+	t.Parallel()
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	stream := true
+
+	convertedAny, err := (&Adaptor{}).ConvertClaudeRequest(ctx, &relaymodel.ClaudeRequest{
+		Model:     "@cf/qwen/qwen3.8-27b",
+		MaxTokens: 256,
+		System:    "Follow the instructions.",
+		Messages: []relaymodel.ClaudeMessage{
+			{Role: "user", Content: "Hello"},
+		},
+		Stream: &stream,
+		Tools: []relaymodel.ClaudeTool{
+			{
+				Name:        "lookup",
+				Description: "Look up an item.",
+				InputSchema: map[string]any{"type": "object"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	converted, ok := convertedAny.(*relaymodel.GeneralOpenAIRequest)
+	require.True(t, ok)
+	require.Equal(t, "@cf/qwen/qwen3.8-27b", converted.Model)
+	require.True(t, converted.Stream)
+	require.NotNil(t, converted.MaxCompletionTokens)
+	require.Equal(t, 256, *converted.MaxCompletionTokens)
+	require.Len(t, converted.Messages, 2)
+	require.Equal(t, "system", converted.Messages[0].Role)
+	require.Equal(t, "Follow the instructions.", converted.Messages[0].Content)
+	require.Equal(t, "user", converted.Messages[1].Role)
+	require.Len(t, converted.Tools, 1)
+	require.True(t, ctx.GetBool(ctxkey.ClaudeMessagesConversion))
+}
+
+// TestDoResponseConvertsChatResponseToClaude verifies the response half of the
+// Cloudflare Claude Messages bridge, including usage and finish-reason mapping.
+func TestDoResponseConvertsChatResponseToClaude(t *testing.T) {
+	t.Parallel()
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	_, err := (&Adaptor{}).ConvertClaudeRequest(ctx, &relaymodel.ClaudeRequest{
+		Model:     "@cf/qwen/qwen3.8-27b",
+		MaxTokens: 32,
+		Messages:  []relaymodel.ClaudeMessage{{Role: "user", Content: "Hello"}},
+	})
+	require.NoError(t, err)
+
+	body := `{"id":"chatcmpl_cf","object":"chat.completion","created":1,"model":"@cf/qwen/qwen3.8-27b","choices":[{"index":0,"message":{"role":"assistant","content":"Hello from Cloudflare"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":3,"total_tokens":7}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	usage, responseErr := (&Adaptor{}).DoResponse(ctx, resp, &meta.Meta{
+		Mode:            relaymode.ClaudeMessages,
+		ActualModelName: "@cf/qwen/qwen3.8-27b",
+		PromptTokens:    4,
+	})
+	require.Nil(t, responseErr)
+	require.Nil(t, usage)
+
+	raw, exists := ctx.Get(ctxkey.ConvertedResponse)
+	require.True(t, exists)
+	convertedResp, ok := raw.(*http.Response)
+	require.True(t, ok)
+	convertedBody, err := io.ReadAll(convertedResp.Body)
+	require.NoError(t, err)
+
+	var converted relaymodel.ClaudeResponse
+	require.NoError(t, json.Unmarshal(convertedBody, &converted))
+	require.Equal(t, "message", converted.Type)
+	require.Equal(t, "assistant", converted.Role)
+	require.Equal(t, "end_turn", converted.StopReason)
+	require.Equal(t, 4, converted.Usage.InputTokens)
+	require.Equal(t, 3, converted.Usage.OutputTokens)
+	require.Len(t, converted.Content, 1)
+	require.Equal(t, "text", converted.Content[0].Type)
+	require.Equal(t, "Hello from Cloudflare", converted.Content[0].Text)
+}

--- a/relay/adaptor/cloudflare/constant_test.go
+++ b/relay/adaptor/cloudflare/constant_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Laisky/one-api/relay/billing/ratio"
 )
 
+// TestModelRatiosIncludeLatestWorkersAITextModels verifies the pricing and
+// capability metadata published for current Cloudflare Workers AI text models.
 func TestModelRatiosIncludeLatestWorkersAITextModels(t *testing.T) {
 	t.Parallel()
 
@@ -15,31 +17,86 @@ func TestModelRatiosIncludeLatestWorkersAITextModels(t *testing.T) {
 		ratio            float64
 		cachedInputRatio float64
 		completionRatio  float64
+		contextLength    int32
+		inputModalities  []string
+		features         []string
 	}{
 		"@cf/zai-org/glm-4.7-flash": {
 			ratio:           0.060 * ratio.MilliTokensUsd,
 			completionRatio: 0.400 / 0.060,
+			contextLength:   131_072,
 		},
 		"@cf/nvidia/nemotron-3-120b-a12b": {
 			ratio:           0.500 * ratio.MilliTokensUsd,
 			completionRatio: 1.500 / 0.500,
+			contextLength:   256_000,
 		},
-		"@cf/moonshotai/kimi-k2.5": {
-			ratio:            0.600 * ratio.MilliTokensUsd,
-			cachedInputRatio: 0.100 * ratio.MilliTokensUsd,
-			completionRatio:  3.000 / 0.600,
+		"@cf/moonshotai/kimi-k2.6": {
+			ratio:            0.950 * ratio.MilliTokensUsd,
+			cachedInputRatio: 0.160 * ratio.MilliTokensUsd,
+			completionRatio:  4.000 / 0.950,
+			contextLength:    262_144,
+		},
+		"@cf/deepseek-ai/deepseek-v4-flash-0731": {
+			ratio:            0.440 * ratio.MilliTokensUsd,
+			cachedInputRatio: 0.014 * ratio.MilliTokensUsd,
+			completionRatio:  1.320 / 0.440,
+			contextLength:    1_048_576,
+			inputModalities:  []string{"text"},
+			features:         []string{"tools", "reasoning"},
+		},
+		"@cf/deepseek-ai/deepseek-v4-pro-0813": {
+			ratio:            1.320 * ratio.MilliTokensUsd,
+			cachedInputRatio: 0.044 * ratio.MilliTokensUsd,
+			completionRatio:  3.960 / 1.320,
+			contextLength:    1_048_576,
+			inputModalities:  []string{"text", "image"},
+			features:         []string{"tools", "reasoning"},
+		},
+		"@cf/qwen/qwen3.8-27b": {
+			ratio:           0.450 * ratio.MilliTokensUsd,
+			completionRatio: 3.200 / 0.450,
+			contextLength:   262_144,
+			inputModalities: []string{"text", "image"},
+			features:        []string{"tools", "reasoning"},
 		},
 	}
 
 	for modelName, expected := range testCases {
-		cfg, ok := ModelRatios[modelName]
-		require.True(t, ok, "%s missing from Cloudflare pricing map", modelName)
-		require.InDelta(t, expected.ratio, cfg.Ratio, 1e-12)
-		require.InDelta(t, expected.cachedInputRatio, cfg.CachedInputRatio, 1e-12)
-		require.InDelta(t, expected.completionRatio, cfg.CompletionRatio, 1e-12)
+		modelName := modelName
+		expected := expected
+		t.Run(modelName, func(t *testing.T) {
+			t.Parallel()
+			cfg, ok := ModelRatios[modelName]
+			require.True(t, ok, "%s missing from Cloudflare pricing map", modelName)
+			require.InDelta(t, expected.ratio, cfg.Ratio, 1e-12)
+			require.InDelta(t, expected.cachedInputRatio, cfg.CachedInputRatio, 1e-12)
+			require.InDelta(t, expected.completionRatio, cfg.CompletionRatio, 1e-12)
+			require.Equal(t, expected.contextLength, cfg.ContextLength)
+			if expected.inputModalities != nil {
+				require.ElementsMatch(t, expected.inputModalities, cfg.InputModalities)
+			}
+			if expected.features != nil {
+				require.ElementsMatch(t, expected.features, cfg.SupportedFeatures)
+			}
+		})
 	}
 }
 
+// TestModelRatiosExcludeDeprecatedWorkersAIModels verifies that the default
+// catalog no longer exposes model identifiers whose deprecation date passed.
+func TestModelRatiosExcludeDeprecatedWorkersAIModels(t *testing.T) {
+	t.Parallel()
+
+	for _, modelName := range deprecatedCloudflareModels20260530 {
+		_, exists := ModelRatios[modelName]
+		require.False(t, exists, "%s must not remain in Cloudflare pricing metadata", modelName)
+		require.NotContains(t, ModelList, modelName, "%s must not remain in the selectable model list", modelName)
+	}
+}
+
+// TestModelRatiosIncludeLatestWorkersAISpeechModels verifies current
+// Cloudflare speech pricing metadata.
 func TestModelRatiosIncludeLatestWorkersAISpeechModels(t *testing.T) {
 	t.Parallel()
 

--- a/relay/adaptor/cloudflare/models_202608.go
+++ b/relay/adaptor/cloudflare/models_202608.go
@@ -1,0 +1,74 @@
+package cloudflare
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+var cloudflareToolsAndReasoningFeatures = []string{"tools", "reasoning"}
+
+// init applies the Cloudflare Workers AI catalog changes published in August
+// 2026 and rebuilds ModelList after removing models whose deprecation date has
+// passed.
+func init() {
+	ModelRatios["@cf/deepseek-ai/deepseek-v4-flash-0731"] = adaptor.ModelConfig{
+		Ratio:                       0.440 * ratio.MilliTokensUsd,
+		CompletionRatio:             1.320 / 0.440,
+		CachedInputRatio:            0.014 * ratio.MilliTokensUsd,
+		ContextLength:               1_048_576,
+		InputModalities:             cfTextInputs,
+		OutputModalities:            cfTextOutputs,
+		SupportedFeatures:           cloudflareToolsAndReasoningFeatures,
+		SupportedSamplingParameters: cfBasicSamplingParams,
+		Description:                 "DeepSeek V4 Flash 0731 long-context reasoning and function-calling model on Cloudflare Workers AI.",
+	}
+	ModelRatios["@cf/deepseek-ai/deepseek-v4-pro-0813"] = adaptor.ModelConfig{
+		Ratio:                       1.320 * ratio.MilliTokensUsd,
+		CompletionRatio:             3.960 / 1.320,
+		CachedInputRatio:            0.044 * ratio.MilliTokensUsd,
+		ContextLength:               1_048_576,
+		InputModalities:             cfVisionInputs,
+		OutputModalities:            cfTextOutputs,
+		SupportedFeatures:           cloudflareToolsAndReasoningFeatures,
+		SupportedSamplingParameters: cfBasicSamplingParams,
+		Description:                 "DeepSeek V4 Pro 0813 long-context multimodal reasoning and function-calling model on Cloudflare Workers AI.",
+	}
+	ModelRatios["@cf/qwen/qwen3.8-27b"] = adaptor.ModelConfig{
+		Ratio:                       0.450 * ratio.MilliTokensUsd,
+		CompletionRatio:             3.200 / 0.450,
+		ContextLength:               262_144,
+		InputModalities:             cfVisionInputs,
+		OutputModalities:            cfTextOutputs,
+		SupportedFeatures:           cloudflareToolsAndReasoningFeatures,
+		SupportedSamplingParameters: cfBasicSamplingParams,
+		Description:                 "Qwen 3.8 27B multimodal reasoning and function-calling model on Cloudflare Workers AI.",
+	}
+
+	for _, modelName := range deprecatedCloudflareModels20260530 {
+		delete(ModelRatios, modelName)
+	}
+	ModelList = adaptor.GetModelListFromPricing(ModelRatios)
+}
+
+// deprecatedCloudflareModels20260530 contains models whose Cloudflare Workers AI
+// deprecation date passed on May 30, 2026.
+var deprecatedCloudflareModels20260530 = []string{
+	"@cf/moonshotai/kimi-k2.5",
+	"@hf/meta-llama/meta-llama-3-8b-instruct",
+	"@cf/meta/llama-3-8b-instruct",
+	"@cf/meta/llama-3-8b-instruct-awq",
+	"@cf/meta/llama-3.1-8b-instruct",
+	"@cf/meta/llama-3.1-8b-instruct-awq",
+	"@cf/meta/llama-3.1-70b-instruct",
+	"@cf/meta/llama-2-7b-chat-int8",
+	"@cf/meta/llama-2-7b-chat-fp16",
+	"@cf/mistral/mistral-7b-instruct-v0.1",
+	"@hf/mistral/mistral-7b-instruct-v0.2",
+	"@hf/google/gemma-7b-it",
+	"@cf/google/gemma-3-12b-it",
+	"@hf/nousresearch/hermes-2-pro-mistral-7b",
+	"@cf/microsoft/phi-2",
+	"@cf/defog/sqlcoder-7b-2",
+	"@cf/unum/uform-gen2-qwen-500m",
+	"@cf/facebook/bart-large-cnn",
+}


### PR DESCRIPTION
## Summary

Fix the Cloudflare Workers AI adaptor so request routing, request conversion, and response parsing use the same API contract.

- route Chat Completions, converted legacy Completions, and converted Claude Messages through Cloudflare's OpenAI-compatible `/v1/chat/completions` endpoint
- route Embeddings and native Responses requests through `/v1/embeddings` and `/v1/responses`
- normalize account-scoped Workers AI and legacy AI Gateway base URLs without duplicated `/client/v4`, `/ai`, or `/v1` segments
- validate URL schemes, credentials, query/fragment components, account IDs, and the exact legacy gateway hostname
- reuse the shared Claude Messages request bridge and OpenAI response handler, including streaming/usage and Claude response conversion
- add August 2026 model metadata and pricing for DeepSeek V4 Flash 0731, DeepSeek V4 Pro 0813, and Qwen 3.8 27B
- remove models whose Cloudflare deprecation date passed on May 30, 2026, then rebuild the selectable model list

## Root cause

The previous adaptor sent only Chat Completions and Embeddings to Cloudflare's OpenAI-compatible surface. Legacy Completions and Claude Messages could be serialized as OpenAI-shaped requests but routed to native `/run/{model}` endpoints, while their responses were still parsed as OpenAI responses. Native `/run` uses Cloudflare's `result/success/errors/messages` envelope, so the request and response contracts did not match.

## Tests

Added regression coverage for:

- standard account-scoped and legacy AI Gateway URL construction
- trailing slash and already-versioned base URL normalization
- rejection of malformed/unsafe base URLs and unsupported relay modes
- legacy Completions to Chat Completions conversion without dropped shared fields
- Claude Messages request conversion and Chat-to-Claude response conversion
- latest model pricing, context windows, modalities, and capabilities
- removal of deprecated models from both pricing metadata and the selectable model list

## Official references

- https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/
- https://developers.cloudflare.com/workers-ai/configuration/rest-api/
- https://developers.cloudflare.com/workers-ai/models/deepseek-v4-flash-0731/
- https://developers.cloudflare.com/workers-ai/models/deepseek-v4-pro-0813/
- https://developers.cloudflare.com/workers-ai/models/qwen3.8-27b/
- https://developers.cloudflare.com/workers-ai/platform/deprecations/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare’s OpenAI-compatible Chat, Embeddings, Responses, and Claude Messages APIs.
  * Added support for current Cloudflare Workers AI models, including updated pricing, capabilities, and model metadata.
  * Improved handling of standard, account-scoped, and legacy AI Gateway URLs.

* **Bug Fixes**
  * Added validation for invalid URLs, credentials, account configuration, requests, and empty prompts.
  * Unsupported image requests are now rejected clearly.
  * Deprecated models are no longer listed or priced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->