### PR TITLE
feat: add DeepInfra adaptor

### DIFF
--- a/relay/adaptor.go
+++ b/relay/adaptor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Laisky/one-api/relay/adaptor/copilot"
 	"github.com/Laisky/one-api/relay/adaptor/coze"
 	"github.com/Laisky/one-api/relay/adaptor/deepl"
+	"github.com/Laisky/one-api/relay/adaptor/deepinfra"
 	"github.com/Laisky/one-api/relay/adaptor/deepseek"
 	"github.com/Laisky/one-api/relay/adaptor/fireworks"
 	"github.com/Laisky/one-api/relay/adaptor/gemini"
@@ -78,6 +79,8 @@ func GetAdaptor(apiType int) adaptor.Adaptor {
 		return &replicate.Adaptor{}
 	case apitype.DeepSeek:
 		return &deepseek.Adaptor{}
+	case apitype.DeepInfra:
+		return &deepinfra.Adaptor{}
 	case apitype.Groq:
 		return &groq.Adaptor{}
 	case apitype.Mistral:

--- a/relay/adaptor/deepinfra/adaptor.go
+++ b/relay/adaptor/deepinfra/adaptor.go
@@ -194,13 +194,20 @@ func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Read
 	return adaptor.DoRequestHelper(a, c, meta, requestBody)
 }
 
-// DoResponse dispatches DeepInfra responses to the matching shared response handler.
+// DoResponse dispatches DeepInfra responses to the matching response handler.
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
 	if meta == nil {
 		return nil, openai_compatible.ErrorWrapper(errors.New("meta is nil"), "invalid_meta", http.StatusInternalServerError)
 	}
 
 	switch meta.Mode {
+	case relaymode.Completions:
+		if meta.IsStream {
+			err, usage = handleCompletionStream(c, resp, meta.PromptTokens, meta.ActualModelName)
+			return
+		}
+		err, usage = handleCompletionResponse(c, resp, meta.PromptTokens, meta.ActualModelName)
+		return
 	case relaymode.Rerank:
 		err, usage = handleRerankResponse(c, resp, meta.ActualModelName, meta.PromptTokens)
 		return
@@ -213,7 +220,8 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Met
 	}
 
 	// Native Claude Messages and audio requests use controller-level passthrough
-	// paths. The remaining modes use DeepInfra's OpenAI-compatible response shape.
+	// paths. Chat and Response-fallback modes use DeepInfra's OpenAI-compatible
+	// Chat Completions response shape.
 	if meta.IsStream {
 		err, usage = openai_compatible.StreamHandler(c, resp, meta.PromptTokens, meta.ActualModelName)
 		return

--- a/relay/adaptor/deepinfra/adaptor.go
+++ b/relay/adaptor/deepinfra/adaptor.go
@@ -1,0 +1,223 @@
+// Package deepinfra implements the DeepInfra serverless inference adaptor.
+//
+// DeepInfra exposes several protocol surfaces under one Bearer-authenticated API:
+//
+//   - /v1/openai/* for OpenAI-compatible chat, completions, embeddings, and images
+//   - /anthropic/v1/messages for native Anthropic Messages requests
+//   - /v1/audio/* for OpenAI-compatible speech, transcription, and translation
+//   - /v1/inference/{model} for model-native reranking
+package deepinfra
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/Laisky/errors/v2"
+	"github.com/gin-gonic/gin"
+
+	"github.com/Laisky/one-api/common/ctxkey"
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/adaptor/openai"
+	"github.com/Laisky/one-api/relay/adaptor/openai_compatible"
+	"github.com/Laisky/one-api/relay/meta"
+	"github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+const defaultAnthropicVersion = "2023-06-01"
+
+// Adaptor translates one-api relay requests to DeepInfra's public API surfaces.
+type Adaptor struct {
+	adaptor.DefaultPricingMethods
+}
+
+// Init initializes request-scoped state. DeepInfra does not require mutable state.
+func (a *Adaptor) Init(meta *meta.Meta) {}
+
+// GetChannelName returns the stable provider identifier used in logs and metrics.
+func (a *Adaptor) GetChannelName() string {
+	return "deepinfra"
+}
+
+// GetModelList returns a deterministic snapshot of supported DeepInfra models.
+func (a *Adaptor) GetModelList() []string {
+	models := make([]string, 0, len(ModelRatios))
+	for modelName := range ModelRatios {
+		models = append(models, modelName)
+	}
+	sort.Strings(models)
+	return models
+}
+
+// GetDefaultModelPricing returns DeepInfra's provider-scoped pricing snapshot.
+func (a *Adaptor) GetDefaultModelPricing() map[string]adaptor.ModelConfig {
+	return ModelRatios
+}
+
+// GetModelRatio returns the input-token or operation ratio for a DeepInfra model.
+func (a *Adaptor) GetModelRatio(modelName string) float64 {
+	if config, ok := ModelRatios[modelName]; ok {
+		return config.Ratio
+	}
+	return a.DefaultPricingMethods.GetModelRatio(modelName)
+}
+
+// GetCompletionRatio returns the output-to-input price multiplier for a model.
+func (a *Adaptor) GetCompletionRatio(modelName string) float64 {
+	if config, ok := ModelRatios[modelName]; ok {
+		return config.CompletionRatio
+	}
+	return a.DefaultPricingMethods.GetCompletionRatio(modelName)
+}
+
+// DefaultToolingConfig returns an empty provider-built-tool policy.
+func (a *Adaptor) DefaultToolingConfig() adaptor.ChannelToolConfig {
+	return adaptor.ChannelToolConfig{}
+}
+
+// GetRequestURL maps each one-api relay mode to the corresponding DeepInfra surface.
+func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
+	if meta == nil {
+		return "", errors.New("meta is nil")
+	}
+
+	baseURL := adaptor.NormalizeBaseURL(meta.BaseURL)
+	switch meta.Mode {
+	case relaymode.ChatCompletions, relaymode.ResponseAPI:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/openai/chat/completions"), nil
+	case relaymode.Completions:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/openai/completions"), nil
+	case relaymode.Embeddings:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/openai/embeddings"), nil
+	case relaymode.ImagesGenerations:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/openai/images/generations"), nil
+	case relaymode.ImagesEdits:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/images/edits"), nil
+	case relaymode.AudioSpeech:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/audio/speech"), nil
+	case relaymode.AudioTranscription:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/audio/transcriptions"), nil
+	case relaymode.AudioTranslation:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/audio/translations"), nil
+	case relaymode.ClaudeMessages:
+		return adaptor.JoinBaseURLAndPath(baseURL, "/anthropic/v1/messages"), nil
+	case relaymode.Rerank:
+		modelPath, err := escapeModelPath(meta.ActualModelName)
+		if err != nil {
+			return "", err
+		}
+		return adaptor.JoinBaseURLAndPath(baseURL, "/v1/inference/"+modelPath), nil
+	default:
+		return "", errors.Errorf("unsupported DeepInfra relay mode: %s", relaymode.String(meta.Mode))
+	}
+}
+
+// escapeModelPath validates and escapes a provider/model identifier one segment at a time.
+func escapeModelPath(modelName string) (string, error) {
+	modelName = strings.TrimSpace(modelName)
+	if modelName == "" {
+		return "", errors.New("DeepInfra model name is empty")
+	}
+
+	segments := strings.Split(modelName, "/")
+	for index, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if segment == "" || segment == "." || segment == ".." {
+			return "", errors.Errorf("invalid DeepInfra model path segment at index %d", index)
+		}
+		segments[index] = url.PathEscape(segment)
+	}
+	return strings.Join(segments, "/"), nil
+}
+
+// SetupRequestHeader applies DeepInfra Bearer authentication and Anthropic version headers.
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, meta *meta.Meta) error {
+	if req == nil {
+		return errors.New("request is nil")
+	}
+	if meta == nil {
+		return errors.New("meta is nil")
+	}
+
+	adaptor.SetupCommonRequestHeader(c, req, meta)
+	req.Header.Set("Authorization", "Bearer "+meta.APIKey)
+
+	if meta.Mode == relaymode.ClaudeMessages {
+		anthropicVersion := defaultAnthropicVersion
+		if c != nil && c.Request != nil {
+			if incoming := strings.TrimSpace(c.Request.Header.Get("anthropic-version")); incoming != "" {
+				anthropicVersion = incoming
+			}
+			if beta := strings.TrimSpace(c.Request.Header.Get("anthropic-beta")); beta != "" {
+				req.Header.Set("anthropic-beta", beta)
+			}
+		}
+		req.Header.Set("anthropic-version", anthropicVersion)
+	}
+	return nil
+}
+
+// ConvertRequest forwards OpenAI-compatible requests without provider-specific mutation.
+func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.GeneralOpenAIRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	return request, nil
+}
+
+// ConvertImageRequest forwards OpenAI-compatible image requests unchanged.
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, request *model.ImageRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	return request, nil
+}
+
+// ConvertClaudeRequest enables native Anthropic Messages passthrough for DeepInfra.
+func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, request *model.ClaudeRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	if c != nil {
+		c.Set(ctxkey.ClaudeModel, request.Model)
+		c.Set(ctxkey.ClaudeMessagesNative, true)
+		c.Set(ctxkey.ClaudeDirectPassthrough, true)
+	}
+	return request, nil
+}
+
+// DoRequest sends the converted request through the shared HTTP transport.
+func (a *Adaptor) DoRequest(c *gin.Context, meta *meta.Meta, requestBody io.Reader) (*http.Response, error) {
+	return adaptor.DoRequestHelper(a, c, meta, requestBody)
+}
+
+// DoResponse dispatches DeepInfra responses to the matching shared response handler.
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *meta.Meta) (usage *model.Usage, err *model.ErrorWithStatusCode) {
+	if meta == nil {
+		return nil, openai_compatible.ErrorWrapper(errors.New("meta is nil"), "invalid_meta", http.StatusInternalServerError)
+	}
+
+	switch meta.Mode {
+	case relaymode.Rerank:
+		err, usage = handleRerankResponse(c, resp, meta.ActualModelName, meta.PromptTokens)
+		return
+	case relaymode.Embeddings:
+		err, usage = openai_compatible.EmbeddingHandler(c, resp)
+		return
+	case relaymode.ImagesGenerations, relaymode.ImagesEdits:
+		err, usage = openai.ImageHandler(c, resp)
+		return
+	}
+
+	// Native Claude Messages and audio requests use controller-level passthrough
+	// paths. The remaining modes use DeepInfra's OpenAI-compatible response shape.
+	if meta.IsStream {
+		err, usage = openai_compatible.StreamHandler(c, resp, meta.PromptTokens, meta.ActualModelName)
+		return
+	}
+	err, usage = openai_compatible.Handler(c, resp, meta.PromptTokens, meta.ActualModelName)
+	return
+}

