### PR TITLE
fix(deepseek): align V4 pricing and reasoning metadata

### DIFF
--- a/relay/adaptor/deepseek/adaptor.go
+++ b/relay/adaptor/deepseek/adaptor.go
@@ -128,10 +128,10 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	return request, nil
 }
 
-// normalizeDeepSeekReasoningEffort maps portable reasoning levels to the
-// values accepted by DeepSeek and clears unsupported values.
-// Parameters: request is the mutable OpenAI-style request to normalize.
-// Returns: nothing; request.ReasoningEffort is updated in place.
+// normalizeDeepSeekReasoningEffort maps portable reasoning levels to the values
+// currently documented by DeepSeek. Parameters: request is the mutable
+// OpenAI-style request to normalize and may be nil. Returns: nothing; supported
+// values are normalized in place and unsupported values are cleared.
 func normalizeDeepSeekReasoningEffort(request *model.GeneralOpenAIRequest) {
 	if request == nil || request.ReasoningEffort == nil {
 		return
@@ -139,13 +139,10 @@ func normalizeDeepSeekReasoningEffort(request *model.GeneralOpenAIRequest) {
 
 	effort := strings.ToLower(strings.TrimSpace(*request.ReasoningEffort))
 	switch effort {
-	case "high", "max":
-	case "low", "medium":
-		// DeepSeek accepts low and medium as compatibility aliases for high.
+	case "low", "high", "max":
+	case "medium", "xhigh":
+		// DeepSeek maps both OpenAI compatibility aliases to high.
 		effort = "high"
-	case "xhigh":
-		// DeepSeek accepts xhigh as a compatibility alias for max.
-		effort = "max"
 	default:
 		request.ReasoningEffort = nil
 		return

--- a/relay/adaptor/deepseek/constants.go
+++ b/relay/adaptor/deepseek/constants.go
@@ -33,8 +33,8 @@ var (
 	// deepseekFlashReasoningEfforts lists the distinct reasoning levels supported
 	// by DeepSeek V4 Flash. The API defaults to high.
 	deepseekFlashReasoningEfforts = []string{"low", "high", "max"}
-	// deepseekProReasoningEfforts lists the effective reasoning levels supported
-	// by DeepSeek V4 Pro. The API accepts low but currently treats it as high.
+	// deepseekProReasoningEfforts lists the distinct reasoning levels supported
+	// by DeepSeek V4 Pro. The API defaults to high.
 	deepseekProReasoningEfforts = []string{"low", "high", "max"}
 )
 
@@ -51,9 +51,9 @@ const (
 	deepseekV4ProCachedInputRatio = 0.003625 * ratio.MilliTokensUsd
 
 	// deepseekV4PricingEffectiveDate is the first local date covered by the new
-	// pricing schedule. The documented activation instant is 2026-08-22 16:00
-	// UTC, which is 2026-08-23 00:00 in the schedule's Asia/Shanghai timezone.
-	deepseekV4PricingEffectiveDate = "2026-08-23"
+	// pricing schedule. The documented activation instant is 2026-08-16 16:00
+	// UTC, which is 2026-08-17 00:00 in the schedule's Asia/Shanghai timezone.
+	deepseekV4PricingEffectiveDate = "2026-08-17"
 )
 
 // deepseekV4PricingWindows returns the official post-activation off-peak and
@@ -123,8 +123,9 @@ func deepseekV4PricingWindows(
 
 // ModelRatios contains the currently available DeepSeek API models and their
 // pricing and capability metadata. Model IDs, capabilities, and prices were
-// verified on 2026-08-21 against the official DeepSeek documentation:
+// verified on 2026-09-01 against the official DeepSeek documentation:
 //   - https://api-docs.deepseek.com/quick_start/pricing/
+//   - https://api-docs.deepseek.com/guides/thinking_mode/
 //   - https://api-docs.deepseek.com/guides/vision/
 //   - https://api-docs.deepseek.com/api/list-models/
 //   - https://api-docs.deepseek.com/api/create-chat-completion/

--- a/relay/adaptor/deepseek/constants_test.go
+++ b/relay/adaptor/deepseek/constants_test.go
@@ -51,7 +51,7 @@ func TestModelRatiosMatchOfficialPricing(t *testing.T) {
 			require.Equal(t, int32(1048576), cfg.ContextLength)
 			require.Equal(t, int32(393216), cfg.MaxOutputTokens)
 			require.Len(t, cfg.TimeWindows, 3)
-			require.Equal(t, "2026-08-23", cfg.TimeWindows[0].DateFrom)
+			require.Equal(t, "2026-08-17", cfg.TimeWindows[0].DateFrom)
 			require.Equal(t, "Asia/Shanghai", cfg.TimeWindows[0].TimeZone)
 
 			beforeActivation := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 16, 15, 59, 0, 0, time.UTC))
@@ -93,15 +93,19 @@ func TestDeepSeekPricingScheduleHonorsActivationAndWeekends(t *testing.T) {
 	t.Parallel()
 
 	cfg := ModelRatios["deepseek-v4-flash"]
-	beforeActivation := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 22, 15, 59, 0, 0, time.UTC))
+	beforeActivation := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 16, 15, 59, 0, 0, time.UTC))
 	require.InDelta(t, cfg.Ratio, beforeActivation.Ratio, 1e-15)
 
-	sundayPeakHour := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 23, 2, 0, 0, 0, time.UTC))
-	require.InDelta(t, 0.22*ratio.MilliTokensUsd, sundayPeakHour.Ratio, 1e-15)
-	require.InDelta(t, 0.007*ratio.MilliTokensUsd, sundayPeakHour.CachedInputRatio, 1e-15)
+	atActivation := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC))
+	require.InDelta(t, 0.22*ratio.MilliTokensUsd, atActivation.Ratio, 1e-15)
+	require.InDelta(t, 0.007*ratio.MilliTokensUsd, atActivation.CachedInputRatio, 1e-15)
 
