### PR TITLE
chore: update Claude 5.1 model catalog

### DIFF
--- a/relay/adaptor/anthropic/constants_test.go
+++ b/relay/adaptor/anthropic/constants_test.go
@@ -63,13 +63,13 @@ func TestClaudeOpus5PricingMatchesPublishedRatios(t *testing.T) {
 func TestClaudeSonnet5PricingMatchesPublishedRatios(t *testing.T) {
 	pricing, ok := ModelRatios["claude-sonnet-5"]
 	require.True(t, ok, "Claude Sonnet 5 pricing missing from Anthropic model ratios")
-	// Standard pricing is $3/$15 per MTok (the introductory $2/$10 promo through
-	// 2026-08-31 is intentionally not encoded to avoid under-billing afterwards).
-	require.InDelta(t, 3*ratio.MilliTokensUsd, pricing.Ratio, 1e-12)
+	// Anthropic made the launch price permanent and canceled the scheduled
+	// September 1, 2026 increase to $3/$15 per MTok.
+	require.InDelta(t, 2*ratio.MilliTokensUsd, pricing.Ratio, 1e-12)
 	require.InDelta(t, 5.0, pricing.CompletionRatio, 1e-12)
-	require.InDelta(t, 0.3*ratio.MilliTokensUsd, pricing.CachedInputRatio, 1e-12)
-	require.InDelta(t, 3.75*ratio.MilliTokensUsd, pricing.CacheWrite5mRatio, 1e-12)
-	require.InDelta(t, 6.0*ratio.MilliTokensUsd, pricing.CacheWrite1hRatio, 1e-12)
+	require.InDelta(t, 0.2*ratio.MilliTokensUsd, pricing.CachedInputRatio, 1e-12)
+	require.InDelta(t, 2.5*ratio.MilliTokensUsd, pricing.CacheWrite5mRatio, 1e-12)
+	require.InDelta(t, 4.0*ratio.MilliTokensUsd, pricing.CacheWrite1hRatio, 1e-12)
 	require.EqualValues(t, 1000000, pricing.ContextLength)
 	require.EqualValues(t, 128000, pricing.MaxOutputTokens)
 	// Sonnet 5 shares Opus 4.7+'s adaptive-only sampling surface: temperature/top_p/top_k

--- a/relay/adaptor/anthropic/models_202609.go
+++ b/relay/adaptor/anthropic/models_202609.go
@@ -1,0 +1,46 @@
+package anthropic
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// claudeSeptember2026ModelRatios adds the Claude model IDs released on
+// 2026-09-01 and replaces Sonnet 5's superseded introductory-price window with
+// Anthropic's permanent $2/$10 per million token pricing.
+//
+// Sources:
+//   - https://platform.claude.com/docs/en/models/overview
+//   - https://platform.claude.com/docs/en/about-claude/pricing
+var claudeSeptember2026ModelRatios = map[string]adaptor.ModelConfig{
+	"claude-fable-5-1": {
+		Ratio: 10 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.25 * ratio.MilliTokensUsd, CacheWrite5mRatio: 12.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 20 * ratio.MilliTokensUsd,
+		ContextLength: 1000000, MaxOutputTokens: 128000,
+		InputModalities: claudeVisionInputs, OutputModalities: claudeTextOutputs,
+		SupportedFeatures: claudeFeaturesWithReasoning, SupportedSamplingParameters: claudeAdaptiveOnlySamplingParams,
+		Description: "Claude Fable 5.1 flagship model with 1M-token context and adaptive thinking; prompt-cache reads cost $0.25 per million tokens.",
+	},
+	"claude-mythos-5-1": {
+		Ratio: 10 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.25 * ratio.MilliTokensUsd, CacheWrite5mRatio: 12.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 20 * ratio.MilliTokensUsd,
+		ContextLength: 1000000, MaxOutputTokens: 128000,
+		InputModalities: claudeVisionInputs, OutputModalities: claudeTextOutputs,
+		SupportedFeatures: claudeFeaturesWithReasoning, SupportedSamplingParameters: claudeAdaptiveOnlySamplingParams,
+		Description: "Claude Mythos 5.1 invite-only model with 1M-token context and adaptive thinking; prompt-cache reads cost $0.25 per million tokens.",
+	},
+	"claude-sonnet-5": {
+		Ratio: 2 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.2 * ratio.MilliTokensUsd, CacheWrite5mRatio: 2.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 4 * ratio.MilliTokensUsd,
+		ContextLength: 1000000, MaxOutputTokens: 128000,
+		InputModalities: claudeVisionInputs, OutputModalities: claudeTextOutputs,
+		SupportedFeatures: claudeFeaturesWithReasoning, SupportedSamplingParameters: claudeAdaptiveOnlySamplingParams,
+		Description: "Claude Sonnet 5 balanced flagship with 1M-token context, adaptive thinking, and permanent $2/$10 per million token pricing.",
+	},
+}
+
+func init() {
+	for model, config := range claudeSeptember2026ModelRatios {
+		ModelRatios[model] = config
+	}
+}

--- a/relay/adaptor/anthropic/models_202609.go
+++ b/relay/adaptor/anthropic/models_202609.go
@@ -39,6 +39,8 @@ var claudeSeptember2026ModelRatios = map[string]adaptor.ModelConfig{
 	},
 }
 
+// init installs the September 2026 Claude entries in the shared Anthropic model
+// registry. It takes no parameters and returns no values.
 func init() {
 	for model, config := range claudeSeptember2026ModelRatios {
 		ModelRatios[model] = config

--- a/relay/adaptor/anthropic/models_202609_test.go
+++ b/relay/adaptor/anthropic/models_202609_test.go
@@ -1,0 +1,60 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+func TestClaudeSeptember2026ModelCatalog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		inputUsd         float64
+		outputMultiplier float64
+		cacheReadUsd     float64
+		cacheWrite5mUsd  float64
+		cacheWrite1hUsd  float64
+	}{
+		{name: "claude-fable-5-1", inputUsd: 10, outputMultiplier: 5, cacheReadUsd: 0.25, cacheWrite5mUsd: 12.5, cacheWrite1hUsd: 20},
+		{name: "claude-mythos-5-1", inputUsd: 10, outputMultiplier: 5, cacheReadUsd: 0.25, cacheWrite5mUsd: 12.5, cacheWrite1hUsd: 20},
+		{name: "claude-sonnet-5", inputUsd: 2, outputMultiplier: 5, cacheReadUsd: 0.2, cacheWrite5mUsd: 2.5, cacheWrite1hUsd: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, ok := ModelRatios[tt.name]
+			require.True(t, ok)
+			require.InDelta(t, tt.inputUsd*ratio.MilliTokensUsd, config.Ratio, 1e-12)
+			require.InDelta(t, tt.outputMultiplier, config.CompletionRatio, 1e-12)
+			require.InDelta(t, tt.cacheReadUsd*ratio.MilliTokensUsd, config.CachedInputRatio, 1e-12)
+			require.InDelta(t, tt.cacheWrite5mUsd*ratio.MilliTokensUsd, config.CacheWrite5mRatio, 1e-12)
+			require.InDelta(t, tt.cacheWrite1hUsd*ratio.MilliTokensUsd, config.CacheWrite1hRatio, 1e-12)
+			require.EqualValues(t, 1000000, config.ContextLength)
+			require.EqualValues(t, 128000, config.MaxOutputTokens)
+			require.Equal(t, claudeAdaptiveOnlySamplingParams, config.SupportedSamplingParameters)
+			require.EqualValues(t, 0, config.MaxReasoningTokens)
+		})
+	}
+}
+
+func TestClaudeSonnet5PermanentPricingHasNoExpiryWindow(t *testing.T) {
+	t.Parallel()
+
+	config := ModelRatios["claude-sonnet-5"]
+	require.Empty(t, config.TimeWindows)
+	require.InDelta(t, 2*ratio.MilliTokensUsd, config.Ratio, 1e-12)
+	require.InDelta(t, 10*ratio.MilliTokensUsd, config.Ratio*config.CompletionRatio, 1e-12)
+}
+
+func TestClaudeSeptember2026ModelsUseAdaptiveThinking(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, IsClaudeAdaptiveThinkingModel("claude-fable-5-1"))
+	require.True(t, IsClaudeAdaptiveThinkingModel("claude-mythos-5-1"))
+}