--- a/relay/adaptor/deepinfra/adaptor_test.go
+++ b/relay/adaptor/deepinfra/adaptor_test.go
@@ -1,0 +1,105 @@
+package deepinfra
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/common/ctxkey"
+	"github.com/Laisky/one-api/relay/meta"
+	"github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+// TestGetRequestURL verifies every DeepInfra relay surface and custom base URL normalization.
+func TestGetRequestURL(t *testing.T) {
+	t.Parallel()
+
+	adaptor := &Adaptor{}
+	tests := []struct {
+		name      string
+		mode      int
+		modelName string
+		wantURL   string
+	}{
+		{name: "chat", mode: relaymode.ChatCompletions, wantURL: "https://api.deepinfra.com/v1/openai/chat/completions"},
+		{name: "responses fallback", mode: relaymode.ResponseAPI, wantURL: "https://api.deepinfra.com/v1/openai/chat/completions"},
+		{name: "completions", mode: relaymode.Completions, wantURL: "https://api.deepinfra.com/v1/openai/completions"},
+		{name: "embeddings", mode: relaymode.Embeddings, wantURL: "https://api.deepinfra.com/v1/openai/embeddings"},
+		{name: "image generation", mode: relaymode.ImagesGenerations, wantURL: "https://api.deepinfra.com/v1/openai/images/generations"},
+		{name: "image edit", mode: relaymode.ImagesEdits, wantURL: "https://api.deepinfra.com/v1/images/edits"},
+		{name: "speech", mode: relaymode.AudioSpeech, wantURL: "https://api.deepinfra.com/v1/audio/speech"},
+		{name: "transcription", mode: relaymode.AudioTranscription, wantURL: "https://api.deepinfra.com/v1/audio/transcriptions"},
+		{name: "translation", mode: relaymode.AudioTranslation, wantURL: "https://api.deepinfra.com/v1/audio/translations"},
+		{name: "claude messages", mode: relaymode.ClaudeMessages, wantURL: "https://api.deepinfra.com/anthropic/v1/messages"},
+		{name: "rerank", mode: relaymode.Rerank, modelName: "Qwen/Qwen3-Reranker-8B", wantURL: "https://api.deepinfra.com/v1/inference/Qwen/Qwen3-Reranker-8B"},
+		{name: "versioned rerank", mode: relaymode.Rerank, modelName: "Qwen/Qwen3-Reranker-8B:2026-08-01", wantURL: "https://api.deepinfra.com/v1/inference/Qwen/Qwen3-Reranker-8B:2026-08-01"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			url, err := adaptor.GetRequestURL(&meta.Meta{
+				Mode:            test.mode,
+				BaseURL:         " https://api.deepinfra.com/ ",
+				ActualModelName: test.modelName,
+			})
+			require.NoError(t, err)
+			require.Equal(t, test.wantURL, url)
+		})
+	}
+}
+
+// TestGetRequestURLRejectsInvalidInputs verifies unsupported modes and unsafe model paths.
+func TestGetRequestURLRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+
+	adaptor := &Adaptor{}
+	_, err := adaptor.GetRequestURL(nil)
+	require.Error(t, err)
+
+	_, err = adaptor.GetRequestURL(&meta.Meta{Mode: relaymode.Moderations, BaseURL: "https://api.deepinfra.com"})
+	require.ErrorContains(t, err, "unsupported DeepInfra relay mode")
+
+	_, err = adaptor.GetRequestURL(&meta.Meta{Mode: relaymode.Rerank, BaseURL: "https://api.deepinfra.com", ActualModelName: "../secret"})
+	require.Error(t, err)
+}
+
+// TestSetupRequestHeader verifies Bearer auth and native Anthropic headers.
+func TestSetupRequestHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	clientRequest := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	clientRequest.Header.Set("anthropic-version", "2024-01-01")
+	clientRequest.Header.Set("anthropic-beta", "prompt-caching-2024-07-31")
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = clientRequest
+
+	upstreamRequest := httptest.NewRequest(http.MethodPost, "https://api.deepinfra.com/anthropic/v1/messages", nil)
+	adaptor := &Adaptor{}
+	err := adaptor.SetupRequestHeader(context, upstreamRequest, &meta.Meta{
+		Mode:   relaymode.ClaudeMessages,
+		APIKey: "deepinfra-token",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Bearer deepinfra-token", upstreamRequest.Header.Get("Authorization"))
+	require.Equal(t, "2024-01-01", upstreamRequest.Header.Get("anthropic-version"))
+	require.Equal(t, "prompt-caching-2024-07-31", upstreamRequest.Header.Get("anthropic-beta"))
+}
+
+// TestConvertClaudeRequest verifies that native Messages passthrough state is enabled.
+func TestConvertClaudeRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	request := &model.ClaudeRequest{Model: "Qwen/Qwen3.8-Max"}
+
+	converted, err := (&Adaptor{}).ConvertClaudeRequest(context, request)
+	require.NoError(t, err)
+	require.Same(t, request, converted)
+	require.Equal(t, request.Model, context.GetString(ctxkey.ClaudeModel))
+	require.True(t, context.GetBool(ctxkey.ClaudeMessagesNative))
+	require.True(t, context.GetBool(ctxkey.ClaudeDirectPassthrough))
+}

--- a/relay/adaptor/deepinfra/completion.go
+++ b/relay/adaptor/deepinfra/completion.go
@@ -1,0 +1,176 @@
+package deepinfra
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Laisky/errors/v2"
+	"github.com/gin-gonic/gin"
+
+	"github.com/Laisky/one-api/relay/adaptor/openai_compatible"
+	"github.com/Laisky/one-api/relay/model"
+)
+
+type completionChoice struct {
+	Text string `json:"text"`
+}
+
+type completionEnvelope struct {
+	Choices []completionChoice `json:"choices"`
+	Usage   *model.Usage       `json:"usage,omitempty"`
+	Error   *model.Error       `json:"error,omitempty"`
+}
+
+// handleCompletionResponse preserves the legacy OpenAI choices[].text envelope
+// while extracting or synthesizing usage for one-api billing.
+func handleCompletionResponse(c *gin.Context, resp *http.Response, promptTokens int, modelName string) (*model.ErrorWithStatusCode, *model.Usage) {
+	if c == nil {
+		return openai_compatible.ErrorWrapper(errors.New("gin context is nil"), "invalid_context", http.StatusInternalServerError), nil
+	}
+	if resp == nil || resp.Body == nil {
+		return openai_compatible.ErrorWrapper(errors.New("upstream response is nil"), "invalid_response", http.StatusInternalServerError), nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return openai_compatible.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		return openai_compatible.ErrorWrapper(closeErr, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+
+	var parsed completionEnvelope
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return openai_compatible.ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if parsed.Error != nil && strings.TrimSpace(parsed.Error.Message) != "" {
+		if parsed.Error.RawError == nil {
+			parsed.Error.RawError = errors.New(parsed.Error.Message)
+		}
+		return &model.ErrorWithStatusCode{Error: *parsed.Error, StatusCode: resp.StatusCode}, nil
+	}
+	if len(parsed.Choices) == 0 {
+		return openai_compatible.ErrorWrapper(errors.New("completion response has no choices"), "no_choices_in_response", http.StatusBadGateway), nil
+	}
+
+	usage := finalizeCompletionUsage(parsed.Usage, parsed.Choices, promptTokens, modelName)
+
+	// Add synthesized usage without losing provider-specific top-level or choice fields.
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return openai_compatible.ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+	usageJSON, err := json.Marshal(usage)
+	if err != nil {
+		return openai_compatible.ErrorWrapper(err, "marshal_usage_failed", http.StatusInternalServerError), nil
+	}
+	payload["usage"] = usageJSON
+	rendered, err := json.Marshal(payload)
+	if err != nil {
+		return openai_compatible.ErrorWrapper(err, "marshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+
+	c.Data(resp.StatusCode, "application/json", rendered)
+	return nil, usage
+}
+
+// handleCompletionStream forwards legacy completion SSE events unchanged and
+// accumulates choices[].text for fallback usage accounting.
+func handleCompletionStream(c *gin.Context, resp *http.Response, promptTokens int, modelName string) (*model.ErrorWithStatusCode, *model.Usage) {
+	if c == nil {
+		return openai_compatible.ErrorWrapper(errors.New("gin context is nil"), "invalid_context", http.StatusInternalServerError), nil
+	}
+	if resp == nil || resp.Body == nil {
+		return openai_compatible.ErrorWrapper(errors.New("upstream response is nil"), "invalid_response", http.StatusInternalServerError), nil
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		if strings.EqualFold(key, "Content-Length") {
+			continue
+		}
+		for _, value := range values {
+			c.Writer.Header().Add(key, value)
+		}
+	}
+	if c.Writer.Header().Get("Content-Type") == "" {
+		c.Writer.Header().Set("Content-Type", "text/event-stream")
+	}
+	c.Status(resp.StatusCode)
+
+	reader := bufio.NewReader(resp.Body)
+	usage := &model.Usage{}
+	var completionText strings.Builder
+	var writeErr error
+
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			parseCompletionStreamLine(line, usage, &completionText)
+			if writeErr == nil {
+				if _, err := c.Writer.Write(line); err != nil {
+					writeErr = err
+				} else if flusher, ok := c.Writer.(http.Flusher); ok {
+					flusher.Flush()
+				}
+			}
+		}
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) {
+				return openai_compatible.ErrorWrapper(readErr, "read_stream_failed", http.StatusInternalServerError), usage
+			}
+			break
+		}
+	}
+
+	finalizeCompletionUsage(usage, []completionChoice{{Text: completionText.String()}}, promptTokens, modelName)
+	if writeErr != nil {
+		return openai_compatible.ErrorWrapper(writeErr, "write_stream_failed", http.StatusInternalServerError), usage
+	}
+	return nil, usage
+}
+
+func parseCompletionStreamLine(line []byte, usage *model.Usage, completionText *strings.Builder) {
+	trimmed := strings.TrimSpace(string(line))
+	if !strings.HasPrefix(trimmed, "data:") {
+		return
+	}
+	payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+	if payload == "" || payload == "[DONE]" {
+		return
+	}
+
+	var chunk completionEnvelope
+	if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+		return
+	}
+	for _, choice := range chunk.Choices {
+		completionText.WriteString(choice.Text)
+	}
+	if chunk.Usage != nil {
+		*usage = *chunk.Usage
+	}
+}
+
+func finalizeCompletionUsage(usage *model.Usage, choices []completionChoice, promptTokens int, modelName string) *model.Usage {
+	if usage == nil {
+		usage = &model.Usage{}
+	}
+	if usage.PromptTokens == 0 {
+		usage.PromptTokens = promptTokens
+	}
+	if usage.CompletionTokens == 0 {
+		for _, choice := range choices {
+			usage.CompletionTokens += openai_compatible.CountTokenText(choice.Text, modelName)
+		}
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	}
+	usage.NormalizeCachedTokens()
+	usage.NormalizeCacheWriteTokens()
+	return usage
+}

--- a/relay/adaptor/deepinfra/completion_test.go
+++ b/relay/adaptor/deepinfra/completion_test.go
@@ -1,0 +1,114 @@
+package deepinfra
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/model"
+)
+
+func TestHandleCompletionResponsePreservesTextEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body: io.NopCloser(bytes.NewBufferString(`{
+			"id":"cmpl-1",
+			"object":"text_completion",
+			"model":"deepseek-ai/DeepSeek-V4-Flash",
+			"choices":[{"text":"hello world","index":0,"finish_reason":"stop","logprobs":null}]
+		}`)),
+	}
+
+	relayError, usage := handleCompletionResponse(context, response, 5, "deepseek-ai/DeepSeek-V4-Flash")
+	require.Nil(t, relayError)
+	require.Equal(t, 5, usage.PromptTokens)
+	require.Equal(t, 2, usage.CompletionTokens)
+	require.Equal(t, 7, usage.TotalTokens)
+
+	var rendered map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &rendered))
+	var choices []struct {
+		Text         string          `json:"text"`
+		Index        int             `json:"index"`
+		FinishReason string          `json:"finish_reason"`
+		Logprobs     json.RawMessage `json:"logprobs"`
+	}
+	require.NoError(t, json.Unmarshal(rendered["choices"], &choices))
+	require.Len(t, choices, 1)
+	require.Equal(t, "hello world", choices[0].Text)
+	require.Equal(t, "stop", choices[0].FinishReason)
+
+	var renderedUsage model.Usage
+	require.NoError(t, json.Unmarshal(rendered["usage"], &renderedUsage))
+	require.Equal(t, 7, renderedUsage.TotalTokens)
+}
+
+func TestHandleCompletionResponseUsesUpstreamUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body: io.NopCloser(bytes.NewBufferString(`{
+			"choices":[{"text":"hello","index":0}],
+			"usage":{"prompt_tokens":11,"completion_tokens":3,"total_tokens":14}
+		}`)),
+	}
+
+	relayError, usage := handleCompletionResponse(context, response, 5, "model")
+	require.Nil(t, relayError)
+	require.Equal(t, 11, usage.PromptTokens)
+	require.Equal(t, 3, usage.CompletionTokens)
+	require.Equal(t, 14, usage.TotalTokens)
+}
+
+func TestHandleCompletionStreamPreservesSSEAndSynthesizesUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	body := "data: {\"id\":\"cmpl-1\",\"choices\":[{\"text\":\"hello \"}]}\n\n" +
+		"data: {\"id\":\"cmpl-1\",\"choices\":[{\"text\":\"world\"}]}\n\n" +
+		"data: [DONE]\n\n"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	relayError, usage := handleCompletionStream(context, response, 4, "model")
+	require.Nil(t, relayError)
+	require.Equal(t, body, recorder.Body.String())
+	require.Equal(t, 4, usage.PromptTokens)
+	require.Equal(t, 2, usage.CompletionTokens)
+	require.Equal(t, 6, usage.TotalTokens)
+}
+
+func TestHandleCompletionStreamUsesUsageChunk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	body := "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":4,\"total_tokens\":13}}\n\n" +
+		"data: [DONE]\n\n"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	relayError, usage := handleCompletionStream(context, response, 1, "model")
+	require.Nil(t, relayError)
+	require.Equal(t, 9, usage.PromptTokens)
+	require.Equal(t, 4, usage.CompletionTokens)
+	require.Equal(t, 13, usage.TotalTokens)
+}