-	mondayPeakHour := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 24, 2, 0, 0, 0, time.UTC))
-	require.InDelta(t, 0.44*ratio.MilliTokensUsd, mondayPeakHour.Ratio, 1e-15)
+	firstWeekdayPeakHour := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC))
+	require.InDelta(t, 0.44*ratio.MilliTokensUsd, firstWeekdayPeakHour.Ratio, 1e-15)
+
+	saturdayPeakHour := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 22, 2, 0, 0, 0, time.UTC))
+	require.InDelta(t, 0.22*ratio.MilliTokensUsd, saturdayPeakHour.Ratio, 1e-15)
+	require.InDelta(t, 0.007*ratio.MilliTokensUsd, saturdayPeakHour.CachedInputRatio, 1e-15)
 }
 
 // TestModelRatiosMatchOfficialCapabilities verifies model-specific version,

--- a/relay/adaptor/deepseek/reasoning_effort_test.go
+++ b/relay/adaptor/deepseek/reasoning_effort_test.go
@@ -1,0 +1,60 @@
+package deepseek
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/model"
+)
+
+// TestNormalizeDeepSeekReasoningEffortMatchesOfficialMapping verifies the
+// current DeepSeek low, medium, high, xhigh, and max compatibility mapping.
+// Parameters: t is the testing handle used for assertions and subtests.
+// Returns: nothing; the test fails when normalization diverges from the official mapping.
+func TestNormalizeDeepSeekReasoningEffortMatchesOfficialMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantNil bool
+	}{
+		{name: "low remains low", input: " low ", want: "low"},
+		{name: "medium maps to high", input: "medium", want: "high"},
+		{name: "high remains high", input: "HIGH", want: "high"},
+		{name: "xhigh maps to high", input: "xhigh", want: "high"},
+		{name: "max remains max", input: "max", want: "max"},
+		{name: "unsupported value is cleared", input: "minimal", wantNil: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			effort := tt.input
+			request := &model.GeneralOpenAIRequest{ReasoningEffort: &effort}
+			normalizeDeepSeekReasoningEffort(request)
+
+			if tt.wantNil {
+				require.Nil(t, request.ReasoningEffort)
+				return
+			}
+			require.NotNil(t, request.ReasoningEffort)
+			require.Equal(t, tt.want, *request.ReasoningEffort)
+		})
+	}
+}
+
+// TestNormalizeDeepSeekReasoningEffortAllowsNil verifies nil inputs remain a no-op.
+// Parameters: t is the testing handle used for the panic assertion.
+// Returns: nothing; the test fails if a nil input causes a panic.
+func TestNormalizeDeepSeekReasoningEffortAllowsNil(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		normalizeDeepSeekReasoningEffort(nil)
+		normalizeDeepSeekReasoningEffort(&model.GeneralOpenAIRequest{})
+	})
+}