--- a/relay/adaptor/aws/claude/models_202609.go
+++ b/relay/adaptor/aws/claude/models_202609.go
@@ -8,6 +8,8 @@ var claudeSeptember2026BedrockModelIDs = map[string]string{
 	"claude-mythos-5-1": "anthropic.claude-mythos-5-1",
 }
 
+// init installs the September 2026 Claude IDs in the Bedrock model-ID registry.
+// It takes no parameters and returns no values.
 func init() {
 	for model, bedrockModelID := range claudeSeptember2026BedrockModelIDs {
 		AwsModelIDMap[model] = bedrockModelID

--- a/relay/adaptor/aws/claude/models_202609.go
+++ b/relay/adaptor/aws/claude/models_202609.go
@@ -1,0 +1,15 @@
+package aws
+
+// claudeSeptember2026BedrockModelIDs maps the Claude 5.1 API model IDs released
+// on 2026-09-01 to their Amazon Bedrock model IDs.
+// Source: https://platform.claude.com/docs/en/models/overview
+var claudeSeptember2026BedrockModelIDs = map[string]string{
+	"claude-fable-5-1":  "anthropic.claude-fable-5-1",
+	"claude-mythos-5-1": "anthropic.claude-mythos-5-1",
+}
+
+func init() {
+	for model, bedrockModelID := range claudeSeptember2026BedrockModelIDs {
+		AwsModelIDMap[model] = bedrockModelID
+	}
+}

--- a/relay/adaptor/aws/claude/models_202609_test.go
+++ b/relay/adaptor/aws/claude/models_202609_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeSeptember2026BedrockModelIDs(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"claude-fable-5-1":  "anthropic.claude-fable-5-1",
+		"claude-mythos-5-1": "anthropic.claude-mythos-5-1",
+	}
+
+	for model, expected := range tests {
+		model := model
+		expected := expected
+		t.Run(model, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := AwsModelID(model)
+			require.NoError(t, err)
+			require.Equal(t, expected, actual)
+		})
+	}
+}