--- a/relay/adaptor/deepinfra/models.go
+++ b/relay/adaptor/deepinfra/models.go
@@ -1,0 +1,251 @@
+package deepinfra
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+var (
+	deepInfraTextInput              = []string{"text"}
+	deepInfraVisionInput            = []string{"text", "image"}
+	deepInfraTextOutput             = []string{"text"}
+	deepInfraChatSamplingParameters = []string{
+		"temperature",
+		"top_p",
+		"top_k",
+		"frequency_penalty",
+		"presence_penalty",
+		"repetition_penalty",
+		"stop",
+		"seed",
+		"max_tokens",
+		"logprobs",
+		"top_logprobs",
+		"response_format",
+		"tools",
+		"tool_choice",
+		"n",
+	}
+)
+
+// ModelRatios is a maintained pricing and capability snapshot for current
+// DeepInfra serverless models. DeepInfra changes its catalog frequently; channel
+// model configuration remains the override path for newly released, versioned,
+// private, or custom-deployment model IDs.
+var ModelRatios = map[string]adaptor.ModelConfig{
+	"moonshotai/Kimi-K3":               textModel(2.85, 14.25, 0.285, 1048576, false, true, "Long-context Kimi K3 reasoning model."),
+	"Qwen/Qwen3.8-2.4T-A95B":           textModel(2.00, 6.00, 0.20, 262144, false, true, "Qwen 3.8 flagship mixture-of-experts model."),
+	"Qwen/Qwen3.8-27B":                 textModel(0.40, 3.00, 0.04, 262144, false, true, "Qwen 3.8 27B instruction and reasoning model."),
+	"Qwen/Qwen3.8-Max":                 textModel(1.65, 4.951, 0.206, 262144, false, true, "Qwen 3.8 Max hosted model."),
+	"Qwen/Qwen3.7-Max":                 textModel(2.50, 7.50, 0.50, 250000, false, true, "Qwen 3.7 Max hosted model."),
+	"Qwen/Qwen3-Max":                   textModel(1.20, 6.00, 0.24, 250000, false, false, "Qwen3 Max general-purpose model."),
+	"Qwen/Qwen3-Max-Thinking":          textModel(1.20, 6.00, 0.24, 250000, false, true, "Qwen3 Max reasoning model."),
+	"Qwen/Qwen3.6-35B-A3B":             textModel(0.10, 0.95, 0.00, 262144, false, true, "Qwen 3.6 sparse 35B model."),
+	"Qwen/Qwen3.6-27B":                 textModel(0.32, 3.20, 0.00, 262144, false, true, "Qwen 3.6 dense 27B model."),
+	"Qwen/Qwen3.5-397B-A17B":           textModel(0.45, 3.00, 0.22, 262144, false, true, "Qwen 3.5 flagship sparse model."),
+	"Qwen/Qwen3.5-122B-A10B":           textModel(0.29, 2.40, 0.00, 262144, false, true, "Qwen 3.5 122B sparse model."),
+	"Qwen/Qwen3.5-35B-A3B":             textModel(0.14, 1.00, 0.05, 262144, false, true, "Qwen 3.5 efficient sparse model."),
+	"Qwen/Qwen3.5-27B":                 textModel(0.26, 2.60, 0.00, 262144, false, true, "Qwen 3.5 dense 27B model."),
+	"Qwen/Qwen3.5-9B":                  textModel(0.10, 0.15, 0.00, 262144, false, false, "Qwen 3.5 compact 9B model."),
+	"Qwen/Qwen3-VL-235B-A22B-Instruct": textModel(0.20, 0.88, 0.11, 262144, true, false, "Qwen3 VL flagship vision-language model."),
+	"Qwen/Qwen3-VL-30B-A3B-Instruct":   textModel(0.15, 0.60, 0.00, 262144, true, false, "Qwen3 VL efficient vision-language model."),
+
+	"deepseek-ai/DeepSeek-V4-Pro-0813":   textModel(1.30, 2.60, 0.10, 1048576, false, true, "DeepSeek V4 Pro dated release."),
+	"deepseek-ai/DeepSeek-V4-Pro":        textModel(1.30, 2.60, 0.10, 1048576, false, true, "DeepSeek V4 Pro long-context reasoning model."),
+	"deepseek-ai/DeepSeek-V4-Flash-0731": textModel(0.08, 0.18, 0.016, 1048576, false, true, "DeepSeek V4 Flash dated release."),
+	"deepseek-ai/DeepSeek-V4-Flash":      textModel(0.09, 0.18, 0.018, 1048576, false, true, "DeepSeek V4 Flash low-cost reasoning model."),
+	"deepseek-ai/DeepSeek-V3.2":          textModel(0.26, 0.38, 0.13, 160000, false, true, "DeepSeek V3.2 reasoning model."),
+
+	"zai-org/GLM-5.2":       textModel(0.75, 2.40, 0.14, 1048576, false, true, "GLM 5.2 long-context reasoning model."),
+	"zai-org/GLM-5.1":       textModel(1.05, 3.50, 0.205, 198000, false, true, "GLM 5.1 reasoning model."),
+	"zai-org/GLM-5":         textModel(0.60, 2.08, 0.12, 198000, false, true, "GLM 5 reasoning model."),
+	"zai-org/GLM-4.7-Flash": textModel(0.06, 0.40, 0.01, 198000, false, true, "GLM 4.7 Flash economical reasoning model."),
+
+	"moonshotai/Kimi-K2.7-Code": textModel(0.68, 3.40, 0.136, 262144, false, true, "Kimi K2.7 optimized for software engineering."),
+	"moonshotai/Kimi-K2.6":      textModel(0.75, 3.50, 0.15, 262144, false, true, "Kimi K2.6 general reasoning model."),
+	"moonshotai/Kimi-K2.5":      textModel(0.45, 2.25, 0.07, 262144, false, true, "Kimi K2.5 general reasoning model."),
+
+	"nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": textModel(0.50, 2.20, 0.10, 262144, false, true, "Nemotron 3 Ultra sparse reasoning model."),
+	"nvidia/NVIDIA-Nemotron-3-Super-120B-A12B": textModel(0.085, 0.40, 0.00, 262144, false, true, "Nemotron 3 Super efficient sparse model."),
+
+	"XiaomiMiMo/MiMo-V2.5-Pro": textModel(1.00, 3.00, 0.20, 1048576, false, true, "MiMo V2.5 Pro long-context reasoning model."),
+	"XiaomiMiMo/MiMo-V2.5":     textModel(0.40, 2.00, 0.08, 262144, false, true, "MiMo V2.5 general reasoning model."),
+
+	"google/gemma-4-26B-A4B-it": textModel(0.07, 0.34, 0.00, 262144, false, false, "Gemma 4 26B sparse instruction model."),
+	"google/gemma-4-31B-it":     textModel(0.13, 0.38, 0.00, 262144, false, false, "Gemma 4 31B instruction model."),
+
+	"ByteDance/Seed-1.8":      textModel(0.25, 2.00, 0.05, 250000, false, true, "Seed 1.8 general reasoning model."),
+	"ByteDance/Seed-2.0-code": textModel(0.50, 3.00, 0.10, 262144, false, true, "Seed 2.0 coding model."),
+	"ByteDance/Seed-2.0-mini": textModel(0.10, 0.40, 0.02, 262144, false, false, "Seed 2.0 compact model."),
+	"ByteDance/Seed-2.0-pro":  textModel(0.50, 3.00, 0.10, 262144, false, true, "Seed 2.0 Pro reasoning model."),
+
+	"MiniMaxAI/MiniMax-M2.7":       textModel(0.25, 1.00, 0.05, 196608, false, true, "MiniMax M2.7 reasoning model."),
+	"MiniMaxAI/MiniMax-M2.7-Turbo": textModel(0.38, 1.70, 0.07, 196608, false, true, "Low-latency MiniMax M2.7 variant."),
+	"MiniMaxAI/MiniMax-M3":         textModel(0.28, 1.10, 0.056, 524288, false, true, "MiniMax M3 long-context reasoning model."),
+
+	"BAAI/bge-base-en-v1.5":                            embeddingModel(0.005, 512, "Compact English embedding model."),
+	"BAAI/bge-en-icl":                                  embeddingModel(0.010, 8192, "Instruction-aware English embedding model."),
+	"BAAI/bge-large-en-v1.5":                           embeddingModel(0.010, 512, "High-quality English embedding model."),
+	"BAAI/bge-m3":                                      embeddingModel(0.010, 8192, "Multilingual and multi-function BGE embedding model."),
+	"BAAI/bge-m3-multi":                                embeddingModel(0.010, 8192, "BGE M3 multilingual embedding variant."),
+	"Qwen/Qwen3-Embedding-0.6B":                        embeddingModel(0.010, 32768, "Compact Qwen3 text embedding model."),
+	"Qwen/Qwen3-Embedding-4B":                          embeddingModel(0.020, 32768, "Mid-size Qwen3 text embedding model."),
+	"Qwen/Qwen3-Embedding-8B":                          embeddingModel(0.010, 32768, "Large Qwen3 text embedding model."),
+	"google/embeddinggemma-300m":                       embeddingModel(0.002, 2048, "Compact multilingual EmbeddingGemma model."),
+	"intfloat/e5-base-v2":                              embeddingModel(0.005, 512, "E5 base English text embedding model."),
+	"intfloat/e5-large-v2":                             embeddingModel(0.010, 512, "E5 large English text embedding model."),
+	"intfloat/multilingual-e5-large":                   embeddingModel(0.010, 512, "Multilingual E5 large embedding model."),
+	"intfloat/multilingual-e5-large-instruct":          embeddingModel(0.010, 512, "Instruction-tuned multilingual E5 embedding model."),
+	"nvidia/Nemotron-3-Embed-1B-BF16":                  embeddingModel(0.015, 32768, "NVIDIA multilingual Nemotron 1B BF16 embedding model."),
+	"nvidia/Nemotron-3-Embed-1B-NVFP4":                 embeddingModel(0.010, 32768, "NVIDIA multilingual Nemotron 1B NVFP4 embedding model."),
+	"nvidia/Nemotron-3-Embed-8B":                       embeddingModel(0.035, 32768, "NVIDIA multilingual Nemotron 8B embedding model."),
+	"sentence-transformers/all-MiniLM-L12-v2":          embeddingModel(0.005, 512, "Sentence Transformers MiniLM L12 embedding model."),
+	"sentence-transformers/all-MiniLM-L6-v2":           embeddingModel(0.005, 512, "Sentence Transformers MiniLM L6 embedding model."),
+	"sentence-transformers/all-mpnet-base-v2":          embeddingModel(0.005, 512, "Sentence Transformers MPNet embedding model."),
+	"sentence-transformers/multi-qa-mpnet-base-dot-v1": embeddingModel(0.005, 512, "MPNet semantic-search embedding model."),
+	"sentence-transformers/paraphrase-MiniLM-L6-v2":    embeddingModel(0.005, 512, "MiniLM paraphrase embedding model."),
+
+	"Qwen/Qwen3-Reranker-0.6B": rerankModel(0.010, 32768, "Compact Qwen3 cross-encoder reranker."),
+	"Qwen/Qwen3-Reranker-4B":   rerankModel(0.025, 32768, "Mid-size Qwen3 cross-encoder reranker."),
+	"Qwen/Qwen3-Reranker-8B":   rerankModel(0.050, 32768, "Large Qwen3 cross-encoder reranker for RAG pipelines."),
+
+	"Qwen/Qwen3-ASR-0.6B":                                 minutePricedAudioModel(0.00020, "Compact multilingual Qwen3 speech recognition model."),
+	"Qwen/Qwen3-ASR-1.7B":                                 minutePricedAudioModel(0.00045, "Flagship multilingual Qwen3 speech recognition model."),
+	"mistralai/Voxtral-Mini-3B-2507":                      minutePricedAudioModel(0.00100, "Voxtral Mini transcription and speech translation model."),
+	"mistralai/Voxtral-Small-24B-2507":                    minutePricedAudioModel(0.00300, "Voxtral Small transcription and speech translation model."),
+	"nvidia/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b": minutePricedAudioModel(0.00020, "Low-latency multilingual Nemotron ASR model."),
+	"openai/whisper-large-v3":                             minutePricedAudioModel(0.00045, "Whisper large v3 transcription and translation model."),
+	"openai/whisper-large-v3-turbo":                       minutePricedAudioModel(0.00020, "Faster Whisper large v3 transcription and translation model."),
+
+	"Qwen/Qwen3-TTS":                     characterPricedAudioModel(20.0, "Qwen3 text-to-speech model."),
+	"Qwen/Qwen3-TTS-VoiceDesign":         characterPricedAudioModel(20.0, "Qwen3 TTS model with prompt-driven voice design."),
+	"Audio8/Audio8-TTS-Preview-0.6b":     characterPricedAudioModel(5.0, "Audio8 compact preview text-to-speech model."),
+	"ResembleAI/chatterbox-multilingual": characterPricedAudioModel(1.0, "Multilingual Chatterbox text-to-speech model."),
+	"ResembleAI/chatterbox-turbo":        characterPricedAudioModel(1.0, "Low-latency Chatterbox text-to-speech model."),
+	"bosonai/HiggsAudioV2.5":             characterPricedAudioModel(20.0, "HiggsAudio V2.5 natural text-to-speech model."),
+	"canopylabs/orpheus-3b-0.1-ft":       characterPricedAudioModel(7.0, "Orpheus empathetic text-to-speech model."),
+	"hexgrad/Kokoro-82M":                 characterPricedAudioModel(0.62, "Compact and efficient Kokoro text-to-speech model."),
+	"inworld-ai/realtime-tts-1.5-max":    characterPricedAudioModel(50.0, "High-quality Inworld real-time text-to-speech model."),
+	"inworld-ai/realtime-tts-1.5-mini":   characterPricedAudioModel(25.0, "Low-latency Inworld real-time text-to-speech model."),
+	"inworld-ai/realtime-tts-2":          characterPricedAudioModel(35.0, "Steerable Inworld real-time text-to-speech model."),
+	"sesame/csm-1b":                      characterPricedAudioModel(7.0, "Sesame conversational speech generation model."),
+
+	"black-forest-labs/FLUX-2-klein-4b": imageModel(0.014, "FLUX.2 Klein 4B text-to-image and image editing model."),
+	"black-forest-labs/FLUX-2-klein-9b": imageModel(0.015, "FLUX.2 Klein 9B text-to-image and image editing model."),
+}
+
+// textModel builds token-priced text or vision model metadata.
+func textModel(inputUSD, outputUSD, cachedInputUSD float64, contextLength int32, vision bool, reasoning bool, description string) adaptor.ModelConfig {
+	completionRatio := 1.0
+	if inputUSD > 0 {
+		completionRatio = outputUSD / inputUSD
+	}
+
+	inputModalities := deepInfraTextInput
+	if vision {
+		inputModalities = deepInfraVisionInput
+	}
+	features := []string{"tools", "json_mode"}
+	if reasoning {
+		features = append(features, "reasoning")
+	}
+
+	config := adaptor.ModelConfig{
+		Ratio:                       inputUSD * billingratio.MilliTokensUsd,
+		CompletionRatio:             completionRatio,
+		ContextLength:               contextLength,
+		InputModalities:             append([]string(nil), inputModalities...),
+		OutputModalities:            append([]string(nil), deepInfraTextOutput...),
+		SupportedFeatures:           features,
+		SupportedSamplingParameters: append([]string(nil), deepInfraChatSamplingParameters...),
+		Description:                 description,
+	}
+	if cachedInputUSD > 0 {
+		config.CachedInputRatio = cachedInputUSD * billingratio.MilliTokensUsd
+	}
+	return config
+}
+
+// embeddingModel builds text-token-priced embedding metadata.
+func embeddingModel(inputUSD float64, contextLength int32, description string) adaptor.ModelConfig {
+	ratio := inputUSD * billingratio.MilliTokensUsd
+	return adaptor.ModelConfig{
+		Ratio:           ratio,
+		CompletionRatio: 1.0,
+		ContextLength:   contextLength,
+		Embedding: &adaptor.EmbeddingPricingConfig{
+			TextTokenRatio: ratio,
+		},
+		InputModalities:  []string{"text"},
+		OutputModalities: []string{"embedding"},
+		Description:      description,
+	}
+}
+
+// rerankModel builds token-priced reranking metadata.
+func rerankModel(inputUSD float64, contextLength int32, description string) adaptor.ModelConfig {
+	return adaptor.ModelConfig{
+		Ratio:                       inputUSD * billingratio.MilliTokensUsd,
+		CompletionRatio:             1.0,
+		ContextLength:               contextLength,
+		InputModalities:             []string{"text"},
+		OutputModalities:            []string{"text"},
+		SupportedSamplingParameters: []string{"top_n"},
+		Description:                 description,
+	}
+}
+
+// minutePricedAudioModel converts a provider per-minute ASR price to the
+// audio-token ratio used by one-api's transcription and translation controller.
+func minutePricedAudioModel(inputUSDPerMinute float64, description string) adaptor.ModelConfig {
+	const promptTokensPerSecond = 10.0
+
+	ratio := inputUSDPerMinute * float64(billingratio.QuotaPerUsd) / (60.0 * promptTokensPerSecond)
+	return adaptor.ModelConfig{
+		Ratio:           ratio,
+		CompletionRatio: 1.0,
+		Audio: &adaptor.AudioPricingConfig{
+			PromptTokensPerSecond: promptTokensPerSecond,
+			UsdPerSecond:          inputUSDPerMinute / 60.0,
+		},
+		InputModalities:  []string{"audio"},
+		OutputModalities: []string{"text"},
+		Description:      description,
+	}
+}
+
+// characterPricedAudioModel builds metadata for speech models billed per input character.
+func characterPricedAudioModel(inputUSDPerMillionCharacters float64, description string) adaptor.ModelConfig {
+	return adaptor.ModelConfig{
+		Ratio:            inputUSDPerMillionCharacters * billingratio.MilliTokensUsd,
+		CompletionRatio:  1.0,
+		InputModalities:  []string{"text"},
+		OutputModalities: []string{"audio"},
+		Description:      description,
+	}
+}
+
+// imageModel builds area-scaled per-image pricing for OpenAI-compatible image requests.
+func imageModel(basePriceUSD float64, description string) adaptor.ModelConfig {
+	return adaptor.ModelConfig{
+		Ratio:           0,
+		CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: basePriceUSD,
+			DefaultSize:      "1024x1024",
+			DefaultQuality:   "standard",
+			MinImages:        1,
+			MaxImages:        4,
+			SizeMultipliers: map[string]float64{
+				"512x512":   0.25,
+				"768x768":   0.5625,
+				"1024x1024": 1.0,
+				"1024x1536": 1.5,
+				"1536x1024": 1.5,
+			},
+		},
+		InputModalities:  []string{"text", "image"},
+		OutputModalities: []string{"image"},
+		Description:      description,
+	}
+}