--- a/relay/adaptor/deepseek/vision_test.go
+++ b/relay/adaptor/deepseek/vision_test.go
@@ -174,11 +174,11 @@ func TestConvertRequestPreservesReasoningEffort(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{input: "low", expected: "high"},
+		{input: "low", expected: "low"},
 		{input: "high", expected: "high"},
 		{input: "max", expected: "max"},
 		{input: "medium", expected: "high"},
-		{input: "xhigh", expected: "max"},
+		{input: "xhigh", expected: "high"},
 	} {
 		testCase := testCase
 		t.Run(testCase.input, func(t *testing.T) {

--- a/relay/controller/thinking.go
+++ b/relay/controller/thinking.go
@@ -381,15 +381,27 @@ func defaultReasoningEffort(modelName string) string {
 	return "high"
 }
 
-// normalizeReasoningEffort sanitizes a requested reasoning effort value for a model.
+// normalizeReasoningEffort sanitizes a requested reasoning effort for a model.
+// Parameters: modelName selects provider-specific rules and effort is the requested value.
+// Returns: a normalized provider-compatible value, or an empty string when unsupported.
 func normalizeReasoningEffort(modelName, effort string) string {
 	normalized := strings.ToLower(strings.TrimSpace(effort))
 	if normalized == "" {
 		return ""
 	}
-	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(modelName)), "deepseek-v4-") && normalized == "xhigh" {
-		return "max"
+
+	name := strings.ToLower(strings.TrimSpace(modelName))
+	if strings.HasPrefix(name, "deepseek-v4-") {
+		switch normalized {
+		case "medium", "xhigh":
+			return "high"
+		case "low", "high", "max":
+			return normalized
+		default:
+			return ""
+		}
 	}
+
 	if !isReasoningEffortAllowed(modelName, normalized) {
 		return ""
 	}

--- a/relay/controller/thinking_deepseek_test.go
+++ b/relay/controller/thinking_deepseek_test.go
@@ -1,0 +1,62 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/apitype"
+	"github.com/Laisky/one-api/relay/channeltype"
+	metalib "github.com/Laisky/one-api/relay/meta"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+)
+
+// TestApplyThinkingQueryToDeepSeekV4NormalizesReasoningEffort verifies the
+// query-parameter path applies the same DeepSeek V4 reasoning mapping as JSON bodies.
+// Parameters: t is the testing handle used for assertions and subtests.
+// Returns: nothing; the test fails when query normalization diverges from the provider mapping.
+func TestApplyThinkingQueryToDeepSeekV4NormalizesReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "low remains low", input: "low", expected: "low"},
+		{name: "medium maps to high", input: "medium", expected: "high"},
+		{name: "high remains high", input: "high", expected: "high"},
+		{name: "xhigh maps to high", input: "xhigh", expected: "high"},
+		{name: "max remains max", input: "max", expected: "max"},
+	}
+
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			writer := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(writer)
+			c.Request = httptest.NewRequest(
+				http.MethodPost,
+				"/v1/chat/completions?thinking=true&reasoning_effort="+testCase.input,
+				nil,
+			)
+
+			meta := &metalib.Meta{
+				ActualModelName: "deepseek-v4-pro",
+				APIType:         apitype.OpenAI,
+				ChannelType:     channeltype.DeepSeek,
+			}
+			payload := &relaymodel.GeneralOpenAIRequest{Model: meta.ActualModelName}
+
+			applyThinkingQueryToChatRequest(c, payload, meta)
+
+			require.NotNil(t, payload.ReasoningEffort)
+			require.Equal(t, testCase.expected, *payload.ReasoningEffort)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- verify the current DeepSeek V4 catalog against the official Models & Pricing page
- correct the peak/off-peak pricing activation boundary to `2026-08-16 16:00 UTC` (`2026-08-17 00:00 Asia/Shanghai`)
- preserve `reasoning_effort=low`, map the compatibility aliases `medium` and `xhigh` to `high`, and preserve `max`
- keep query-parameter and JSON-body reasoning mappings consistent
- refresh the model metadata verification date and add the official Thinking Mode source
- add focused regression coverage for pricing activation, weekday/weekend selection, all reasoning-effort mappings, normalization, nil inputs, and the controller query path

## Official sources

- Models and pricing: https://api-docs.deepseek.com/quick_start/pricing/
- V4 Pro release and pricing activation: https://api-docs.deepseek.com/news/news260813/
- Thinking effort mapping: https://api-docs.deepseek.com/guides/thinking_mode/
- Model lifecycle: https://api-docs.deepseek.com/updates/

## Validation

- `gofmt` is clean for all changed Go files
- GitHub's server-side comparison shows two focused commits across seven intended files
- focused adaptor and controller tests cover the documented DeepSeek V4 reasoning mappings
- both reviewer threads have been addressed, replied to, and resolved
- `Go Vet`, static guardrails, and CodeRabbit pass on the current head; full Go test workflows are tracked by GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * DeepSeek reasoning-level handling now follows the latest supported mappings, including consistent treatment across request formats.
  * Unsupported reasoning levels continue to be safely ignored.

* **Pricing**
  * DeepSeek Pro V4 pricing now reflects activation beginning August 17, 2026, including weekday peak and weekend off-peak rates.

* **Documentation**
  * Updated DeepSeek Pro reasoning-level and pricing information to reflect current support and activation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->