--- a/relay/adaptor/aws/claude/models_202609_test.go
+++ b/relay/adaptor/aws/claude/models_202609_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestClaudeSeptember2026BedrockModelIDs verifies the Bedrock model-ID mappings
+// for the Claude 5.1 releases. It accepts a testing handle and returns no value.
 func TestClaudeSeptember2026BedrockModelIDs(t *testing.T) {
 	t.Parallel()
 

--- a/relay/adaptor/aws/models_202609.go
+++ b/relay/adaptor/aws/models_202609.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// awsClaudeAdaptiveOnlySamplingParams lists the parameters accepted by Claude
+// models whose adaptive thinking is always enabled.
+var awsClaudeAdaptiveOnlySamplingParams = []string{"stop", "max_tokens"}
+
+// claudeSeptember2026BedrockModelPricing adds the Claude 5.1 releases and
+// replaces Sonnet 5's expired introductory-price window with its permanent
+// pricing.
+//
+// Sources:
+//   - https://platform.claude.com/docs/en/models/overview
+//   - https://platform.claude.com/docs/en/about-claude/pricing
+var claudeSeptember2026BedrockModelPricing = map[string]adaptor.ModelConfig{
+	"claude-fable-5-1": {
+		Ratio: 10 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.25 * ratio.MilliTokensUsd, CacheWrite5mRatio: 12.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 20 * ratio.MilliTokensUsd,
+		ContextLength: 1000000, MaxOutputTokens: 128000,
+		InputModalities: awsClaudeVisionInputs, OutputModalities: awsTextOutputs,
+		SupportedFeatures: awsClaudeFeaturesWithReasoning, SupportedSamplingParameters: awsClaudeAdaptiveOnlySamplingParams,
+		Description: "Claude Fable 5.1 on AWS Bedrock with 1M-token context and adaptive thinking; prompt-cache reads cost $0.25 per million tokens.",
+	},
+	"claude-mythos-5-1": {
+		Ratio: 10 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.25 * ratio.MilliTokensUsd, CacheWrite5mRatio: 12.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 20 * ratio.MilliTokensUsd,
+		ContextLength: 1000000, MaxOutputTokens: 128000,
+		InputModalities: awsClaudeVisionInputs, OutputModalities: awsTextOutputs,
+		SupportedFeatures: awsClaudeFeaturesWithReasoning, SupportedSamplingParameters: awsClaudeAdaptiveOnlySamplingParams,
+		Description: "Claude Mythos 5.1 invite-only model on AWS Bedrock with 1M-token context and adaptive thinking; prompt-cache reads cost $0.25 per million tokens.",
+	},
+	"claude-sonnet-5": {
+		Ratio: 2 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.2 * ratio.MilliTokensUsd, CacheWrite5mRatio: 2.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 4 * ratio.MilliTokensUsd,
+		ContextLength: 1000000, MaxOutputTokens: 128000,
+		InputModalities: awsClaudeVisionInputs, OutputModalities: awsTextOutputs,
+		SupportedFeatures: awsClaudeFeaturesWithReasoning, SupportedSamplingParameters: awsClaudeAdaptiveOnlySamplingParams,
+		Description: "Claude Sonnet 5 on AWS Bedrock with 1M-token context, adaptive thinking, and permanent $2/$10 per million token pricing.",
+	},
+}
+
+// init installs the September 2026 Claude entries in the canonical Bedrock
+// pricing registry. It takes no parameters and returns no values.
+func init() {
+	for model, config := range claudeSeptember2026BedrockModelPricing {
+		awsBedrockModelPricing[model] = config
+	}
+}

--- a/relay/adaptor/aws/models_202609_test.go
+++ b/relay/adaptor/aws/models_202609_test.go
@@ -1,4 +1,4 @@
-package anthropic
+package aws
 
 import (
 	"testing"
@@ -8,9 +8,10 @@ import (
 	"github.com/Laisky/one-api/relay/billing/ratio"
 )
 
-// TestClaudeSeptember2026ModelCatalog verifies the September 2026 Claude model
-// metadata and pricing. It accepts a testing handle and returns no value.
-func TestClaudeSeptember2026ModelCatalog(t *testing.T) {
+// TestClaudeSeptember2026BedrockPricing verifies that the canonical Bedrock
+// pricing registry exposes the September 2026 Claude rates and metadata. It
+// accepts a testing handle and returns no value.
+func TestClaudeSeptember2026BedrockPricing(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -26,11 +27,12 @@ func TestClaudeSeptember2026ModelCatalog(t *testing.T) {
 		{name: "claude-sonnet-5", inputUsd: 2, outputMultiplier: 5, cacheReadUsd: 0.2, cacheWrite5mUsd: 2.5, cacheWrite1hUsd: 4},
 	}
 
+	pricing := (&Adaptor{}).GetDefaultModelPricing()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			config, ok := ModelRatios[tt.name]
+			config, ok := pricing[tt.name]
 			require.True(t, ok)
 			require.InDelta(t, tt.inputUsd*ratio.MilliTokensUsd, config.Ratio, 1e-12)
 			require.InDelta(t, tt.outputMultiplier, config.CompletionRatio, 1e-12)
@@ -39,30 +41,21 @@ func TestClaudeSeptember2026ModelCatalog(t *testing.T) {
 			require.InDelta(t, tt.cacheWrite1hUsd*ratio.MilliTokensUsd, config.CacheWrite1hRatio, 1e-12)
 			require.EqualValues(t, 1000000, config.ContextLength)
 			require.EqualValues(t, 128000, config.MaxOutputTokens)
-			require.Equal(t, claudeAdaptiveOnlySamplingParams, config.SupportedSamplingParameters)
-			require.EqualValues(t, 0, config.MaxReasoningTokens)
+			require.Equal(t, awsClaudeAdaptiveOnlySamplingParams, config.SupportedSamplingParameters)
+			require.Empty(t, config.TimeWindows)
 		})
 	}
 }
 
-// TestClaudeSonnet5PermanentPricingHasNoExpiryWindow verifies that Sonnet 5
-// uses its permanent price without a time-window override. It accepts a testing
+// TestClaudeSeptember2026BedrockModelsAreRoutable verifies that the parent AWS
+// registry exposes adapters for both Claude 5.1 model IDs. It accepts a testing
 // handle and returns no value.
-func TestClaudeSonnet5PermanentPricingHasNoExpiryWindow(t *testing.T) {
+func TestClaudeSeptember2026BedrockModelsAreRoutable(t *testing.T) {
 	t.Parallel()
 
-	config := ModelRatios["claude-sonnet-5"]
-	require.Empty(t, config.TimeWindows)
-	require.InDelta(t, 2*ratio.MilliTokensUsd, config.Ratio, 1e-12)
-	require.InDelta(t, 10*ratio.MilliTokensUsd, config.Ratio*config.CompletionRatio, 1e-12)
-}
-
-// TestClaudeSeptember2026ModelsUseAdaptiveThinking verifies that the new Claude
-// 5.1 model IDs use adaptive thinking. It accepts a testing handle and returns
-// no value.
-func TestClaudeSeptember2026ModelsUseAdaptiveThinking(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, IsClaudeAdaptiveThinkingModel("claude-fable-5-1"))
-	require.True(t, IsClaudeAdaptiveThinkingModel("claude-mythos-5-1"))
+	modelList := (&Adaptor{}).GetModelList()
+	for _, model := range []string{"claude-fable-5-1", "claude-mythos-5-1"} {
+		require.Contains(t, modelList, model)
+		require.NotNil(t, GetAdaptor(model))
+	}
 }

--- a/relay/adaptor/aws/utils/models_202609.go
+++ b/relay/adaptor/aws/utils/models_202609.go
@@ -1,0 +1,24 @@
+package utils
+
+import "slices"
+
+const (
+	claudeFable5BedrockModelID   = "anthropic.claude-fable-5"
+	claudeFable51BedrockModelID  = "anthropic.claude-fable-5-1"
+	claudeMythos51BedrockModelID = "anthropic.claude-mythos-5-1"
+)
+
+// init registers the Claude 5.1 global inference profiles using the same source
+// Region coverage as Claude Fable 5. It takes no parameters and returns no
+// values.
+func init() {
+	sourceRegions := GlobalProfileSourceRegions[claudeFable5BedrockModelID]
+	GlobalProfileSourceRegions[claudeFable51BedrockModelID] = slices.Clone(sourceRegions)
+	GlobalProfileSourceRegions[claudeMythos51BedrockModelID] = slices.Clone(sourceRegions)
+
+	CrossRegionInferences = append(
+		CrossRegionInferences,
+		"global."+claudeFable51BedrockModelID,
+		"global."+claudeMythos51BedrockModelID,
+	)
+}

--- a/relay/adaptor/aws/utils/models_202609_test.go
+++ b/relay/adaptor/aws/utils/models_202609_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClaudeSeptember2026GlobalInferenceProfiles verifies that both Claude 5.1
+// Bedrock model IDs resolve to registered global inference profiles. It accepts
+// a testing handle and returns no value.
+func TestClaudeSeptember2026GlobalInferenceProfiles(t *testing.T) {
+	t.Parallel()
+
+	sourceRegions := GlobalProfileSourceRegions[claudeFable5BedrockModelID]
+	require.NotEmpty(t, sourceRegions)
+
+	ctx := context.Background()
+	for _, model := range []string{claudeFable51BedrockModelID, claudeMythos51BedrockModelID} {
+		profile := "global." + model
+		require.ElementsMatch(t, sourceRegions, GlobalProfileSourceRegions[model])
+		require.Contains(t, CrossRegionInferences, profile)
+		require.Equal(t, profile, ConvertModelID2CrossRegionProfile(ctx, model, "us-east-1"))
+		require.Equal(t, profile, ConvertModelID2CrossRegionProfile(ctx, model, "eu-west-1"))
+	}
+}

--- a/relay/adaptor/vertexai/claude/models_202609.go
+++ b/relay/adaptor/vertexai/claude/models_202609.go
@@ -1,0 +1,34 @@
+package vertexai
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// claudeSeptember2026ModelRatios adds the Claude model IDs released on
+// 2026-09-01 and applies Anthropic's permanent Sonnet 5 pricing to Vertex AI.
+//
+// Sources:
+//   - https://platform.claude.com/docs/en/models/overview
+//   - https://platform.claude.com/docs/en/about-claude/pricing
+var claudeSeptember2026ModelRatios = map[string]adaptor.ModelConfig{
+	"claude-fable-5-1": {
+		Ratio: 10 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.25 * ratio.MilliTokensUsd, CacheWrite5mRatio: 12.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 20 * ratio.MilliTokensUsd,
+	},
+	"claude-mythos-5-1": {
+		Ratio: 10 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.25 * ratio.MilliTokensUsd, CacheWrite5mRatio: 12.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 20 * ratio.MilliTokensUsd,
+	},
+	"claude-sonnet-5": {
+		Ratio: 2 * ratio.MilliTokensUsd, CompletionRatio: 5.0,
+		CachedInputRatio: 0.2 * ratio.MilliTokensUsd, CacheWrite5mRatio: 2.5 * ratio.MilliTokensUsd, CacheWrite1hRatio: 4 * ratio.MilliTokensUsd,
+	},
+}
+
+func init() {
+	for model, config := range claudeSeptember2026ModelRatios {
+		ModelRatios[model] = config
+	}
+	ModelList = adaptor.GetModelListFromPricing(ModelRatios)
+}

--- a/relay/adaptor/vertexai/claude/models_202609.go
+++ b/relay/adaptor/vertexai/claude/models_202609.go
@@ -26,6 +26,8 @@ var claudeSeptember2026ModelRatios = map[string]adaptor.ModelConfig{
 	},
 }
 