--- a/relay/adaptor/deepinfra/models_catalog_media_20260819.go
+++ b/relay/adaptor/deepinfra/models_catalog_media_20260819.go
@@ -1,0 +1,46 @@
+package deepinfra
+
+// mediaCatalog20260819 contains active DeepInfra models whose relay protocol
+// and published pricing can be represented exactly by one-api. Iteration-priced
+// and output-token-priced image models, video/world/music/OCR models, and the
+// image-document reranker are intentionally excluded.
+func init() {
+	addDeepInfraCatalogModel("nvidia/llama-nemotron-embed-vl-1b-v2", catalogEmbeddingModel(0.01, 10000, []string{"text", "image"}, "Nemotron VL 1B multimodal embedding model."))
+	addDeepInfraCatalogModel("sentence-transformers/clip-ViT-B-32", catalogEmbeddingModel(0.005, 77, []string{"text", "image"}, "CLIP ViT-B/32 text and image embedding model."))
+	addDeepInfraCatalogModel("sentence-transformers/clip-ViT-B-32-multilingual-v1", catalogEmbeddingModel(0.005, 512, []string{"text", "image"}, "Multilingual CLIP ViT-B/32 embedding model."))
+	addDeepInfraCatalogModel("shibing624/text2vec-base-chinese", catalogEmbeddingModel(0.005, 512, []string{"text"}, "Chinese Text2Vec base embedding model."))
+	addDeepInfraCatalogModel("thenlper/gte-base", catalogEmbeddingModel(0.005, 512, []string{"text"}, "GTE base text embedding model."))
+	addDeepInfraCatalogModel("thenlper/gte-large", catalogEmbeddingModel(0.01, 512, []string{"text"}, "GTE large text embedding model."))
+	addDeepInfraCatalogModel("XiaomiMiMo/MiMo-V2.5-tts", characterPricedAudioModel(0, "MiMo V2.5 text-to-speech model."))
+	addDeepInfraCatalogModel("XiaomiMiMo/MiMo-V2.5-tts-voiceclone", characterPricedAudioModel(0, "MiMo V2.5 voice-cloning speech model."))
+	addDeepInfraCatalogModel("XiaomiMiMo/MiMo-V2.5-tts-voicedesign", characterPricedAudioModel(0, "MiMo V2.5 voice-design speech model."))
+	addDeepInfraCatalogModel("Bria/Bria-3.2", flatImageModel(0.04, false, "Bria 3.2 commercial text-to-image model."))
+	addDeepInfraCatalogModel("Bria/Bria-3.2-vector", flatImageModel(0.04, false, "Bria 3.2 Vector text-to-vector-image model."))
+	addDeepInfraCatalogModel("Bria/blur_background", flatImageModel(0.04, true, "Bria licensed-data background blur model."))
+	addDeepInfraCatalogModel("Bria/enhance", flatImageModel(0.04, true, "Bria licensed-data image enhancement model."))
+	addDeepInfraCatalogModel("Bria/erase", flatImageModel(0.04, true, "Bria licensed-data object eraser."))
+	addDeepInfraCatalogModel("Bria/erase_foreground", flatImageModel(0.04, true, "Bria licensed-data foreground eraser."))
+	addDeepInfraCatalogModel("Bria/expand", flatImageModel(0.04, true, "Bria licensed-data image expansion model."))
+	addDeepInfraCatalogModel("Bria/fibo", flatImageModel(0.04, false, "Bria FIBO structured text-to-image model."))
+	addDeepInfraCatalogModel("Bria/fibo_edit", flatImageModel(0.04, true, "Bria FIBO image editing model."))
+	addDeepInfraCatalogModel("Bria/gen_fill", flatImageModel(0.04, true, "Bria licensed-data generative fill model."))
+	addDeepInfraCatalogModel("Bria/remove_background", flatImageModel(0.018, true, "Bria background removal model."))
+	addDeepInfraCatalogModel("Bria/replace_background", flatImageModel(0.04, true, "Bria background replacement model."))
+	addDeepInfraCatalogModel("ByteDance/Seedream-4", flatImageModel(0.04, true, "Seedream 4 multimodal image generation and editing model."))
+	addDeepInfraCatalogModel("ByteDance/Seedream-4.5", flatImageModel(0.04, true, "Seedream 4.5 multimodal image generation and editing model."))
+	addDeepInfraCatalogModel("ClarityAI/creative", flatImageModel(0.05, true, "ClarityAI creative image upscaler."))
+	addDeepInfraCatalogModel("ClarityAI/crystal", flatImageModel(0.05, true, "ClarityAI portrait and product upscaler."))
+	addDeepInfraCatalogModel("ClarityAI/flux", flatImageModel(0.2, true, "ClarityAI FLUX-powered image upscaler."))
+	addDeepInfraCatalogModel("PrunaAI/p-image", flatImageModel(0.005, false, "Pruna P-Image real-time generation model."))
+	addDeepInfraCatalogModel("PrunaAI/p-image-Edit", flatImageModel(0.01, true, "Pruna P-Image-Edit transformation model."))
+	addDeepInfraCatalogModel("Qwen/Qwen-Image-Edit-Max", flatImageModel(0.075, true, "Qwen Image Edit Max model."))
+	addDeepInfraCatalogModel("Qwen/Qwen-Image-Max", flatImageModel(0.075, false, "Qwen Image Max generation model."))
+	addDeepInfraCatalogModel("Wan-AI/Wan2.6-Image-Edit", flatImageModel(0.03, true, "Wan 2.6 image generation and editing model."))
+	addDeepInfraCatalogModel("Wan-AI/Wan2.6-T2I", flatImageModel(0.03, false, "Wan 2.6 text-to-image model."))
+	addDeepInfraCatalogModel("Wan-AI/Wan2.7-Image-Edit", flatImageModel(0.03, true, "Wan 2.7 image generation and editing model."))
+	addDeepInfraCatalogModel("black-forest-labs/FLUX-1.1-pro", flatImageModel(0.04, false, "FLUX 1.1 Pro text-to-image model."))
+	addDeepInfraCatalogModel("black-forest-labs/FLUX-2-max", flatImageModel(0.07, true, "FLUX 2 Max image generation and editing model."))
+	addDeepInfraCatalogModel("black-forest-labs/FLUX-2-pro", flatImageModel(0.015, true, "FLUX 2 Pro image generation and editing model."))
+	addDeepInfraCatalogModel("deepseek-ai/Janus-Pro-1B", flatImageModel(0.0005, false, "Janus Pro 1B image generation model."))
+	addDeepInfraCatalogModel("deepseek-ai/Janus-Pro-7B", flatImageModel(0.002, false, "Janus Pro 7B image generation model."))
+}

