### PR TITLE
fix(channel-test): select chat-compatible models only

### DIFF
--- a/controller/channel_testing_model.go
+++ b/controller/channel_testing_model.go
@@ -15,26 +15,36 @@ import (
 	"github.com/Laisky/one-api/relay/pricing"
 )
 
-const textTestModality = "text"
+const (
+	textTestModality          = "text"
+	chatCompletionsTestTarget = "chat_completions"
+)
 
-// chooseChannelTestModel returns the model name that should be used for a text-only channel test.
+// chooseChannelTestModel returns the model name that should be used for a Chat Completions channel test.
 // Parameters: channel is the channel being tested, and requestedModel is an optional explicit model name.
 // Returns: the selected model name, whether an incompatible stored testing model should be cleared, and an error.
 func chooseChannelTestModel(channel *model.Channel, requestedModel string) (string, bool, error) {
 	return chooseChannelTestModelWithContext(context.Background(), channel, requestedModel)
 }
 
-// chooseChannelTestModelWithContext selects a text-compatible test model with request-scoped configuration diagnostics.
+// chooseChannelTestModelWithContext selects a text Chat Completions model with request-scoped configuration diagnostics.
 // Parameters: ctx carries request logging, channel is the channel being tested, and requestedModel is optional.
 // Returns: the selected model name, whether an incompatible stored model should be cleared, and an error.
 func chooseChannelTestModelWithContext(ctx context.Context, channel *model.Channel, requestedModel string) (string, bool, error) {
+	if channel == nil {
+		return "", false, errors.New("channel is nil")
+	}
+	if !channelSupportsChatCompletionsWithContext(ctx, channel) {
+		return "", false, errors.New("channel does not support the Chat Completions endpoint required for channel testing")
+	}
+
 	requestedModel = strings.TrimSpace(requestedModel)
 	if requestedModel != "" {
 		if !channel.SupportsModel(requestedModel) {
 			return "", false, errors.Errorf("test model %q is not supported by channel", requestedModel)
 		}
 		if !channelTestModelSupportsText(channel, requestedModel) {
-			return "", false, errors.Errorf("test model %q does not support both text input and text output", requestedModel)
+			return "", false, errors.Errorf("test model %q does not support both text input and text output through Chat Completions", requestedModel)
 		}
 		return requestedModel, false, nil
 	}
@@ -50,14 +60,28 @@ func chooseChannelTestModelWithContext(ctx context.Context, channel *model.Chann
 
 	modelName := cheapestTextTestModel(ctx, channel)
 	if modelName == "" {
-		return "", clearStored, errors.New("channel has no model that supports both text input and text output for testing")
+		return "", clearStored, errors.New("channel has no model that supports both text input and text output through Chat Completions for testing")
 	}
 	return modelName, clearStored, nil
 }
 
-// cheapestTextTestModel returns the cheapest text-in/text-out model available on the channel.
+// channelSupportsChatCompletionsWithContext reports whether the channel exposes the endpoint used by live channel tests.
+// Parameters: ctx carries request logging and channel contains the effective endpoint configuration.
+// Returns: true when Chat Completions is explicitly configured or enabled by the channel type defaults.
+func channelSupportsChatCompletionsWithContext(ctx context.Context, channel *model.Channel) bool {
+	if channel == nil {
+		return false
+	}
+	endpoints := channel.GetSupportedEndpointsWithContext(ctx)
+	if len(endpoints) == 0 {
+		endpoints = channeltype.DefaultEndpointNamesForChannelType(channel.Type)
+	}
+	return channeltype.IsEndpointSupportedByName(chatCompletionsTestTarget, endpoints)
+}
+
+// cheapestTextTestModel returns the cheapest text Chat Completions model available on the channel.
 // Parameters: channel provides the configured model list, model mapping, and channel-specific pricing.
-// Returns: the selected model name, or an empty string when no text-capable test model is available.
+// Returns: the selected model name, or an empty string when no compatible model is available.
 func cheapestTextTestModel(ctx context.Context, channel *model.Channel) string {
 	names := channelTextTestModels(channel)
 	defaultPricing := defaultModelPricingForChannel(channel)
@@ -79,7 +103,7 @@ func cheapestTextTestModel(ctx context.Context, channel *model.Channel) string {
 }
 
 // channelListItem is the admin channel-list row: the boundary channel DTO plus
-// the text-compatible test-model choices for the per-channel test selector.
+// the Chat Completions-compatible test-model choices for the per-channel test selector.
 //
 // It embeds dto.ChannelResponse (a plain struct with no methods), so json.Marshal
 // promotes the channel fields inline and appends test_models — byte-identical to
@@ -91,7 +115,7 @@ type channelListItem struct {
 	TestModels []string `json:"test_models"`
 }
 
-// buildChannelListResponse wraps channel rows with text-compatible test model choices.
+// buildChannelListResponse wraps channel rows with Chat Completions-compatible test model choices.
 // Parameters: channels is the list returned by channel list or search APIs.
 // Returns: channel response rows with an added test_models field for the admin UI.
 func buildChannelListResponse(channels []*model.Channel) []channelListItem {
@@ -110,10 +134,15 @@ func buildChannelListResponse(channels []*model.Channel) []channelListItem {
 	return items
 }
 
-// channelTextTestModels returns text-in/text-out model names that can be used for channel tests.
-// Parameters: channel provides configured models, model mapping, and provider metadata.
+// channelTextTestModels returns model names that can receive the standard text Chat Completions probe.
+// Parameters: channel provides configured models, model mapping, endpoint configuration, and provider metadata.
 // Returns: a sorted list of public model names suitable for the admin testing-model selector.
 func channelTextTestModels(channel *model.Channel) []string {
+	testModels := make([]string, 0)
+	if channel == nil || !channelSupportsChatCompletionsWithContext(context.Background(), channel) {
+		return testModels
+	}
+
 	names := channel.GetSupportedModelNames()
 	defaultPricing := defaultModelPricingForChannel(channel)
 	if len(names) == 0 {
@@ -123,7 +152,6 @@ func channelTextTestModels(channel *model.Channel) []string {
 		}
 	}
 
-	testModels := make([]string, 0, len(names))
 	for _, name := range names {
 		if channelTestModelSupportsText(channel, name) {
 			testModels = append(testModels, name)
@@ -133,23 +161,21 @@ func channelTextTestModels(channel *model.Channel) []string {
 	return testModels
 }
 
-// channelTestModelSupportsText reports whether a model can support the text-only channel test.
+// channelTestModelSupportsText reports whether a model can support the standard text Chat Completions test.
 // Parameters: channel provides provider metadata and model mappings, while modelName is the public model name.
-// Returns: true when the model accepts text input and can produce text output.
+// Returns: true when the model accepts text input, returns text, and is not a specialized non-chat task model.
 func channelTestModelSupportsText(channel *model.Channel, modelName string) bool {
+	if channel == nil {
+		return false
+	}
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" {
 		return false
 	}
 
 	defaultPricing := defaultModelPricingForChannel(channel)
-	mappedName := modelName
-	if mapping := channel.GetModelMapping(); mapping != nil {
-		if mapped := strings.TrimSpace(mapping[modelName]); mapped != "" {
-			mappedName = mapped
-		}
-	}
-	if modelNameLooksNonTextTestable(mappedName) {
+	mappedName := mappedChannelTestModelName(channel, modelName)
+	if modelNameLooksNonTextTestable(modelName) || modelNameLooksNonTextTestable(mappedName) {
 		return false
 	}
 
@@ -162,39 +188,96 @@ func channelTestModelSupportsText(channel *model.Channel, modelName string) bool
 	return modelConfigSupportsTextTest(adaptor.ModelConfig{}, false)
 }
 
-// modelNameLooksNonTextTestable rejects known non-chat model families even when legacy metadata is incomplete.
-// Parameters: modelName is the resolved upstream model name when available.
-// Returns: true when the model name identifies a model that cannot return chat text.
+// mappedChannelTestModelName resolves a public model name to its configured upstream model name.
+// Parameters: channel supplies model mappings and modelName is the public channel model name.
+// Returns: the mapped upstream name, or the original model name when no mapping exists.
+func mappedChannelTestModelName(channel *model.Channel, modelName string) string {
+	modelName = strings.TrimSpace(modelName)
+	if channel == nil {
+		return modelName
+	}
+	if mapping := channel.GetModelMapping(); mapping != nil {
+		if mapped := strings.TrimSpace(mapping[modelName]); mapped != "" {
+			return mapped
+		}
+	}
+	return modelName
+}
+
+// modelNameLooksNonTextTestable rejects known non-chat model families even when provider metadata is incomplete.
+// Parameters: modelName is the public or resolved upstream model name.
+// Returns: true when the model name identifies a task that cannot receive a Chat Completions request.
 func modelNameLooksNonTextTestable(modelName string) bool {
 	lowerName := strings.ToLower(strings.TrimSpace(modelName))
 	if lowerName == "" {
 		return false
 	}
-	nonTextMarkers := []string{
+
+	nonChatMarkers := []string{
 		"embedding",
+		"embeddings",
+		"bge-",
+		"bge_",
 		"rerank",
-		"sora",
+		"reranker",
+		"moderation",
+		"llama-guard",
+		"/guard-",
+		"distilbert",
+		"resnet",
+		"m2m100",
+		"indictrans",
+		"bart-large-cnn",
+		"moondream",
+		"ocr",
+		"layout-parsing",
+		"voice-clone",
+		"voice_clone",
+		"whisper",
+		"melotts",
+		"aura-",
 		"tts",
 		"transcribe",
-		"whisper",
+		"transcription",
+		"speech-to-text",
+		"text-to-speech",
 		"dall-e",
 		"gpt-image",
+		"stable-diffusion",
+		"dreamshaper",
+		"flux-",
 		"imagen",
+		"sora",
 		"veo",
 		"video",
+		"text-davinci-",
+		"code-davinci-",
+		"text-curie-",
+		"text-babbage-",
+		"text-ada-",
+		"gpt-3.5-turbo-instruct",
 	}
-	for _, marker := range nonTextMarkers {
+	for _, marker := range nonChatMarkers {
 		if strings.Contains(lowerName, marker) {
 			return true
 		}
 	}
-	return false
+
+	switch lowerName {
+	case "ada", "babbage", "curie", "davinci":
+		return true
+	default:
+		return false
+	}
 }
 
 // defaultModelPricingForChannel returns provider model metadata for channel test selection.
 // Parameters: channel identifies the upstream channel type.
 // Returns: the provider default model configuration map, or nil when no adaptor metadata is available.
 func defaultModelPricingForChannel(channel *model.Channel) map[string]adaptor.ModelConfig {
+	if channel == nil {
+		return nil
+	}
 	if channeltype.IsOpenAICompatible(channel.Type) {
 		return pricing.GetGlobalModelPricing()
 	}
@@ -223,17 +306,69 @@ func lookupModelConfig(configs map[string]adaptor.ModelConfig, modelName string)
 	return adaptor.ModelConfig{}, false
 }
 
-// modelConfigSupportsTextTest reports whether model metadata is compatible with text channel tests.
+// modelConfigSupportsTextTest reports whether model metadata is compatible with text Chat Completions tests.
 // Parameters: cfg is the provider model metadata, and known indicates whether the metadata came from a known model entry.
-// Returns: true when the model accepts text input and produces text chat output.
+// Returns: true when the model accepts text input, returns text, and is not explicitly specialized for another task.
 func modelConfigSupportsTextTest(cfg adaptor.ModelConfig, known bool) bool {
 	if !known {
 		return true
 	}
-	if cfg.Embedding != nil || cfg.PerCall != nil {
+	if cfg.Embedding != nil || cfg.PerCall != nil || cfg.Image != nil || cfg.Video != nil {
 		return false
 	}
-	return modalitiesContainTextOrDefault(cfg.InputModalities) && modalitiesContainTextOrDefault(cfg.OutputModalities)
+	if !modalitiesContainTextOrDefault(cfg.InputModalities) || !modalitiesContainTextOrDefault(cfg.OutputModalities) {
+		return false
+	}
+	return !modelDescriptionLooksNonChatTestable(cfg.Description)
+}
+
+// modelDescriptionLooksNonChatTestable rejects provider descriptions that explicitly identify a specialized non-chat task.
+// Parameters: description is provider-maintained model metadata.
+// Returns: true when the description identifies embeddings, classification, media processing, or another non-chat task.
+func modelDescriptionLooksNonChatTestable(description string) bool {
+	lowerDescription := strings.ToLower(strings.TrimSpace(description))
+	if lowerDescription == "" {
+		return false
+	}
+
+	nonChatDescriptions := []string{
+		"embedding model",
+		"embeddings model",
+		"text embeddings",
+		"vector embedding",
+		"reranker",
+		"reranking model",
+		"text classifier",
+		"text classification",
+		"sentiment classifier",
+		"classification model",
+		"safety classifier",
+		"content safety classification",
+		"moderation model",
+		"translation model",
+		"multilingual translation",
+		"speech-to-text",
+		"automatic speech recognition",
+		"text-to-speech",
+		"voice cloning",
+		"transcription model",
+		"text-to-image",
+		"image generation model",
+		"image classifier",
+		"object detection",
+		"image-to-text",
+		"video generation",
+		"summarization model",
+		"text summarization",
+		"document ocr",
+		"layout parsing",
+	}
+	for _, marker := range nonChatDescriptions {
+		if strings.Contains(lowerDescription, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // modalitiesContainTextOrDefault reports whether a modality list supports text.
@@ -255,6 +390,9 @@ func modalitiesContainTextOrDefault(modalities []string) bool {
 // Parameters: channel provides channel-specific pricing, modelName is the candidate, and defaultPricing is provider metadata.
 // Returns: the best available input ratio for ordering candidates.
 func testModelRatio(ctx context.Context, channel *model.Channel, modelName string, defaultPricing map[string]adaptor.ModelConfig) float64 {
+	if channel == nil {
+		return 0
+	}
 	if configs := channel.GetModelPriceConfigsWithContext(ctx); len(configs) > 0 {
 		if cfg, ok := configs[modelName]; ok {
 			return cfg.Ratio
@@ -264,6 +402,10 @@ func testModelRatio(ctx context.Context, channel *model.Channel, modelName strin
 		if ratio, ok := ratios[modelName]; ok {
 			return ratio
 		}
+	}
+	mappedName := mappedChannelTestModelName(channel, modelName)
+	if cfg, ok := lookupModelConfig(defaultPricing, mappedName); ok {
+		return cfg.Ratio
 	}
 	if cfg, ok := lookupModelConfig(defaultPricing, modelName); ok {
 		return cfg.Ratio

--- a/controller/channel_testing_test.go
+++ b/controller/channel_testing_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,7 @@ func TestResponseStatus(t *testing.T) {
 	})
 }
 
-// TestModelConfigSupportsTextTest verifies that channel tests only accept text-in/text-out model metadata.
+// TestModelConfigSupportsTextTest verifies that channel tests accept only text Chat Completions metadata.
 func TestModelConfigSupportsTextTest(t *testing.T) {
 	t.Parallel()
 
@@ -41,19 +42,39 @@ func TestModelConfigSupportsTextTest(t *testing.T) {
 	}, true))
 	require.False(t, modelConfigSupportsTextTest(adaptor.ModelConfig{
 		InputModalities:  []string{"text"},
-		OutputModalities: []string{},
+		OutputModalities: []string{"text"},
 		Embedding:        &adaptor.EmbeddingPricingConfig{TextTokenRatio: 1},
+	}, true))
+	require.False(t, modelConfigSupportsTextTest(adaptor.ModelConfig{
+		InputModalities:  []string{"text"},
+		OutputModalities: []string{"text"},
+		Description:      "A multilingual text embeddings model.",
+	}, true))
+	require.False(t, modelConfigSupportsTextTest(adaptor.ModelConfig{
+		InputModalities:  []string{"text"},
+		OutputModalities: []string{"text"},
+		Description:      "A sentiment classifier for text classification.",
 	}, true))
 	require.True(t, modelConfigSupportsTextTest(adaptor.ModelConfig{}, false))
 }
 
-// TestChooseChannelTestModelFiltersNonTextModels verifies fallback selection skips models that cannot output text.
-func TestChooseChannelTestModelFiltersNonTextModels(t *testing.T) {
+// TestModelNameLooksNonTextTestable distinguishes specialized tasks from similarly named chat models.
+func TestModelNameLooksNonTextTestable(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, modelNameLooksNonTextTestable("@cf/baai/bge-m3"))
+	require.True(t, modelNameLooksNonTextTestable("gpt-3.5-turbo-instruct"))
+	require.False(t, modelNameLooksNonTextTestable("amazon.nova-pro-v1:0"))
+	require.False(t, modelNameLooksNonTextTestable("gpt-4o-mini"))
+}
+
+// TestChooseChannelTestModelFiltersNonChatModels verifies fallback selection skips models that cannot serve Chat Completions.
+func TestChooseChannelTestModelFiltersNonChatModels(t *testing.T) {
 	t.Parallel()
 
 	channel := &model.Channel{
 		Type:   channeltype.OpenAI,
-		Models: "sora-2,gpt-4o-mini,text-embedding-3-small",
+		Models: "sora-2,gpt-4o-mini,text-embedding-3-small,gpt-3.5-turbo-instruct",
 	}
 
 	modelName, clearStored, err := chooseChannelTestModel(channel, "")
@@ -62,20 +83,61 @@ func TestChooseChannelTestModelFiltersNonTextModels(t *testing.T) {
 	require.Equal(t, "gpt-4o-mini", modelName)
 }
 
-// TestBuildChannelListResponseFiltersNonTextModels verifies channel rows expose only text-compatible test models.
-func TestBuildChannelListResponseFiltersNonTextModels(t *testing.T) {
+// TestChooseChannelTestModelSkipsCloudflareEmbeddingTasks reproduces the bge-m3 channel-test failure globally.
+func TestChooseChannelTestModelSkipsCloudflareEmbeddingTasks(t *testing.T) {
+	t.Parallel()
+
+	channel := &model.Channel{
+		Type: channeltype.Cloudflare,
+		Models: strings.Join([]string{
+			"@cf/baai/bge-m3",
+			"@cf/baai/bge-reranker-base",
+			"@cf/huggingface/distilbert-sst-2-int8",
+			"@cf/qwen/qwen3-30b-a3b-fp8",
+		}, ","),
+	}
+
+	modelName, clearStored, err := chooseChannelTestModel(channel, "")
+	require.NoError(t, err)
+	require.False(t, clearStored)
+	require.Equal(t, "@cf/qwen/qwen3-30b-a3b-fp8", modelName)
+}
+
+// TestBuildChannelListResponseFiltersNonChatModels verifies channel rows expose only Chat Completions-compatible models.
+func TestBuildChannelListResponseFiltersNonChatModels(t *testing.T) {
 	t.Parallel()
 
 	channels := []*model.Channel{
 		{
 			Type:   channeltype.OpenAI,
-			Models: "sora-2,gpt-4o-mini,text-embedding-3-small",
+			Models: "sora-2,gpt-4o-mini,text-embedding-3-small,gpt-3.5-turbo-instruct",
 		},
 	}
 
 	rows := buildChannelListResponse(channels)
 	require.Len(t, rows, 1)
 	require.Equal(t, []string{"gpt-4o-mini"}, rows[0].TestModels)
+}
+
+// TestBuildChannelListResponseFiltersCloudflareTasks verifies Cloudflare task models are absent from the test selector.
+func TestBuildChannelListResponseFiltersCloudflareTasks(t *testing.T) {
+	t.Parallel()
+
+	channels := []*model.Channel{
+		{
+			Type: channeltype.Cloudflare,
+			Models: strings.Join([]string{
+				"@cf/baai/bge-m3",
+				"@cf/baai/bge-reranker-base",
+				"@cf/meta/m2m100-1.2b",
+				"@cf/qwen/qwen3-30b-a3b-fp8",
+			}, ","),
+		},
+	}
+
+	rows := buildChannelListResponse(channels)
+	require.Len(t, rows, 1)
+	require.Equal(t, []string{"@cf/qwen/qwen3-30b-a3b-fp8"}, rows[0].TestModels)
 }
 
 // TestBuildChannelListResponseFiltersCompatibleChannels verifies compatible channels use global metadata.
@@ -114,8 +176,25 @@ func TestBuildChannelListResponseSerializesEmptyTestModels(t *testing.T) {
 	require.Contains(t, string(payload), `"test_models":[]`)
 }
 
-// TestChooseChannelTestModelClearsStoredNonTextModel verifies stored testing models must support text output.
-func TestChooseChannelTestModelClearsStoredNonTextModel(t *testing.T) {
+// TestBuildChannelListResponseRequiresChatEndpoint verifies endpoint-restricted channels expose no chat test choices.
+func TestBuildChannelListResponseRequiresChatEndpoint(t *testing.T) {
+	t.Parallel()
+
+	channels := []*model.Channel{
+		{
+			Type:   channeltype.OpenAICompatible,
+			Models: "gpt-4o-mini",
+			Config: `{"supported_endpoints":["embeddings"]}`,
+		},
+	}
+
+	rows := buildChannelListResponse(channels)
+	require.Len(t, rows, 1)
+	require.Empty(t, rows[0].TestModels)
+}
+
+// TestChooseChannelTestModelClearsStoredNonChatModel verifies stored testing models must support Chat Completions.
+func TestChooseChannelTestModelClearsStoredNonChatModel(t *testing.T) {
 	t.Parallel()
 
 	stored := "sora-2"
@@ -131,33 +210,82 @@ func TestChooseChannelTestModelClearsStoredNonTextModel(t *testing.T) {
 	require.Equal(t, "gpt-4o-mini", modelName)
 }
 
-// TestChooseChannelTestModelRejectsExplicitNonTextModel verifies explicit tests fail fast for non-text models.
-func TestChooseChannelTestModelRejectsExplicitNonTextModel(t *testing.T) {
+// TestChooseChannelTestModelClearsStoredCloudflareEmbedding verifies stale embedding selections are repaired automatically.
+func TestChooseChannelTestModelClearsStoredCloudflareEmbedding(t *testing.T) {
+	t.Parallel()
+
+	stored := "@cf/baai/bge-m3"
+	channel := &model.Channel{
+		Type:         channeltype.Cloudflare,
+		Models:       "@cf/baai/bge-m3,@cf/qwen/qwen3-30b-a3b-fp8",
+		TestingModel: &stored,
+	}
+
+	modelName, clearStored, err := chooseChannelTestModel(channel, "")
+	require.NoError(t, err)
+	require.True(t, clearStored)
+	require.Equal(t, "@cf/qwen/qwen3-30b-a3b-fp8", modelName)
+}
+
+// TestChooseChannelTestModelRejectsExplicitNonChatModel verifies explicit tests fail fast for non-chat models.
+func TestChooseChannelTestModelRejectsExplicitNonChatModel(t *testing.T) {
 	t.Parallel()
 
 	channel := &model.Channel{
-		Type:   channeltype.OpenAI,
-		Models: "sora-2,gpt-4o-mini",
+		Type:   channeltype.Cloudflare,
+		Models: "@cf/baai/bge-m3,@cf/qwen/qwen3-30b-a3b-fp8",
 	}
 
-	modelName, clearStored, err := chooseChannelTestModel(channel, "sora-2")
+	modelName, clearStored, err := chooseChannelTestModel(channel, "@cf/baai/bge-m3")
 	require.Error(t, err)
 	require.False(t, clearStored)
 	require.Empty(t, modelName)
-	require.Contains(t, err.Error(), "does not support both text input and text output")
+	require.Contains(t, err.Error(), "does not support both text input and text output through Chat Completions")
 }
 
-// TestChannelTestModelSupportsTextUsesMapping verifies aliases inherit capability checks from mapped upstream models.
+// TestChooseChannelTestModelRejectsChannelWithoutChatEndpoint verifies all probes use the Chat Completions endpoint contract.
+func TestChooseChannelTestModelRejectsChannelWithoutChatEndpoint(t *testing.T) {
+	t.Parallel()
+
+	channel := &model.Channel{
+		Type:   channeltype.OpenAICompatible,
+		Models: "gpt-4o-mini",
+		Config: `{"supported_endpoints":["embeddings"]}`,
+	}
+
+	modelName, clearStored, err := chooseChannelTestModel(channel, "")
+	require.Error(t, err)
+	require.False(t, clearStored)
+	require.Empty(t, modelName)
+	require.Contains(t, err.Error(), "does not support the Chat Completions endpoint")
+}
+
+// TestChooseChannelTestModelAllowsUnknownCustomChatModel preserves custom-provider compatibility when metadata is unavailable.
+func TestChooseChannelTestModelAllowsUnknownCustomChatModel(t *testing.T) {
+	t.Parallel()
+
+	channel := &model.Channel{
+		Type:   channeltype.OpenAICompatible,
+		Models: "vendor/new-chat-model",
+	}
+
+	modelName, clearStored, err := chooseChannelTestModel(channel, "")
+	require.NoError(t, err)
+	require.False(t, clearStored)
+	require.Equal(t, "vendor/new-chat-model", modelName)
+}
+
+// TestChannelTestModelSupportsTextUsesMapping verifies aliases inherit task checks from mapped upstream models.
 func TestChannelTestModelSupportsTextUsesMapping(t *testing.T) {
 	t.Parallel()
 
-	mapping := `{"video-alias":"sora-2","chat-alias":"gpt-4o-mini"}`
+	mapping := `{"embedding-alias":"@cf/baai/bge-m3","chat-alias":"@cf/qwen/qwen3-30b-a3b-fp8"}`
 	channel := &model.Channel{
-		Type:         channeltype.OpenAI,
-		Models:       "video-alias,chat-alias",
+		Type:         channeltype.Cloudflare,
+		Models:       "embedding-alias,chat-alias",
 		ModelMapping: &mapping,
 	}
 
-	require.False(t, channelTestModelSupportsText(channel, "video-alias"))
+	require.False(t, channelTestModelSupportsText(channel, "embedding-alias"))
 	require.True(t, channelTestModelSupportsText(channel, "chat-alias"))
 }


### PR DESCRIPTION
## Summary

Make every channel health test use a model that is compatible with the text Chat Completions probe, rather than treating every text-input/text-output model as a chat model.

This is a follow-up to #363. The Cloudflare adaptor itself is now aligned with the OpenAI-compatible API, but the global channel-test selector could still choose `@cf/baai/bge-m3` because it is cheap and its legacy metadata advertises text input/output. BGE-M3 is an embeddings task whose schema accepts `text`, `contexts`, or batch `requests`, so sending a Chat Completions payload produces the reported Cloudflare 400 schema error.

## Changes

- require the channel's effective endpoint configuration to include `chat_completions`
- apply the same Chat model validation to:
  - automatic cheapest-model selection
  - explicitly requested test models
  - persisted `testing_model` values
  - single-channel tests
  - bulk channel tests
  - the admin UI `test_models` selector
- reject specialized non-chat tasks even when they expose text input/output:
  - embeddings and reranking
  - classification, moderation, and safety models
  - translation and summarization task models
  - speech, OCR, image, and video models
  - legacy Completions-only models
- inspect both mapped upstream model names and provider descriptions, so aliases and incomplete modality metadata cannot bypass the check
- keep unknown custom-provider models compatible when their names do not identify a non-chat task
- preserve price-based selection after filtering to valid Chat candidates

## Regression coverage

- reproduces the Cloudflare BGE-M3 selection failure and verifies a Qwen Chat model is selected instead
- filters BGE-M3, BGE reranker, DistilBERT classification, and M2M100 translation from Cloudflare test choices
- clears a stale persisted Cloudflare embeddings `testing_model`
- rejects explicitly selected embeddings models before contacting upstream
- rejects channels configured without the Chat Completions endpoint
- preserves OpenAI-compatible custom Chat models without catalog metadata
- preserves Amazon Nova Chat model names while rejecting task-specific model names
- verifies aliases inherit the mapped upstream model's task classification

## Validation

- files formatted with `gofmt`
- full repository validation is delegated to GitHub Actions because this execution environment cannot clone GitHub or resolve external modules

## References

- https://developers.cloudflare.com/workers-ai/models/bge-m3/
- https://developers.cloudflare.com/workers-ai/models/bge-reranker-base/