+// init installs the September 2026 Claude entries and rebuilds the Vertex AI
+// model list. It takes no parameters and returns no values.
 func init() {
 	for model, config := range claudeSeptember2026ModelRatios {
 		ModelRatios[model] = config

--- a/relay/adaptor/vertexai/claude/models_202609_test.go
+++ b/relay/adaptor/vertexai/claude/models_202609_test.go
@@ -1,0 +1,49 @@
+package vertexai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+func TestClaudeSeptember2026VertexModelCatalog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		inputUsd        float64
+		cacheReadUsd    float64
+		cacheWrite5mUsd float64
+		cacheWrite1hUsd float64
+	}{
+		{name: "claude-fable-5-1", inputUsd: 10, cacheReadUsd: 0.25, cacheWrite5mUsd: 12.5, cacheWrite1hUsd: 20},
+		{name: "claude-mythos-5-1", inputUsd: 10, cacheReadUsd: 0.25, cacheWrite5mUsd: 12.5, cacheWrite1hUsd: 20},
+		{name: "claude-sonnet-5", inputUsd: 2, cacheReadUsd: 0.2, cacheWrite5mUsd: 2.5, cacheWrite1hUsd: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			config, ok := ModelRatios[tt.name]
+			require.True(t, ok)
+			require.InDelta(t, tt.inputUsd*ratio.MilliTokensUsd, config.Ratio, 1e-12)
+			require.InDelta(t, 5.0, config.CompletionRatio, 1e-12)
+			require.InDelta(t, tt.cacheReadUsd*ratio.MilliTokensUsd, config.CachedInputRatio, 1e-12)
+			require.InDelta(t, tt.cacheWrite5mUsd*ratio.MilliTokensUsd, config.CacheWrite5mRatio, 1e-12)
+			require.InDelta(t, tt.cacheWrite1hUsd*ratio.MilliTokensUsd, config.CacheWrite1hRatio, 1e-12)
+			require.Contains(t, ModelList, tt.name)
+		})
+	}
+}
+
+func TestClaudeSonnet5VertexPricingHasNoExpiryWindow(t *testing.T) {
+	t.Parallel()
+
+	config := ModelRatios["claude-sonnet-5"]
+	require.Empty(t, config.TimeWindows)
+	require.InDelta(t, 2*ratio.MilliTokensUsd, config.Ratio, 1e-12)
+	require.InDelta(t, 10*ratio.MilliTokensUsd, config.Ratio*config.CompletionRatio, 1e-12)
+}