--- a/relay/adaptor/deepinfra/models_catalog_shared.go
+++ b/relay/adaptor/deepinfra/models_catalog_shared.go
@@ -1,0 +1,47 @@
+package deepinfra
+
+import (
+	"fmt"
+
+	"github.com/Laisky/one-api/relay/adaptor"
+)
+
+type catalogTextEntry struct {
+	name           string
+	inputUSD       float64
+	outputUSD      float64
+	cachedInputUSD float64
+	contextLength  int32
+	modalities     []string
+	reasoning      bool
+}
+
+func addDeepInfraCatalogModel(modelName string, config adaptor.ModelConfig) {
+	if _, exists := ModelRatios[modelName]; exists {
+		panic(fmt.Sprintf("duplicate DeepInfra model catalog entry %q", modelName))
+	}
+	ModelRatios[modelName] = config
+}
+
+func catalogTextModel(inputUSD, outputUSD, cachedInputUSD float64, contextLength int32, modalities []string, reasoning bool, description string) adaptor.ModelConfig {
+	config := textModel(inputUSD, outputUSD, cachedInputUSD, contextLength, false, reasoning, description)
+	config.InputModalities = append([]string(nil), modalities...)
+	return config
+}
+
+func catalogEmbeddingModel(inputUSD float64, contextLength int32, modalities []string, description string) adaptor.ModelConfig {
+	config := embeddingModel(inputUSD, contextLength, description)
+	config.InputModalities = append([]string(nil), modalities...)
+	return config
+}
+
+func flatImageModel(pricePerImageUSD float64, acceptsImageInput bool, description string) adaptor.ModelConfig {
+	config := imageModel(pricePerImageUSD, description)
+	// These catalog entries are flat per-image prices, independent of image size.
+	config.Image.SizeMultipliers = nil
+	config.InputModalities = []string{"text"}
+	if acceptsImageInput {
+		config.InputModalities = []string{"text", "image"}
+	}
+	return config
+}

--- a/relay/adaptor/deepinfra/models_catalog_text_20260819.go
+++ b/relay/adaptor/deepinfra/models_catalog_text_20260819.go
@@ -1,0 +1,82 @@
+package deepinfra
+
+// textCatalog20260819 contains the active text-generation entries that are
+// not already present in the flagship catalog in models.go. Prices are USD
+// per one million input/output/cached-input tokens; contexts follow the live
+// DeepInfra catalog captured on 2026-08-19.
+var textCatalog20260819 = []catalogTextEntry{
+	{"Gryphe/MythoMax-L2-13b", 0.4, 0.4, 0, 4000, deepInfraTextInput, false},
+	{"NousResearch/Hermes-3-Llama-3.1-405B", 1, 1, 0, 128000, deepInfraTextInput, false},
+	{"NousResearch/Hermes-3-Llama-3.1-70B", 0.7, 0.7, 0, 128000, deepInfraTextInput, false},
+	{"Qwen/Qwen2.5-72B-Instruct", 0.36, 0.4, 0, 32000, deepInfraTextInput, false},
+	{"Qwen/Qwen3-14B", 0.12, 0.24, 0, 40000, deepInfraTextInput, true},
+	{"Qwen/Qwen3-235B-A22B-Instruct-2507", 0.09, 0.55, 0, 256000, deepInfraTextInput, false},
+	{"Qwen/Qwen3-30B-A3B", 0.12, 0.5, 0, 40000, deepInfraTextInput, true},
+	{"Qwen/Qwen3-32B", 0.08, 0.28, 0, 40000, deepInfraTextInput, true},
+	{"Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo", 0.3, 1, 0.1, 256000, deepInfraTextInput, true},
+	{"Qwen/Qwen3-Next-80B-A3B-Instruct", 0.09, 1.1, 0, 256000, deepInfraTextInput, false},
+	{"Sao10K/L3-8B-Lunaris-v1-Turbo", 0.04, 0.05, 0, 8000, deepInfraTextInput, false},
+	{"Sao10K/L3.1-70B-Euryale-v2.2", 0.85, 0.85, 0, 128000, deepInfraTextInput, false},
+	{"anthropic/claude-fable-5", 10, 50, 0, 976000, deepInfraVisionInput, true},
+	{"anthropic/claude-haiku-4-5", 1, 5, 0, 195000, deepInfraVisionInput, true},
+	{"anthropic/claude-opus-4-7", 5, 25, 0, 976000, deepInfraVisionInput, true},
+	{"anthropic/claude-opus-4-8", 5, 25, 0, 976000, deepInfraVisionInput, true},
+	{"anthropic/claude-opus-5", 5, 25, 0, 976000, deepInfraVisionInput, true},
+	{"anthropic/claude-sonnet-4-6", 3, 15, 0, 976000, deepInfraVisionInput, true},
+	{"anthropic/claude-sonnet-5", 2, 10, 0, 976000, deepInfraVisionInput, true},
+	{"deepseek-ai/DeepSeek-R1-0528", 0.5, 2.15, 0.35, 160000, deepInfraTextInput, true},
+	{"deepseek-ai/DeepSeek-V3", 0.32, 0.89, 0, 160000, deepInfraTextInput, false},
+	{"deepseek-ai/DeepSeek-V3-0324", 0.24, 0.9, 0.135, 160000, deepInfraTextInput, false},
+	{"deepseek-ai/DeepSeek-V3.1", 0.25, 0.95, 0.13, 160000, deepInfraTextInput, true},
+	{"google/gemini-2.5-flash", 0.3, 2.5, 0, 976000, deepInfraVisionInput, true},
+	{"google/gemini-2.5-pro", 1.25, 10, 0, 976000, deepInfraVisionInput, true},
+	{"google/gemini-3.1-flash-lite", 0.25, 1.5, 0, 976000, deepInfraVisionInput, true},
+	{"google/gemini-3.1-pro", 2, 12, 0, 976000, deepInfraVisionInput, true},
+	{"google/gemini-3.5-flash", 0.5, 3, 0, 976000, deepInfraVisionInput, true},
+	{"google/gemini-3.7-flash", 0.5, 3, 0, 976000, deepInfraVisionInput, true},
+	{"google/gemma-3-12b-it", 0.09, 0.3, 0, 128000, deepInfraVisionInput, false},
+	{"google/gemma-3-27b-it", 0.09, 0.16, 0, 128000, deepInfraVisionInput, false},
+	{"google/gemma-3-4b-it", 0.05, 0.1, 0, 128000, deepInfraVisionInput, false},
+	{"google/gemma-4-31B-it-Ultra", 0.27, 0.76, 0, 128000, deepInfraVisionInput, false},
+	{"google/gemma-4-31B-it-turbo", 0.09, 0.34, 0.05, 256000, deepInfraVisionInput, false},
+	{"google/gemma-4-E4B-it", 0.02, 0.1, 0, 128000, deepInfraVisionInput, false},
+	{"inclusionAI/Ling-3.0-flash", 0.06, 0.18, 0.012, 128000, deepInfraTextInput, true},
+	{"meta-llama/Llama-3.3-70B-Instruct-Turbo", 0.1, 0.32, 0, 128000, deepInfraTextInput, false},
+	{"meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8", 0.2, 0.8, 0, 1024000, deepInfraVisionInput, false},
+	{"meta-llama/Llama-4-Scout-17B-16E-Instruct", 0.1, 0.3, 0, 320000, deepInfraVisionInput, false},
+	{"meta-llama/Llama-Guard-4-12B", 0.18, 0.18, 0, 160000, deepInfraVisionInput, false},
+	{"meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo", 0.4, 0.4, 0, 128000, deepInfraTextInput, false},
+	{"meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", 0.02, 0.04, 0, 128000, deepInfraTextInput, false},
+	{"meta-models/Muse-Glimmer-30B", 0.3, 1.2, 0.04, 128000, deepInfraVisionInput, true},
+	{"microsoft/phi-4", 0.07, 0.14, 0, 16000, deepInfraTextInput, true},
+	{"mistralai/Mistral-Nemo-Instruct-2407", 0.019, 0.03, 0, 128000, deepInfraTextInput, false},
+	{"mistralai/Mistral-Small-24B-Instruct-2501", 0.05, 0.08, 0, 32000, deepInfraTextInput, false},
+	{"mistralai/Mistral-Small-3.2-24B-Instruct-2506", 0.075, 0.2, 0, 125000, deepInfraVisionInput, false},
+	{"nvidia/NVIDIA-Nemotron-3.5-Lightning", 0.08, 0.2, 0.04, 256000, deepInfraTextInput, true},
+	{"nvidia/Nemotron-3-Nano-30B-A3B", 0.05, 0.2, 0.025, 256000, deepInfraTextInput, true},
+	{"nvidia/Nemotron-Content-Safety-3.5", 0.2, 0.2, 0, 128000, deepInfraVisionInput, false},
+	{"openai/gpt-oss-120b", 0.037, 0.17, 0, 128000, deepInfraTextInput, true},
+	{"openai/gpt-oss-120b-Turbo", 0.15, 0.6, 0, 128000, deepInfraTextInput, true},
+	{"openai/gpt-oss-120b-Ultra", 0.2, 0.95, 0, 128000, deepInfraTextInput, true},
+	{"openai/gpt-oss-20b", 0.03, 0.14, 0, 128000, deepInfraTextInput, true},
+	{"stepfun-ai/Step-3.7-Flash", 0.2, 1.15, 0.04, 256000, deepInfraVisionInput, true},
+	{"tencent/Hy3", 0.14, 0.58, 0.035, 256000, deepInfraTextInput, false},
+	{"thinkingmachines/Inkling", 0.95, 4.05, 0.16, 512000, []string{"text", "image", "audio"}, true},
+	{"thinkingmachines/Inkling-Small", 0.45, 1.2, 0.1, 512000, []string{"text", "image", "audio"}, true},
+	{"zai-org/GLM-4.6", 0.5, 2, 0.1, 198000, deepInfraTextInput, true},
+	{"zai-org/GLM-4.7", 0.4, 1.75, 0.08, 198000, deepInfraTextInput, true},
+}
+
+func init() {
+	for _, entry := range textCatalog20260819 {
+		addDeepInfraCatalogModel(entry.name, catalogTextModel(
+			entry.inputUSD,
+			entry.outputUSD,
+			entry.cachedInputUSD,
+			entry.contextLength,
+			entry.modalities,
+			entry.reasoning,
+			"DeepInfra hosted text-generation model.",
+		))
+	}
+}

--- a/relay/adaptor/deepinfra/models_test.go
+++ b/relay/adaptor/deepinfra/models_test.go
@@ -1,0 +1,59 @@
+package deepinfra
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// TestModelCatalogCoversSupportedModalities verifies representative models for each relay family.
+func TestModelCatalogCoversSupportedModalities(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, ModelRatios, "deepseek-ai/DeepSeek-V4-Flash")
+	require.Contains(t, ModelRatios, "Qwen/Qwen3-VL-235B-A22B-Instruct")
+	require.Contains(t, ModelRatios, "BAAI/bge-m3")
+	require.Contains(t, ModelRatios, "Qwen/Qwen3-Embedding-8B")
+	require.Contains(t, ModelRatios, "Qwen/Qwen3-Reranker-8B")
+	require.Contains(t, ModelRatios, "openai/whisper-large-v3-turbo")
+	require.Contains(t, ModelRatios, "Qwen/Qwen3-TTS")
+	require.Contains(t, ModelRatios, "black-forest-labs/FLUX-2-klein-4b")
+}
+
+// TestModelPricing verifies token, cache, embedding, and image pricing metadata.
+func TestModelPricing(t *testing.T) {
+	t.Parallel()
+
+	flash := ModelRatios["deepseek-ai/DeepSeek-V4-Flash-0731"]
+	require.InDelta(t, 0.08*billingratio.MilliTokensUsd, flash.Ratio, 1e-12)
+	require.InDelta(t, 0.18/0.08, flash.CompletionRatio, 1e-12)
+	require.InDelta(t, 0.016*billingratio.MilliTokensUsd, flash.CachedInputRatio, 1e-12)
+
+	embedding := ModelRatios["BAAI/bge-m3"]
+	require.NotNil(t, embedding.Embedding)
+	require.InDelta(t, embedding.Ratio, embedding.Embedding.TextTokenRatio, 1e-12)
+
+	reranker := ModelRatios["Qwen/Qwen3-Reranker-4B"]
+	require.InDelta(t, 0.025*billingratio.MilliTokensUsd, reranker.Ratio, 1e-12)
+
+	asr := ModelRatios["openai/whisper-large-v3-turbo"]
+	require.NotNil(t, asr.Audio)
+	require.InDelta(t, 10.0, asr.Audio.PromptTokensPerSecond, 1e-12)
+	require.InDelta(t, 0.00020*float64(billingratio.QuotaPerUsd)/600.0, asr.Ratio, 1e-12)
+
+	image := ModelRatios["black-forest-labs/FLUX-2-klein-4b"]
+	require.NotNil(t, image.Image)
+	require.InDelta(t, 0.014, image.Image.PricePerImageUsd, 1e-12)
+}
+
+// TestGetModelListIsSorted verifies deterministic frontend and API model ordering.
+func TestGetModelListIsSorted(t *testing.T) {
+	t.Parallel()
+
+	models := (&Adaptor{}).GetModelList()
+	require.Greater(t, len(models), 70)
+	require.True(t, sort.StringsAreSorted(models))
+}

--- a/relay/adaptor/deepinfra/models_test.go
+++ b/relay/adaptor/deepinfra/models_test.go
@@ -14,16 +14,26 @@ func TestModelCatalogCoversSupportedModalities(t *testing.T) {
 	t.Parallel()
 
 	require.Contains(t, ModelRatios, "deepseek-ai/DeepSeek-V4-Flash")
+	require.Contains(t, ModelRatios, "anthropic/claude-sonnet-5")
+	require.Contains(t, ModelRatios, "thinkingmachines/Inkling")
 	require.Contains(t, ModelRatios, "Qwen/Qwen3-VL-235B-A22B-Instruct")
 	require.Contains(t, ModelRatios, "BAAI/bge-m3")
-	require.Contains(t, ModelRatios, "Qwen/Qwen3-Embedding-8B")
+	require.Contains(t, ModelRatios, "nvidia/llama-nemotron-embed-vl-1b-v2")
 	require.Contains(t, ModelRatios, "Qwen/Qwen3-Reranker-8B")
 	require.Contains(t, ModelRatios, "openai/whisper-large-v3-turbo")
 	require.Contains(t, ModelRatios, "Qwen/Qwen3-TTS")
+	require.Contains(t, ModelRatios, "XiaomiMiMo/MiMo-V2.5-tts-voiceclone")
 	require.Contains(t, ModelRatios, "black-forest-labs/FLUX-2-klein-4b")
+	require.Contains(t, ModelRatios, "ByteDance/Seedream-4.5")
+
+	// These live catalog entries require relay or billing contracts that one-api
+	// cannot represent exactly yet, so they must not be advertised as supported.
+	require.NotContains(t, ModelRatios, "nvidia/llama-nemotron-rerank-vl-1b-v2")
+	require.NotContains(t, ModelRatios, "Qwen/Qwen-Image-Edit")
+	require.NotContains(t, ModelRatios, "google/nano-banana-pro")
 }
 
-// TestModelPricing verifies token, cache, embedding, and image pricing metadata.
+// TestModelPricing verifies token, cache, embedding, audio, and image pricing metadata.
 func TestModelPricing(t *testing.T) {
 	t.Parallel()
 
@@ -32,9 +42,22 @@ func TestModelPricing(t *testing.T) {
 	require.InDelta(t, 0.18/0.08, flash.CompletionRatio, 1e-12)
 	require.InDelta(t, 0.016*billingratio.MilliTokensUsd, flash.CachedInputRatio, 1e-12)
 
+	claude := ModelRatios["anthropic/claude-sonnet-5"]
+	require.InDelta(t, 2.0*billingratio.MilliTokensUsd, claude.Ratio, 1e-12)
+	require.InDelta(t, 5.0, claude.CompletionRatio, 1e-12)
+	require.Equal(t, []string{"text", "image"}, claude.InputModalities)
+
+	inkling := ModelRatios["thinkingmachines/Inkling"]
+	require.Equal(t, []string{"text", "image", "audio"}, inkling.InputModalities)
+	require.InDelta(t, 0.16*billingratio.MilliTokensUsd, inkling.CachedInputRatio, 1e-12)
+
 	embedding := ModelRatios["BAAI/bge-m3"]
 	require.NotNil(t, embedding.Embedding)
 	require.InDelta(t, embedding.Ratio, embedding.Embedding.TextTokenRatio, 1e-12)
+
+	multimodalEmbedding := ModelRatios["nvidia/llama-nemotron-embed-vl-1b-v2"]
+	require.NotNil(t, multimodalEmbedding.Embedding)
+	require.Equal(t, []string{"text", "image"}, multimodalEmbedding.InputModalities)
 
 	reranker := ModelRatios["Qwen/Qwen3-Reranker-4B"]
 	require.InDelta(t, 0.025*billingratio.MilliTokensUsd, reranker.Ratio, 1e-12)
@@ -44,16 +67,27 @@ func TestModelPricing(t *testing.T) {
 	require.InDelta(t, 10.0, asr.Audio.PromptTokensPerSecond, 1e-12)
 	require.InDelta(t, 0.00020*float64(billingratio.QuotaPerUsd)/600.0, asr.Ratio, 1e-12)
 
-	image := ModelRatios["black-forest-labs/FLUX-2-klein-4b"]
-	require.NotNil(t, image.Image)
-	require.InDelta(t, 0.014, image.Image.PricePerImageUsd, 1e-12)
+	freeTTS := ModelRatios["XiaomiMiMo/MiMo-V2.5-tts"]
+	require.Zero(t, freeTTS.Ratio)
+	require.Equal(t, []string{"audio"}, freeTTS.OutputModalities)
+
+	areaPricedImage := ModelRatios["black-forest-labs/FLUX-2-klein-4b"]
+	require.NotNil(t, areaPricedImage.Image)
+	require.InDelta(t, 0.014, areaPricedImage.Image.PricePerImageUsd, 1e-12)
+	require.NotEmpty(t, areaPricedImage.Image.SizeMultipliers)
+
+	flatImage := ModelRatios["ByteDance/Seedream-4.5"]
+	require.NotNil(t, flatImage.Image)
+	require.InDelta(t, 0.04, flatImage.Image.PricePerImageUsd, 1e-12)
+	require.Empty(t, flatImage.Image.SizeMultipliers)
+	require.Equal(t, []string{"text", "image"}, flatImage.InputModalities)
 }
 
-// TestGetModelListIsSorted verifies deterministic frontend and API model ordering.
+// TestGetModelListIsSorted verifies deterministic ordering and guards the catalog snapshot size.
 func TestGetModelListIsSorted(t *testing.T) {
 	t.Parallel()
 
 	models := (&Adaptor{}).GetModelList()
-	require.Greater(t, len(models), 70)
+	require.Len(t, models, 184)
 	require.True(t, sort.StringsAreSorted(models))
 }

--- a/relay/adaptor/deepinfra/rerank.go
+++ b/relay/adaptor/deepinfra/rerank.go
@@ -1,0 +1,232 @@
+package deepinfra
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/Laisky/errors/v2"
+	"github.com/gin-gonic/gin"
+
+	"github.com/Laisky/one-api/relay/adaptor/openai_compatible"
+	"github.com/Laisky/one-api/relay/model"
+)
+
+const (
+	rerankDocumentsContextKey = "deepinfra_rerank_documents"
+	rerankTopNContextKey      = "deepinfra_rerank_top_n"
+)
+
+type upstreamRerankRequest struct {
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+}
+
+type upstreamRerankResponse struct {
+	Scores []float64 `json:"scores"`
+}
+
+type canonicalRerankResponse struct {
+	Object string                  `json:"object"`
+	Model  string                  `json:"model,omitempty"`
+	Data   []canonicalRerankResult `json:"data"`
+	Usage  *model.Usage            `json:"usage,omitempty"`
+}
+
+type canonicalRerankResult struct {
+	Index          int     `json:"index"`
+	RelevanceScore float64 `json:"relevance_score"`
+	Document       string  `json:"document,omitempty"`
+}
+
+// ConvertRerankRequest converts one-api's canonical rerank DTO to DeepInfra's
+// model-native {query, documents} request and preserves response shaping state.
+func (a *Adaptor) ConvertRerankRequest(c *gin.Context, request *model.RerankRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	if strings.TrimSpace(request.Query) == "" {
+		return nil, errors.New("rerank query is empty")
+	}
+	if len(request.Documents) == 0 {
+		return nil, errors.New("rerank documents are empty")
+	}
+	if request.MaxTokensPerDoc != nil {
+		return nil, errors.New("DeepInfra rerank does not support max_tokens_per_doc")
+	}
+	if request.Priority != nil {
+		return nil, errors.New("DeepInfra rerank does not support priority")
+	}
+
+	topN := len(request.Documents)
+	if request.TopN != nil {
+		if *request.TopN <= 0 {
+			return nil, errors.New("top_n must be greater than zero")
+		}
+		if *request.TopN > len(request.Documents) {
+			return nil, errors.New("top_n cannot exceed the number of documents")
+		}
+		topN = *request.TopN
+	}
+
+	documents := append([]string(nil), request.Documents...)
+	if c != nil {
+		c.Set(rerankDocumentsContextKey, documents)
+		c.Set(rerankTopNContextKey, topN)
+	}
+	return &upstreamRerankRequest{
+		Query:     request.Query,
+		Documents: documents,
+	}, nil
+}
+
+// handleRerankResponse converts DeepInfra's score vector into the canonical
+// sorted rerank list while retaining original document indexes.
+func handleRerankResponse(c *gin.Context, resp *http.Response, modelName string, promptTokens int) (*model.ErrorWithStatusCode, *model.Usage) {
+	if c == nil {
+		return openai_compatible.ErrorWrapper(errors.New("gin context is nil"), "invalid_context", http.StatusInternalServerError), nil
+	}
+	if resp == nil || resp.Body == nil {
+		return openai_compatible.ErrorWrapper(errors.New("upstream response is nil"), "invalid_response", http.StatusInternalServerError), nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return openai_compatible.ErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		return openai_compatible.ErrorWrapper(closeErr, "close_response_body_failed", http.StatusInternalServerError), nil
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return buildDeepInfraError(body, resp.StatusCode), nil
+	}
+
+	var upstream upstreamRerankResponse
+	if err := json.Unmarshal(body, &upstream); err != nil {
+		return openai_compatible.ErrorWrapper(err, "unmarshal_response_body_failed", http.StatusInternalServerError), nil
+	}
+
+	documents, ok := c.Get(rerankDocumentsContextKey)
+	if !ok {
+		return openai_compatible.ErrorWrapper(errors.New("rerank documents are missing from request context"), "missing_rerank_context", http.StatusInternalServerError), nil
+	}
+	documentList, ok := documents.([]string)
+	if !ok {
+		return openai_compatible.ErrorWrapper(errors.New("rerank documents have an invalid context type"), "invalid_rerank_context", http.StatusInternalServerError), nil
+	}
+	if len(upstream.Scores) != len(documentList) {
+		return openai_compatible.ErrorWrapper(
+			errors.Errorf("DeepInfra returned %d scores for %d documents", len(upstream.Scores), len(documentList)),
+			"invalid_rerank_response",
+			http.StatusBadGateway,
+		), nil
+	}
+
+	results := make([]canonicalRerankResult, 0, len(documentList))
+	for index, score := range upstream.Scores {
+		results = append(results, canonicalRerankResult{
+			Index:          index,
+			RelevanceScore: score,
+			Document:       documentList[index],
+		})
+	}
+	sort.SliceStable(results, func(left, right int) bool {
+		return results[left].RelevanceScore > results[right].RelevanceScore
+	})
+
+	topN := len(results)
+	if value, exists := c.Get(rerankTopNContextKey); exists {
+		if requestedTopN, valid := value.(int); valid && requestedTopN > 0 && requestedTopN < topN {
+			topN = requestedTopN
+		}
+	}
+	results = results[:topN]
+
+	usage := &model.Usage{
+		PromptTokens: promptTokens,
+		TotalTokens:  promptTokens,
+	}
+	c.JSON(resp.StatusCode, canonicalRerankResponse{
+		Object: "list",
+		Model:  modelName,
+		Data:   results,
+		Usage:  usage,
+	})
+	return nil, usage
+}
+
+// buildDeepInfraError normalizes DeepInfra's error and validation envelopes.
+func buildDeepInfraError(body []byte, statusCode int) *model.ErrorWithStatusCode {
+	var envelope struct {
+		Error   *model.Error    `json:"error,omitempty"`
+		Message string          `json:"message,omitempty"`
+		Detail  json.RawMessage `json:"detail,omitempty"`
+	}
+	_ = json.Unmarshal(body, &envelope)
+
+	message := strings.TrimSpace(envelope.Message)
+	errorType := model.ErrorType("deepinfra_error")
+	var code any = statusCode
+	if envelope.Error != nil {
+		if value := strings.TrimSpace(envelope.Error.Message); value != "" {
+			message = value
+		}
+		if value := strings.TrimSpace(string(envelope.Error.Type)); value != "" {
+			errorType = model.ErrorType(value)
+		}
+		if envelope.Error.Code != nil {
+			code = envelope.Error.Code
+		}
+	}
+	if message == "" {
+		message = detailMessage(envelope.Detail)
+	}
+	if message == "" {
+		message = http.StatusText(statusCode)
+	}
+
+	return &model.ErrorWithStatusCode{
+		Error: model.Error{
+			Message:  message,
+			Type:     errorType,
+			Code:     code,
+			RawError: errors.New(message),
+		},
+		StatusCode: statusCode,
+	}
+}
+
+// detailMessage renders FastAPI-style detail strings or validation issue arrays.
+func detailMessage(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return strings.TrimSpace(text)
+	}
+
+	var issues []struct {
+		Message string `json:"msg"`
+		Type    string `json:"type"`
+	}
+	if json.Unmarshal(raw, &issues) == nil {
+		messages := make([]string, 0, len(issues))
+		for _, issue := range issues {
+			message := strings.TrimSpace(issue.Message)
+			if message == "" {
+				message = strings.TrimSpace(issue.Type)
+			}
+			if message != "" {
+				messages = append(messages, message)
+			}
+		}
+		return strings.Join(messages, "; ")
+	}
+
+	return strings.TrimSpace(fmt.Sprintf("%s", raw))
+}