--- a/relay/adaptor/vertexai/claude/models_202609_test.go
+++ b/relay/adaptor/vertexai/claude/models_202609_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/Laisky/one-api/relay/billing/ratio"
 )
 
+// TestClaudeSeptember2026VertexModelCatalog verifies the September 2026 Claude
+// pricing and model-list exposure on Vertex AI. It accepts a testing handle and
+// returns no value.
 func TestClaudeSeptember2026VertexModelCatalog(t *testing.T) {
 	t.Parallel()
 
@@ -39,6 +42,9 @@ func TestClaudeSeptember2026VertexModelCatalog(t *testing.T) {
 	}
 }
 
+// TestClaudeSonnet5VertexPricingHasNoExpiryWindow verifies that Vertex AI
+// Sonnet 5 uses its permanent price without a time-window override. It accepts
+// a testing handle and returns no value.
 func TestClaudeSonnet5VertexPricingHasNoExpiryWindow(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add `claude-fable-5-1` and invite-only `claude-mythos-5-1` to the native Anthropic catalog
- add matching Amazon Bedrock and Vertex AI model IDs
- record the 1M context window, 128K maximum output, `$10/$50` token pricing, and `$0.25/MTok` cache-read pricing for both 5.1 models
- make Claude Sonnet 5's `$2/$10` pricing permanent after Anthropic canceled the scheduled September 1 increase
- preserve all existing Claude model entries for compatibility
- add regression tests for model metadata, pricing, adaptive-thinking classification, provider IDs, and Vertex model-list exposure

## Sources

- https://platform.claude.com/docs/en/models/overview
- https://platform.claude.com/docs/en/about-claude/pricing
- https://platform.claude.com/docs/en/models/fable-5-1/overview
- https://platform.claude.com/docs/en/models/mythos-5-1/overview

## Validation

- `gofmt` applied to all changed Go files
- targeted regression tests added for Anthropic, Amazon Bedrock, and Vertex AI; full execution is delegated to repository CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Claude Fable 5.1, Claude Mythos 5.1, and Claude Sonnet 5.
  - Added model availability through Anthropic, AWS Bedrock, and Vertex AI.
  - Added pricing details, including cached-input and cache-write rates.
  - Added support for 1M-token context windows and up to 128K output tokens.
  - Added model capability information for text, vision, and reasoning features.

- **Tests**
  - Added coverage validating model availability, pricing, capabilities, and provider mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->