--- a/relay/adaptor/deepinfra/rerank_test.go
+++ b/relay/adaptor/deepinfra/rerank_test.go
@@ -1,0 +1,102 @@
+package deepinfra
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/model"
+)
+
+// TestConvertRerankRequest verifies native request shaping and response context retention.
+func TestConvertRerankRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	topN := 2
+
+	converted, err := (&Adaptor{}).ConvertRerankRequest(context, &model.RerankRequest{
+		Model:     "Qwen/Qwen3-Reranker-8B",
+		Query:     "best database for vectors",
+		Documents: []string{"postgres", "redis", "sqlite"},
+		TopN:      &topN,
+	})
+	require.NoError(t, err)
+	require.Equal(t, &upstreamRerankRequest{
+		Query:     "best database for vectors",
+		Documents: []string{"postgres", "redis", "sqlite"},
+	}, converted)
+	require.Equal(t, 2, context.GetInt(rerankTopNContextKey))
+}
+
+// TestConvertRerankRequestRejectsUnsupportedFields verifies explicit validation.
+func TestConvertRerankRequestRejectsUnsupportedFields(t *testing.T) {
+	t.Parallel()
+
+	maxTokens := 256
+	_, err := (&Adaptor{}).ConvertRerankRequest(nil, &model.RerankRequest{
+		Query:           "query",
+		Documents:       []string{"document"},
+		MaxTokensPerDoc: &maxTokens,
+	})
+	require.ErrorContains(t, err, "max_tokens_per_doc")
+}
+
+// TestHandleRerankResponse verifies sorting, top_n truncation, index preservation, and usage.
+func TestHandleRerankResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Set(rerankDocumentsContextKey, []string{"first", "second", "third"})
+	context.Set(rerankTopNContextKey, 2)
+
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(`{"scores":[0.1,0.9,0.5]}`)),
+		Header:     make(http.Header),
+	}
+	relayError, usage := handleRerankResponse(context, response, "Qwen/Qwen3-Reranker-8B", 42)
+	require.Nil(t, relayError)
+	require.NotNil(t, usage)
+	require.Equal(t, 42, usage.PromptTokens)
+
+	var body canonicalRerankResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
+	require.Equal(t, "list", body.Object)
+	require.Len(t, body.Data, 2)
+	require.Equal(t, 1, body.Data[0].Index)
+	require.Equal(t, "second", body.Data[0].Document)
+	require.Equal(t, 2, body.Data[1].Index)
+}
+
+// TestHandleRerankResponseRejectsScoreCardinalityMismatch verifies upstream validation.
+func TestHandleRerankResponseRejectsScoreCardinalityMismatch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Set(rerankDocumentsContextKey, []string{"first", "second"})
+	context.Set(rerankTopNContextKey, 2)
+
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(`{"scores":[0.7]}`)),
+		Header:     make(http.Header),
+	}
+	relayError, usage := handleRerankResponse(context, response, "Qwen/Qwen3-Reranker-8B", 10)
+	require.Nil(t, usage)
+	require.NotNil(t, relayError)
+	require.Equal(t, http.StatusBadGateway, relayError.StatusCode)
+}
+
+// TestBuildDeepInfraError verifies FastAPI validation detail normalization.
+func TestBuildDeepInfraError(t *testing.T) {
+	t.Parallel()
+
+	err := buildDeepInfraError([]byte(`{"detail":[{"msg":"field required","type":"missing"}]}`), http.StatusUnprocessableEntity)
+	require.Equal(t, http.StatusUnprocessableEntity, err.StatusCode)
+	require.Equal(t, "field required", err.Message)
+}

--- a/relay/apitype/define.go
+++ b/relay/apitype/define.go
@@ -31,6 +31,7 @@ const (
 	NVIDIA
 	Cerebras
 	Azure
+	DeepInfra
 
 	Dummy // this one is only for count, do not add any channel after this
 )

--- a/relay/apitype/helper.go
+++ b/relay/apitype/helper.go
@@ -62,6 +62,8 @@ func String(apiType int) string {
 		return "cerebras"
 	case Azure:
 		return "azure"
+	case DeepInfra:
+		return "deepinfra"
 	default:
 		return ""
 	}

--- a/relay/channeltype/deepinfra_test.go
+++ b/relay/channeltype/deepinfra_test.go
@@ -1,0 +1,45 @@
+package channeltype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/apitype"
+)
+
+// TestDeepInfraRegistration verifies the stable channel ID and backend mappings.
+func TestDeepInfraRegistration(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 57, DeepInfra)
+	require.Equal(t, 58, Dummy)
+	require.Equal(t, apitype.DeepInfra, ToAPIType(DeepInfra))
+	require.Equal(t, "deepinfra", IdToName(DeepInfra))
+	require.Equal(t, "deepinfra", apitype.String(apitype.DeepInfra))
+
+	config := GetChannelBaseURLConfig(DeepInfra)
+	require.Equal(t, "https://api.deepinfra.com", config.URL)
+	require.False(t, config.Editable)
+}
+
+// TestDeepInfraDefaultEndpoints verifies the advertised relay capability matrix.
+func TestDeepInfraDefaultEndpoints(t *testing.T) {
+	t.Parallel()
+
+	endpoints := DefaultEndpointsForChannelType(DeepInfra)
+	require.Contains(t, endpoints, EndpointChatCompletions)
+	require.Contains(t, endpoints, EndpointCompletions)
+	require.Contains(t, endpoints, EndpointEmbeddings)
+	require.Contains(t, endpoints, EndpointImagesGenerations)
+	require.Contains(t, endpoints, EndpointImagesEdits)
+	require.Contains(t, endpoints, EndpointAudioSpeech)
+	require.Contains(t, endpoints, EndpointAudioTranscription)
+	require.Contains(t, endpoints, EndpointAudioTranslation)
+	require.Contains(t, endpoints, EndpointRerank)
+	require.Contains(t, endpoints, EndpointResponseAPI)
+	require.Contains(t, endpoints, EndpointClaudeMessages)
+	require.NotContains(t, endpoints, EndpointModerations)
+	require.NotContains(t, endpoints, EndpointRealtime)
+	require.NotContains(t, endpoints, EndpointVideos)
+}

--- a/relay/channeltype/define.go
+++ b/relay/channeltype/define.go
@@ -58,5 +58,6 @@ const (
 	Fireworks
 	NVIDIA
 	Cerebras
+	DeepInfra
 	Dummy
 )

--- a/relay/channeltype/endpoints.go
+++ b/relay/channeltype/endpoints.go
@@ -88,7 +88,7 @@ func EndpointNameToID(name string) Endpoint {
 	return -1
 }
 
-// EndpointIDToName converts an Endpoint ID to its string name.
+// EndpointIDToName converts an endpoint ID to its string name.
 // Returns empty string if the ID is not recognized.
 func EndpointIDToName(id Endpoint) string {
 	if name, ok := endpointIDToName[id]; ok {
@@ -394,6 +394,25 @@ func DefaultEndpointsForChannelType(channelType int) []Endpoint {
 		// not expose embeddings.
 		return []Endpoint{
 			EndpointChatCompletions,
+			EndpointResponseAPI,
+			EndpointClaudeMessages,
+		}
+	case DeepInfra:
+		// DeepInfra combines OpenAI-compatible, native Anthropic Messages, and
+		// model-native inference surfaces under one Bearer-authenticated API.
+		// Responses uses one-api's Chat Completions fallback. DeepInfra video is
+		// intentionally omitted because its native inference contract does not
+		// match one-api's /v1/videos lifecycle API.
+		return []Endpoint{
+			EndpointChatCompletions,
+			EndpointCompletions,
+			EndpointEmbeddings,
+			EndpointImagesGenerations,
+			EndpointImagesEdits,
+			EndpointAudioSpeech,
+			EndpointAudioTranscription,
+			EndpointAudioTranslation,
+			EndpointRerank,
 			EndpointResponseAPI,
 			EndpointClaudeMessages,
 		}

--- a/relay/channeltype/helper.go
+++ b/relay/channeltype/helper.go
@@ -63,6 +63,8 @@ func ToAPIType(channelType int) int {
 		apiType = apitype.NVIDIA
 	case Cerebras:
 		apiType = apitype.Cerebras
+	case DeepInfra:
+		apiType = apitype.DeepInfra
 	}
 
 	return apiType
@@ -192,6 +194,8 @@ func IdToName(channelType int) string {
 		return "nvidia"
 	case Cerebras:
 		return "cerebras"
+	case DeepInfra:
+		return "deepinfra"
 	case Dummy:
 		return "dummy"
 	default:

--- a/relay/channeltype/url.go
+++ b/relay/channeltype/url.go
@@ -68,6 +68,7 @@ var ChannelBaseURLConfigs = []ChannelBaseURLConfig{
 	{URL: "https://api.fireworks.ai/inference", Editable: false},                       // 54 Fireworks
 	{URL: "https://integrate.api.nvidia.com/v1", Editable: true},                       // 55 NVIDIA
 	{URL: "https://api.cerebras.ai/v1", Editable: false},                               // 56 Cerebras
+	{URL: "https://api.deepinfra.com", Editable: false},                                // 57 DeepInfra
 }
 
 // ChannelBaseURLs provides backward compatibility by returning only the URL strings.

--- a/relay/controller/rerank.go
+++ b/relay/controller/rerank.go
@@ -58,14 +58,13 @@ func RelayRerankHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 	channelModelConfigs := getChannelModelConfigs(c)
 	pricingAdaptor := resolvePricingAdaptor(meta)
 	modelRatio := pricing.ResolveModelRatioAt(rerankRequest.Model, channelModelConfigs, channelModelRatio, pricingAdaptor, meta.StartTime)
+	modelConfig, hasModelConfig := pricing.ResolveModelConfig(rerankRequest.Model, channelModelConfigs, pricingAdaptor, meta.StartTime)
+	perCallBilling := hasModelConfig && modelConfig.PerCall != nil && modelConfig.PerCall.HasData()
 	groupRatio := c.GetFloat64(ctxkey.ChannelRatio)
-	totalQuota := int64(math.Ceil(modelRatio * groupRatio))
-	if modelRatio > 0 && totalQuota == 0 {
-		totalQuota = 1
-	}
 
 	promptTokens := countRerankPromptTokens(ctx, rerankRequest)
 	meta.PromptTokens = promptTokens
+	totalQuota := calculateRerankQuota(promptTokens, modelRatio, groupRatio, perCallBilling)
 
 	preConsumedQuota, bizErr := preConsumeRerankQuota(c, totalQuota, meta)
 	if bizErr != nil {
@@ -215,7 +214,7 @@ func RelayRerankHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 		logMessage:          "CRITICAL BILLING TIMEOUT",
 		includeElapsedField: true,
 	}, func(ctx context.Context) {
-		quota := postConsumeRerankQuota(ctx, usage, meta, rerankRequest, preConsumedQuota, totalQuota, modelRatio, groupRatio)
+		quota := postConsumeRerankQuota(ctx, usage, meta, rerankRequest, preConsumedQuota, totalQuota, modelRatio, groupRatio, perCallBilling)
 		if requestId != "" {
 			if err := model.UpdateUserRequestCostQuotaByRequestID(quotaId, requestId, quota); err != nil {
 				lg.Error("update user request cost failed", zap.Error(err), zap.String("request_id", requestId))
@@ -289,6 +288,26 @@ func countRerankPromptTokens(ctx context.Context, request *relaymodel.RerankRequ
 	return tokens
 }
 
+// calculateRerankQuota computes either token-priced or flat per-call rerank quota.
+func calculateRerankQuota(promptTokens int, modelRatio float64, groupRatio float64, perCall bool) int64 {
+	if modelRatio <= 0 || groupRatio <= 0 {
+		return 0
+	}
+
+	units := 1.0
+	if !perCall {
+		if promptTokens <= 0 {
+			return 0
+		}
+		units = float64(promptTokens)
+	}
+	quota := int64(math.Ceil(units * modelRatio * groupRatio))
+	if quota == 0 {
+		return 1
+	}
+	return quota
+}
+
 func preConsumeRerankQuota(c *gin.Context, perCallQuota int64, meta *metalib.Meta) (int64, *relaymodel.ErrorWithStatusCode) {
 	ctx := gmw.Ctx(c)
 	lg := gmw.GetLogger(c)
@@ -330,8 +349,12 @@ func postConsumeRerankQuota(ctx context.Context,
 	preConsumedQuota int64,
 	totalQuota int64,
 	modelRatio float64,
-	groupRatio float64) (quota int64) {
+	groupRatio float64,
+	perCallBilling bool) (quota int64) {
 	quota = max(totalQuota, 0)
+	if !perCallBilling && usage != nil && usage.PromptTokens > 0 {
+		quota = calculateRerankQuota(usage.PromptTokens, modelRatio, groupRatio, false)
+	}
 
 	quotaDelta := quota - preConsumedQuota
 
@@ -348,6 +371,10 @@ func postConsumeRerankQuota(ctx context.Context,
 		promptTokens = usage.PromptTokens
 		completionTokens = usage.CompletionTokens
 	}
+	billingMode := "token"
+	if perCallBilling {
+		billingMode = "per-call"
+	}
 
 	if meta.TokenId > 0 && meta.UserId > 0 && meta.ChannelId > 0 {
 		logEntry := &model.Log{
@@ -357,7 +384,7 @@ func postConsumeRerankQuota(ctx context.Context,
 			CompletionTokens: completionTokens,
 			ModelName:        request.Model,
 			TokenName:        meta.TokenName,
-			Content:          fmt.Sprintf("rerank per-call billing, base unit %.2f, group rate %.2f", modelRatio, groupRatio),
+			Content:          fmt.Sprintf("rerank %s billing, base unit %.6f, group rate %.2f", billingMode, modelRatio, groupRatio),
 			IsStream:         false,
 			ElapsedTime:      helper.CalcElapsedTime(meta.StartTime),
 			RequestId:        requestId,

--- a/relay/controller/rerank_pricing_test.go
+++ b/relay/controller/rerank_pricing_test.go
@@ -1,0 +1,18 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCalculateRerankQuota verifies token-priced and per-call rerank settlement.
+func TestCalculateRerankQuota(t *testing.T) {
+	t.Parallel()
+
+	require.EqualValues(t, 25, calculateRerankQuota(1000, 0.025, 1.0, false))
+	require.EqualValues(t, 50, calculateRerankQuota(1000, 50, 1.0, true))
+	require.EqualValues(t, 1, calculateRerankQuota(1, 0.001, 1.0, false))
+	require.EqualValues(t, 0, calculateRerankQuota(1000, 0, 1.0, false))
+	require.EqualValues(t, 0, calculateRerankQuota(-1, 1, 1.0, false))
+}

--- a/relay/controller/rerank_test.go
+++ b/relay/controller/rerank_test.go
@@ -26,6 +26,22 @@ func TestPostConsumeRerankQuotaPerCall(t *testing.T) {
 	totalQuota := int64(1000)
 	preConsumed := int64(100)
 
-	got := postConsumeRerankQuota(context.Background(), usage, meta, request, preConsumed, totalQuota, 1000, 1)
+	got := postConsumeRerankQuota(context.Background(), usage, meta, request, preConsumed, totalQuota, 1000, 1, true)
 	require.Equal(t, totalQuota, got)
+}
+
+func TestPostConsumeRerankQuotaTokenPriced(t *testing.T) {
+	t.Parallel()
+	usage := &relaymodel.Usage{PromptTokens: 42, CompletionTokens: 0}
+	meta := &metalib.Meta{
+		UserId:    1,
+		ChannelId: 1,
+		TokenId:   0,
+		TokenName: "unit-test",
+		StartTime: time.Now().Add(-500 * time.Millisecond),
+	}
+	request := &relaymodel.RerankRequest{Model: "Qwen/Qwen3-Reranker-8B"}
+
+	got := postConsumeRerankQuota(context.Background(), usage, meta, request, 0, 1000, 2, 1.5, false)
+	require.EqualValues(t, 126, got)
 }

--- a/web/air/src/constants/channel.constants.js
+++ b/web/air/src/constants/channel.constants.js
@@ -37,6 +37,7 @@ export const CHANNEL_OPTIONS = [
   { key: 54, text: 'Fireworks', value: 54, color: 'orange' },
   { key: 55, text: 'NVIDIA', value: 55, color: 'green' },
   { key: 56, text: 'Cerebras', value: 56, color: 'orange' },
+  { key: 57, text: 'DeepInfra', value: 57, color: 'purple' },
   { key: 42, text: 'VertexAI', value: 42, color: 'blue' },
   { key: 43, text: 'Proxy', value: 43, color: 'blue' },
   { key: 44, text: 'SiliconFlow', value: 44, color: 'blue' },

--- a/web/berry/src/constants/ChannelConstants.js
+++ b/web/berry/src/constants/ChannelConstants.js
@@ -182,6 +182,12 @@ export const CHANNEL_OPTIONS = {
     value: 56,
     color: 'orange'
   },
+  57: {
+    key: 57,
+    text: 'DeepInfra',
+    value: 57,
+    color: 'primary'
+  },
   50: {
     key: 50,
     text: 'OpenAI Compatible',
@@ -280,7 +286,7 @@ export const CHANNEL_OPTIONS = {
   },
   20: {
     key: 20,
-      text: 'OpenRouter',
+    text: 'OpenRouter',
     value: 20,
     color: 'success'
   },

--- a/web/modern/src/pages/channels/__tests__/constants.deepinfra.test.ts
+++ b/web/modern/src/pages/channels/__tests__/constants.deepinfra.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { CHANNEL_TYPES, CHANNEL_TYPE_LABELS } from '../constants';
+
+describe('DeepInfra channel metadata', () => {
+  it('registers channel type 57 in the create dropdown and label map', () => {
+    const channel = CHANNEL_TYPES.find((candidate) => candidate.value === 57);
+
+    expect(channel).toMatchObject({
+      key: 57,
+      text: 'DeepInfra',
+      value: 57,
+    });
+    expect(CHANNEL_TYPE_LABELS[57]).toEqual({ name: 'DeepInfra', color: 'purple' });
+  });
+});

--- a/web/modern/src/pages/channels/constants.ts
+++ b/web/modern/src/pages/channels/constants.ts
@@ -286,6 +286,14 @@ export const CHANNEL_TYPES: ChannelType[] = [
     description: 'Cerebras Inference (api.cerebras.ai); ultra-fast OpenAI-compatible chat on wafer-scale hardware (gpt-oss-120b, GLM-4.7).',
   },
   {
+    key: 57,
+    text: 'DeepInfra',
+    value: 57,
+    color: 'purple',
+    description:
+      'DeepInfra serverless inference; OpenAI-compatible chat, completions, embeddings, images, and audio, plus rerank and native Anthropic Messages.',
+  },
+  {
     key: 42,
     text: 'VertexAI',
     value: 42,


### PR DESCRIPTION
## Summary

Add DeepInfra as a first-class one-api channel and adaptor instead of treating it as a generic OpenAI-compatible base URL.

## What changed

- Register channel type `57` and a dedicated `apitype.DeepInfra` adaptor.
- Add the default `https://api.deepinfra.com` base URL and Modern frontend channel metadata.
- Advertise and route these relay surfaces:
  - Chat Completions
  - legacy Completions
  - Embeddings
  - Image Generations and Edits
  - Audio Speech, Transcriptions, and Translations
  - Rerank
  - Responses through one-api's existing Chat Completions fallback
  - native Anthropic Messages
- Route requests to DeepInfra's distinct OpenAI, Anthropic, audio, image-edit, and model-native inference paths.
- Normalize DeepInfra rerank score vectors to one-api's canonical sorted response while preserving original document indexes and `top_n`.
- Add a provider-scoped snapshot of 86 priced models across text, vision, embeddings, rerank, ASR, TTS, and image generation/editing.
- Correct generic rerank billing so token-priced rerankers settle by prompt tokens while models with explicit `PerCall` metadata retain flat billing.
- Add Go and Vitest regression tests for registration, routing, headers, model metadata, rerank conversion, response normalization, and billing.

## Relay paths

| one-api mode | DeepInfra upstream |
| --- | --- |
| Chat Completions | `/v1/openai/chat/completions` |
| Completions | `/v1/openai/completions` |
| Embeddings | `/v1/openai/embeddings` |
| Image Generations | `/v1/openai/images/generations` |
| Image Edits | `/v1/images/edits` |
| Audio Speech | `/v1/audio/speech` |
| Audio Transcriptions | `/v1/audio/transcriptions` |
| Audio Translations | `/v1/audio/translations` |
| Anthropic Messages | `/anthropic/v1/messages` |
| Rerank | `/v1/inference/{model}` |
| Responses | one-api Chat Completions fallback |

## Deliberate exclusions

- DeepInfra video models use the native `/v1/inference/{model}` contract, which does not match one-api's `/v1/videos` lifecycle API, so video is not advertised.
- Moderation and Realtime are not advertised because no matching one-api relay contracts are implemented here.
- The built-in model map is a priced snapshot observed on 2026-08-19, not a claim that DeepInfra's fast-changing catalog is static. Versioned, private, custom-deployment, and newly released model IDs remain usable through channel model configuration and model mapping.

## Validation

Completed for the submitted patch:

- `gofmt` on every added Go file.
- Go parser validation for all eight added Go files.
- `git apply --check` against the recorded source contexts before publishing.
- Model catalog self-check: 86 unique IDs with representative coverage for every advertised model family.
- Final GitHub comparison: one commit, 18 changed files, based directly on current `main` (`8022a60fffe578fc1c8225df99266cc2a953998d`).

Full repository CI still needs to run with the repository-required toolchain:

```bash
go vet ./...
go test -race ./...
make build-frontend-modern
```

## Documentation

- https://docs.deepinfra.com/models
- https://docs.deepinfra.com/api-reference/introduction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepInfra as a supported provider and channel.
  * Supports chat, completions, embeddings, image generation, audio, reranking, and Anthropic Messages APIs.
  * Added access to DeepInfra model catalogs, capabilities, pricing, and modality information.
  * Added DeepInfra configuration options across the web interfaces.
* **Bug Fixes**
  * Improved rerank billing calculations for token-based and per-call pricing.
* **Tests**
  * Added coverage for requests, responses, streaming, model metadata, reranking, billing, and channel configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->