### PR TITLE
fix(anthropic): preserve thinking across model switches

### DIFF
--- a/common/ctxkey/claude_preserved_thinking.go
+++ b/common/ctxkey/claude_preserved_thinking.go
@@ -1,0 +1,5 @@
+package ctxkey
+
+// ClaudeThinkingBindingControlsEnabled marks requests that use Anthropic's
+// preserved-thinking block binding controls and therefore require the matching beta header.
+const ClaudeThinkingBindingControlsEnabled = "claude_thinking_binding_controls_enabled"

--- a/relay/adaptor/anthropic/adaptor.go
+++ b/relay/adaptor/anthropic/adaptor.go
@@ -70,6 +70,11 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, meta *me
 				betaHeaders = append(betaHeaders, AnthropicBetaAdvancedToolUse)
 			}
 		}
+		if enabled, ok := c.Get(ctxkey.ClaudeThinkingBindingControlsEnabled); ok {
+			if enabledBool, ok := enabled.(bool); ok && enabledBool {
+				betaHeaders = append(betaHeaders, AnthropicBetaThinkingBindingControls)
+			}
+		}
 	}
 
 	mergedBeta := mergeAnthropicBetaHeaders(betaHeaders)
@@ -86,6 +91,7 @@ func (a *Adaptor) ConvertRequest(c *gin.Context, relayMode int, request *model.G
 	}
 
 	c.Set(ctxkey.ClaudeModel, request.Model)
+	c.Set(ctxkey.ClaudeThinkingBindingControlsEnabled, hasClaudeThinkingBindingControls(request.Thinking))
 	// Anthropic's `tools[].name` validator enforces `^[a-zA-Z0-9_-]{1,64}$`; sanitize
 	// the OpenAI-shaped payload before conversion so the resulting Anthropic tool
 	// definitions carry compliant names. Restoration happens in the response path
@@ -117,6 +123,7 @@ func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, request *model.ClaudeRequ
 	// Set flag to use direct pass-through instead of conversion
 	c.Set(ctxkey.ClaudeDirectPassthrough, true)
 	c.Set(ctxkey.ClaudeToolSearchEnabled, hasClaudeToolSearchTools(request))
+	c.Set(ctxkey.ClaudeThinkingBindingControlsEnabled, hasClaudeThinkingBindingControls(request.Thinking))
 
 	// Still parse the request for billing purposes, but we won't use the converted result
 	// The original request body will be forwarded directly for better compatibility

--- a/relay/adaptor/anthropic/model.go
+++ b/relay/adaptor/anthropic/model.go
@@ -27,6 +27,7 @@ type Content struct {
 	// https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#implementing-extended-thinking
 	Thinking  *string `json:"thinking,omitempty"`
 	Signature *string `json:"signature,omitempty"`
+	Data      *string `json:"data,omitempty"`
 }
 
 type Message struct {
@@ -82,6 +83,10 @@ type CacheCreation struct {
 	Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens,omitempty"`
 }
 
+// InputTransformation intentionally remains an open map because Anthropic may
+// add transformation types or metadata while the beta evolves.
+type InputTransformation map[string]any
+
 type Error struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
@@ -102,15 +107,16 @@ const (
 
 // https://docs.anthropic.com/claude/reference/messages-streaming
 type Response struct {
-	Id           string    `json:"id"`
-	Type         string    `json:"type"`
-	Role         string    `json:"role"`
-	Content      []Content `json:"content"`
-	Model        string    `json:"model"`
-	StopReason   *string   `json:"stop_reason"`
-	StopSequence *string   `json:"stop_sequence"`
-	Usage        Usage     `json:"usage"`
-	Error        Error     `json:"error"`
+	Id                   string                 `json:"id"`
+	Type                 string                 `json:"type"`
+	Role                 string                 `json:"role"`
+	Content              []Content              `json:"content"`
+	Model                string                 `json:"model"`
+	StopReason           *string                `json:"stop_reason"`
+	StopSequence         *string                `json:"stop_sequence"`
+	Usage                Usage                  `json:"usage"`
+	InputTransformations *[]InputTransformation `json:"input_transformations,omitempty"`
+	Error                Error                  `json:"error"`
 }
 
 type Delta struct {
@@ -124,12 +130,13 @@ type Delta struct {
 }
 
 type StreamResponse struct {
-	Type         string    `json:"type"`
-	Message      *Response `json:"message"`
-	Index        int       `json:"index"`
-	ContentBlock *Content  `json:"content_block"`
-	Delta        *Delta    `json:"delta"`
-	Usage        *Usage    `json:"usage"`
+	Type                 string                 `json:"type"`
+	Message              *Response              `json:"message"`
+	Index                int                    `json:"index"`
+	ContentBlock         *Content               `json:"content_block"`
+	Delta                *Delta                 `json:"delta"`
+	Usage                *Usage                 `json:"usage"`
+	InputTransformations *[]InputTransformation `json:"input_transformations,omitempty"`
 	// Error events are sent over SSE as {"type":"error","error":{...},"request_id":"..."}
 	Error     Error  `json:"error"`
 	RequestId string `json:"request_id,omitempty"`

--- a/relay/adaptor/anthropic/preserved_thinking.go
+++ b/relay/adaptor/anthropic/preserved_thinking.go
@@ -1,0 +1,11 @@
+package anthropic
+
+import "github.com/Laisky/one-api/relay/model"
+
+// AnthropicBetaThinkingBindingControls enables preserved-thinking mismatch controls
+// and the input_transformations response field.
+const AnthropicBetaThinkingBindingControls = "thinking-binding-controls-2026-08-01"
+
+func hasClaudeThinkingBindingControls(thinking *model.Thinking) bool {
+	return thinking != nil && thinking.BlockBinding != nil
+}

--- a/relay/adaptor/anthropic/preserved_thinking.go
+++ b/relay/adaptor/anthropic/preserved_thinking.go
@@ -6,6 +6,9 @@ import "github.com/Laisky/one-api/relay/model"
 // and the input_transformations response field.
 const AnthropicBetaThinkingBindingControls = "thinking-binding-controls-2026-08-01"
 
+// hasClaudeThinkingBindingControls reports whether thinking explicitly contains
+// Anthropic block-binding controls. The parameter may be nil, and the return value
+// determines whether the adaptor adds the matching Anthropic beta header.
 func hasClaudeThinkingBindingControls(thinking *model.Thinking) bool {
 	return thinking != nil && thinking.BlockBinding != nil
 }

--- a/relay/adaptor/anthropic/preserved_thinking_test.go
+++ b/relay/adaptor/anthropic/preserved_thinking_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/Laisky/one-api/relay/model"
 )
 
+// TestThinkingBindingControls_ConvertedRequestRoundTrip verifies converted Anthropic
+// requests retain explicit block-binding controls and enable the required beta flag.
+// It accepts the test context and reports all validation failures through that context.
 func TestThinkingBindingControls_ConvertedRequestRoundTrip(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -47,6 +50,9 @@ func TestThinkingBindingControls_ConvertedRequestRoundTrip(t *testing.T) {
 	require.True(t, c.GetBool(ctxkey.ClaudeThinkingBindingControlsEnabled))
 }
 
+// TestThinkingBindingControls_HeaderActivation verifies the Anthropic beta header
+// is added only for explicit binding controls and is deduplicated case-insensitively.
+// It accepts the test context and reports all validation failures through that context.
 func TestThinkingBindingControls_HeaderActivation(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -120,6 +126,9 @@ func TestThinkingBindingControls_HeaderActivation(t *testing.T) {
 	}
 }
 
+// TestPreservedThinkingResponseMetadataRoundTrip verifies typed response handling
+// retains empty thinking text, redacted data, and future transformation metadata.
+// It accepts the test context and reports all validation failures through that context.
 func TestPreservedThinkingResponseMetadataRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -169,6 +178,9 @@ func TestPreservedThinkingResponseMetadataRoundTrip(t *testing.T) {
 	require.Contains(t, string(reencoded), `"input_transformations":[]`)
 }
 
+// TestNativeStream_PreservesThinkingInputTransformations verifies native streaming
+// forwards preserved-thinking transformation metadata from the message_start event.
+// It accepts the test context and reports all validation failures through that context.
 func TestNativeStream_PreservesThinkingInputTransformations(t *testing.T) {
 	t.Parallel()
 	c, recorder := newTestContext(t)

--- a/relay/adaptor/anthropic/preserved_thinking_test.go
+++ b/relay/adaptor/anthropic/preserved_thinking_test.go
@@ -1,0 +1,188 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/common/ctxkey"
+	metalib "github.com/Laisky/one-api/relay/meta"
+	"github.com/Laisky/one-api/relay/model"
+)
+
+func TestThinkingBindingControls_ConvertedRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	request := &model.GeneralOpenAIRequest{
+		Model:     "claude-fable-5-1",
+		MaxTokens: 1024,
+		Messages:  []model.Message{{Role: "user", Content: "hello"}},
+		Thinking: &model.Thinking{
+			Type: "adaptive",
+			BlockBinding: &model.ThinkingBlockBinding{
+				PrefixMismatchBehavior: "drop_block",
+			},
+		},
+	}
+
+	out, err := (&Adaptor{}).ConvertRequest(c, 0, request)
+	require.NoError(t, err)
+	converted, ok := out.(*Request)
+	require.True(t, ok, "expected *anthropic.Request, got %T", out)
+	require.NotNil(t, converted.Thinking)
+	require.NotNil(t, converted.Thinking.BlockBinding)
+	require.Equal(t, "drop_block", converted.Thinking.BlockBinding.PrefixMismatchBehavior)
+
+	raw, err := json.Marshal(converted)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"block_binding":{"prefix_mismatch_behavior":"drop_block"}`)
+	require.True(t, c.GetBool(ctxkey.ClaudeThinkingBindingControlsEnabled))
+}
+
+func TestThinkingBindingControls_HeaderActivation(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		thinking    *model.Thinking
+		inboundBeta string
+		wantHeader  bool
+	}{
+		{name: "absent", wantHeader: false},
+		{
+			name: "error",
+			thinking: &model.Thinking{
+				Type:         "adaptive",
+				BlockBinding: &model.ThinkingBlockBinding{PrefixMismatchBehavior: "error"},
+			},
+			wantHeader: true,
+		},
+		{
+			name: "drop block deduplicates inbound beta",
+			thinking: &model.Thinking{
+				Type:         "adaptive",
+				BlockBinding: &model.ThinkingBlockBinding{PrefixMismatchBehavior: "drop_block"},
+			},
+			inboundBeta: strings.ToUpper(AnthropicBetaThinkingBindingControls),
+			wantHeader:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+			if tt.inboundBeta != "" {
+				c.Request.Header.Set("anthropic-beta", tt.inboundBeta)
+			}
+
+			request := &model.ClaudeRequest{
+				Model:     "claude-fable-5-1",
+				MaxTokens: 1024,
+				Messages:  []model.ClaudeMessage{{Role: "user", Content: "hello"}},
+				Thinking:  tt.thinking,
+			}
+			a := &Adaptor{}
+			_, err := a.ConvertClaudeRequest(c, request)
+			require.NoError(t, err)
+
+			upstreamReq, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+			require.NoError(t, err)
+			require.NoError(t, a.SetupRequestHeader(c, upstreamReq, &metalib.Meta{
+				APIKey:          "test-key",
+				ActualModelName: "claude-fable-5-1",
+			}))
+
+			tokens := strings.Split(upstreamReq.Header.Get("anthropic-beta"), ",")
+			count := 0
+			for _, token := range tokens {
+				if token == AnthropicBetaThinkingBindingControls {
+					count++
+				}
+			}
+			if tt.wantHeader {
+				require.Equal(t, 1, count)
+			} else {
+				require.Zero(t, count)
+			}
+		})
+	}
+}
+
+func TestPreservedThinkingResponseMetadataRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-fable-5-1",
+		"content":[
+			{"type":"thinking","thinking":"","signature":"sig=="},
+			{"type":"redacted_thinking","data":"opaque=="}
+		],
+		"stop_reason":"end_turn",
+		"stop_sequence":null,
+		"usage":{"input_tokens":10,"output_tokens":2},
+		"input_transformations":[{
+			"type":"thinking_dropped",
+			"path":"messages.1.content.0",
+			"reason":"prefix_binding_mismatch",
+			"future_metadata":{"kept":true}
+		}]
+	}`)
+
+	var response Response
+	require.NoError(t, json.Unmarshal(raw, &response))
+	require.Len(t, response.Content, 2)
+	require.NotNil(t, response.Content[0].Thinking)
+	require.Equal(t, "", *response.Content[0].Thinking)
+	require.NotNil(t, response.Content[1].Data)
+	require.Equal(t, "opaque==", *response.Content[1].Data)
+	require.NotNil(t, response.InputTransformations)
+	require.Len(t, *response.InputTransformations, 1)
+	require.Equal(t, "thinking_dropped", (*response.InputTransformations)[0]["type"])
+	require.Contains(t, (*response.InputTransformations)[0], "future_metadata")
+
+	reencoded, err := json.Marshal(response)
+	require.NoError(t, err)
+	require.Contains(t, string(reencoded), `"thinking":""`)
+	require.Contains(t, string(reencoded), `"data":"opaque=="`)
+	require.Contains(t, string(reencoded), `"future_metadata":{"kept":true}`)
+
+	var empty Response
+	require.NoError(t, json.Unmarshal([]byte(`{"input_transformations":[]}`), &empty))
+	require.NotNil(t, empty.InputTransformations)
+	reencoded, err = json.Marshal(empty)
+	require.NoError(t, err)
+	require.Contains(t, string(reencoded), `"input_transformations":[]`)
+}
+
+func TestNativeStream_PreservesThinkingInputTransformations(t *testing.T) {
+	t.Parallel()
+	c, recorder := newTestContext(t)
+
+	sse := "event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-fable-5-1","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0},"input_transformations":[{"type":"thinking_dropped","path":"messages.1.content.0","reason":"prefix_binding_mismatch","future_metadata":{"kept":true}}]}}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":10,"output_tokens":2}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n"
+
+	errResp, usage := ClaudeNativeStreamHandler(c, makeSSEResponse(sse))
+	require.Nil(t, errResp)
+	require.NotNil(t, usage)
+	body := recorder.Body.String()
+	require.Contains(t, body, `"input_transformations":[{"type":"thinking_dropped","path":"messages.1.content.0","reason":"prefix_binding_mismatch","future_metadata":{"kept":true}}]`)
+}

--- a/relay/adaptor/deepseek/adaptor.go
+++ b/relay/adaptor/deepseek/adaptor.go
@@ -165,12 +165,17 @@ func ensureDeepSeekStreamUsage(request *model.GeneralOpenAIRequest) {
 	request.StreamOptions.IncludeUsage = true
 }
 
-// normalizeDeepSeekThinkingConfig coerces thinking.type into values accepted by DeepSeek.
-// DeepSeek chat completion currently supports only enabled/disabled.
+// normalizeDeepSeekThinkingConfig removes Anthropic-only controls and coerces
+// thinking.type into values accepted by DeepSeek. The context supplies request-scoped
+// logging, request is mutated in place, and the function returns no value.
 func normalizeDeepSeekThinkingConfig(c *gin.Context, request *model.GeneralOpenAIRequest) {
 	if request == nil || request.Thinking == nil {
 		return
 	}
+
+	// block_binding controls Anthropic signature validation and has no DeepSeek
+	// equivalent. Remove it while retaining portable thinking mode and budget data.
+	request.Thinking.BlockBinding = nil
 
 	originalType := request.Thinking.Type
 	normalizedType, changed := deepseekcompat.NormalizeThinkingType(originalType, request.Thinking.BudgetTokens)

--- a/relay/adaptor/deepseek/thinking_normalization_test.go
+++ b/relay/adaptor/deepseek/thinking_normalization_test.go
@@ -1,6 +1,7 @@
 package deepseek
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -67,4 +68,48 @@ func TestConvertRequest_PreservesSupportedThinkingType(t *testing.T) {
 	require.NotNil(t, converted.Thinking)
 	require.Equal(t, "enabled", converted.Thinking.Type)
 	require.Equal(t, 1024, *converted.Thinking.BudgetTokens)
+}
+
+// TestConvertClaudeRequest_RemovesAnthropicThinkingBinding verifies a Claude request
+// routed to DeepSeek keeps portable reasoning settings but drops Anthropic-only controls.
+// It accepts the test context and reports all validation failures through that context.
+func TestConvertClaudeRequest_RemovesAnthropicThinkingBinding(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	request := &relaymodel.ClaudeRequest{
+		Model:     "deepseek-chat",
+		MaxTokens: 4096,
+		Messages: []relaymodel.ClaudeMessage{
+			{Role: "user", Content: "hello"},
+		},
+		Thinking: &relaymodel.Thinking{
+			Type:         "adaptive",
+			BudgetTokens: relaymodel.IntPtr(2048),
+			BlockBinding: &relaymodel.ThinkingBlockBinding{
+				PrefixMismatchBehavior: "drop_block",
+			},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = &http.Request{}
+
+	convertedAny, err := (&Adaptor{}).ConvertClaudeRequest(context, request)
+	require.NoError(t, err)
+	converted, ok := convertedAny.(*relaymodel.GeneralOpenAIRequest)
+	require.True(t, ok)
+	require.NotNil(t, converted.Thinking)
+	require.Equal(t, "enabled", converted.Thinking.Type)
+	require.Equal(t, 2048, *converted.Thinking.BudgetTokens)
+	require.Nil(t, converted.Thinking.BlockBinding)
+
+	encoded, err := json.Marshal(converted)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), `"block_binding"`)
+
+	// Conversion must not mutate the caller's reusable request object.
+	require.NotNil(t, request.Thinking.BlockBinding)
+	require.Equal(t, "drop_block", request.Thinking.BlockBinding.PrefixMismatchBehavior)
 }

--- a/relay/adaptor/openai_compatible/claude_preserved_thinking_test.go
+++ b/relay/adaptor/openai_compatible/claude_preserved_thinking_test.go
@@ -1,0 +1,76 @@
+package openai_compatible
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	relaymodel "github.com/Laisky/one-api/relay/model"
+)
+
+// TestConvertClaudeRequest_DoesNotLeakAnthropicThinkingBinding verifies model
+// switching to an OpenAI-compatible upstream translates visible reasoning context
+// without forwarding Anthropic-only binding controls or signatures. It accepts the
+// test context and reports all validation failures through that context.
+func TestConvertClaudeRequest_DoesNotLeakAnthropicThinkingBinding(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	request := &relaymodel.ClaudeRequest{
+		Model:     "gpt-compatible-model",
+		MaxTokens: 4096,
+		Thinking: &relaymodel.Thinking{
+			Type: "adaptive",
+			BlockBinding: &relaymodel.ThinkingBlockBinding{
+				PrefixMismatchBehavior: "drop_block",
+			},
+		},
+		Messages: []relaymodel.ClaudeMessage{
+			{Role: "user", Content: "first question"},
+			{Role: "assistant", Content: []any{
+				map[string]any{
+					"type":      "thinking",
+					"thinking":  "portable reasoning context",
+					"signature": "anthropic-signature",
+				},
+				map[string]any{"type": "text", "text": "first answer"},
+			}},
+			{Role: "user", Content: "follow up"},
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	convertedAny, err := ConvertClaudeRequest(context, request)
+	require.NoError(t, err)
+	converted, ok := convertedAny.(*relaymodel.GeneralOpenAIRequest)
+	require.True(t, ok)
+
+	// The generic conversion does not forward an Anthropic top-level thinking object.
+	require.Nil(t, converted.Thinking)
+
+	var assistant *relaymodel.Message
+	for i := range converted.Messages {
+		if converted.Messages[i].Role == "assistant" {
+			assistant = &converted.Messages[i]
+			break
+		}
+	}
+	require.NotNil(t, assistant)
+	require.NotNil(t, assistant.Thinking)
+	require.Equal(t, "portable reasoning context", *assistant.Thinking)
+
+	encoded, err := json.Marshal(converted)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), `"block_binding"`)
+	require.NotContains(t, string(encoded), `"anthropic-signature"`)
+
+	// Conversion must not mutate the caller's reusable request object.
+	require.NotNil(t, request.Thinking.BlockBinding)
+}

--- a/relay/controller/claude_messages.go
+++ b/relay/controller/claude_messages.go
@@ -312,7 +312,7 @@ func RelayClaudeMessagesHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 					zap.Error(bodyErr),
 					zap.Int("status_code", resp.StatusCode),
 				)
-			} else if shouldRetryClaudeThinkingReplay(resp.StatusCode, responseBody, passthroughBody) {
+			} else if shouldRetryClaudeThinkingReplay(resp.StatusCode, responseBody, claudeRequest) {
 				logUpstreamResponseFromBytes(lg, resp, responseBody, "claude_messages_signature_rejected")
 
 				retryBody, retryStats, retryBodyErr := stripClaudeThinkingFromAssistantHistory(passthroughBody)

--- a/relay/controller/claude_messages.go
+++ b/relay/controller/claude_messages.go
@@ -47,13 +47,15 @@ func shouldRetryClaudeInvalidThinkingSignature(statusCode int, responseBody []by
 	if err := json.Unmarshal(responseBody, &envelope); err == nil {
 		if strings.EqualFold(strings.TrimSpace(envelope.Error.Type), "invalid_request_error") &&
 			(strings.Contains(envelope.Error.Message, "Invalid `signature` in `thinking` block") ||
-				strings.Contains(envelope.Error.Message, ".thinking.signature: Field required")) {
+				strings.Contains(envelope.Error.Message, ".thinking.signature: Field required") ||
+				isClaudePreservedThinkingBindingError(envelope.Error.Message)) {
 			return true
 		}
 	}
 
 	return bytes.Contains(responseBody, []byte("Invalid `signature` in `thinking` block")) ||
-		bytes.Contains(responseBody, []byte(".thinking.signature: Field required"))
+		bytes.Contains(responseBody, []byte(".thinking.signature: Field required")) ||
+		isClaudePreservedThinkingBindingError(string(responseBody))
 }
 
 // readAndRestoreResponseBody reads an HTTP response body and restores it for subsequent consumers.
@@ -310,7 +312,7 @@ func RelayClaudeMessagesHelper(c *gin.Context) *relaymodel.ErrorWithStatusCode {
 					zap.Error(bodyErr),
 					zap.Int("status_code", resp.StatusCode),
 				)
-			} else if shouldRetryClaudeInvalidThinkingSignature(resp.StatusCode, responseBody) {
+			} else if shouldRetryClaudeThinkingReplay(resp.StatusCode, responseBody, passthroughBody) {
 				logUpstreamResponseFromBytes(lg, resp, responseBody, "claude_messages_signature_rejected")
 
 				retryBody, retryStats, retryBodyErr := stripClaudeThinkingFromAssistantHistory(passthroughBody)

--- a/relay/controller/claude_messages_request.go
+++ b/relay/controller/claude_messages_request.go
@@ -88,15 +88,16 @@ func rewriteClaudeAdaptiveThinking(rawThinking json.RawMessage) (json.RawMessage
 		if _, ok := obj["budget_tokens"]; !ok {
 			return rawThinking, false, nil
 		}
-		delete(obj, "budget_tokens")
-		rewritten, err := encodeClaudeRawJSONObject(obj)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "marshal adaptive thinking")
-		}
-		return json.RawMessage(rewritten), true, nil
 	}
 
-	rewritten, err := json.Marshal(map[string]string{"type": "adaptive"})
+	adaptiveType, err := json.Marshal("adaptive")
+	if err != nil {
+		return nil, false, errors.Wrap(err, "marshal adaptive thinking type")
+	}
+	obj["type"] = json.RawMessage(adaptiveType)
+	delete(obj, "budget_tokens")
+
+	rewritten, err := encodeClaudeRawJSONObject(obj)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "marshal adaptive thinking")
 	}
@@ -381,8 +382,9 @@ func stripClaudeThinkingFromAssistantHistory(raw []byte) ([]byte, claudeSignatur
 	return encodedRequest, stats, nil
 }
 
-// stripClaudeUnsignedThinkingFromAssistantMessage removes assistant thinking blocks that cannot be replayed because they lack signatures.
-// stripClaudeUnsignedThinkingFromAssistantMessage returns the rewritten message, removal stats, whether the message should be kept, and any error.
+// stripClaudeUnsignedThinkingFromAssistantMessage removes visible assistant thinking blocks that cannot be replayed because they lack signatures.
+// Redacted thinking blocks carry opaque data instead of a signature and must be replayed unchanged.
+// The function returns the rewritten message, removal stats, whether the message should be kept, and any error.
 func stripClaudeUnsignedThinkingFromAssistantMessage(messageRaw json.RawMessage, messageIndex int) ([]byte, claudeUnsignedThinkingStats, bool, error) {
 	var stats claudeUnsignedThinkingStats
 	var message map[string]json.RawMessage
@@ -425,7 +427,9 @@ func stripClaudeUnsignedThinkingFromAssistantMessage(messageRaw json.RawMessage,
 		}
 
 		normalizedType := strings.ToLower(strings.TrimSpace(blockType))
-		if normalizedType != "thinking" && normalizedType != "redacted_thinking" {
+		if normalizedType != "thinking" {
+			// redacted_thinking has an opaque data field and no signature field.
+			// Preserve it, along with unknown future block types, byte-for-byte.
 			keptBlocks = append(keptBlocks, blockRaw)
 			continue
 		}

--- a/relay/controller/claude_messages_request.go
+++ b/relay/controller/claude_messages_request.go
@@ -76,6 +76,11 @@ func rewriteClaudeAdaptiveThinking(rawThinking json.RawMessage) (json.RawMessage
 		}
 		return json.RawMessage(rewritten), true, nil
 	}
+	if obj == nil {
+		// JSON null represents an absent optional thinking configuration. Preserve it
+		// rather than synthesizing adaptive thinking or assigning into a nil map.
+		return rawThinking, false, nil
+	}
 
 	var thinkingType string
 	if rawType, ok := obj["type"]; ok {

--- a/relay/controller/claude_preserved_thinking.go
+++ b/relay/controller/claude_preserved_thinking.go
@@ -1,31 +1,35 @@
 package controller
 
-import (
-	"encoding/json"
-	"strings"
-)
+import "strings"
 
+// isClaudePreservedThinkingBindingError reports whether message is Anthropic's
+// preserved-thinking prefix-binding failure. The message parameter is an upstream
+// error string, and the return value is true only for the recognized failure shape.
 func isClaudePreservedThinkingBindingError(message string) bool {
 	normalized := strings.ToLower(message)
 	return strings.Contains(normalized, "thinking") &&
 		strings.Contains(normalized, "bound to a different conversation")
 }
 
-func claudeThinkingBindingRequiresError(requestBody []byte) bool {
-	var request struct {
-		Thinking struct {
-			BlockBinding struct {
-				PrefixMismatchBehavior string `json:"prefix_mismatch_behavior"`
-			} `json:"block_binding"`
-		} `json:"thinking"`
-	}
-	if err := json.Unmarshal(requestBody, &request); err != nil {
+// claudeThinkingBindingRequiresError reports whether request explicitly selects
+// prefix_mismatch_behavior=error. The request parameter is the validated Claude
+// request, and the return value is false for nil or absent binding controls.
+func claudeThinkingBindingRequiresError(request *ClaudeMessagesRequest) bool {
+	if request == nil || request.Thinking == nil || request.Thinking.BlockBinding == nil {
 		return false
 	}
-	return strings.EqualFold(strings.TrimSpace(request.Thinking.BlockBinding.PrefixMismatchBehavior), "error")
+
+	return strings.EqualFold(
+		strings.TrimSpace(request.Thinking.BlockBinding.PrefixMismatchBehavior),
+		"error",
+	)
 }
 
-func shouldRetryClaudeThinkingReplay(statusCode int, responseBody, requestBody []byte) bool {
+// shouldRetryClaudeThinkingReplay reports whether one-api may retry a rejected
+// thinking replay after removing prior thinking blocks. The status and response
+// describe the upstream failure, request carries the validated caller policy, and
+// the return value is false when the caller explicitly requested strict errors.
+func shouldRetryClaudeThinkingReplay(statusCode int, responseBody []byte, request *ClaudeMessagesRequest) bool {
 	return shouldRetryClaudeInvalidThinkingSignature(statusCode, responseBody) &&
-		!claudeThinkingBindingRequiresError(requestBody)
+		!claudeThinkingBindingRequiresError(request)
 }

--- a/relay/controller/claude_preserved_thinking.go
+++ b/relay/controller/claude_preserved_thinking.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func isClaudePreservedThinkingBindingError(message string) bool {
+	normalized := strings.ToLower(message)
+	return strings.Contains(normalized, "thinking") &&
+		strings.Contains(normalized, "bound to a different conversation")
+}
+
+func claudeThinkingBindingRequiresError(requestBody []byte) bool {
+	var request struct {
+		Thinking struct {
+			BlockBinding struct {
+				PrefixMismatchBehavior string `json:"prefix_mismatch_behavior"`
+			} `json:"block_binding"`
+		} `json:"thinking"`
+	}
+	if err := json.Unmarshal(requestBody, &request); err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(request.Thinking.BlockBinding.PrefixMismatchBehavior), "error")
+}
+
+func shouldRetryClaudeThinkingReplay(statusCode int, responseBody, requestBody []byte) bool {
+	return shouldRetryClaudeInvalidThinkingSignature(statusCode, responseBody) &&
+		!claudeThinkingBindingRequiresError(requestBody)
+}

--- a/relay/controller/claude_preserved_thinking_test.go
+++ b/relay/controller/claude_preserved_thinking_test.go
@@ -6,8 +6,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	relaymodel "github.com/Laisky/one-api/relay/model"
 )
 
+// TestRewriteAndSanitizeClaudeRequestBody_PreservesBoundThinkingBlocks verifies
+// signed, redacted, and future thinking blocks survive request rewriting. It accepts
+// the test context and reports all validation failures through that context.
 func TestRewriteAndSanitizeClaudeRequestBody_PreservesBoundThinkingBlocks(t *testing.T) {
 	t.Parallel()
 
@@ -70,6 +75,9 @@ func TestRewriteAndSanitizeClaudeRequestBody_PreservesBoundThinkingBlocks(t *tes
 	}
 }
 
+// TestRewriteAndSanitizeClaudeRequestBody_StripsOnlyUnsignedVisibleThinking verifies
+// only unsigned visible thinking is removed while opaque redacted blocks remain. It
+// accepts the test context and reports all validation failures through that context.
 func TestRewriteAndSanitizeClaudeRequestBody_StripsOnlyUnsignedVisibleThinking(t *testing.T) {
 	t.Parallel()
 
@@ -113,6 +121,9 @@ func TestRewriteAndSanitizeClaudeRequestBody_StripsOnlyUnsignedVisibleThinking(t
 	require.Equal(t, "sig==", *root.Messages[0].Content[1].Signature)
 }
 
+// TestRewriteClaudeRequestBody_AdaptiveThinkingPreservesBindingAndFutureFields verifies
+// adaptive normalization changes only supported fields and preserves future siblings. It
+// accepts the test context and reports all validation failures through that context.
 func TestRewriteClaudeRequestBody_AdaptiveThinkingPreservesBindingAndFutureFields(t *testing.T) {
 	t.Parallel()
 
@@ -148,6 +159,30 @@ func TestRewriteClaudeRequestBody_AdaptiveThinkingPreservesBindingAndFutureField
 	require.Equal(t, "true", string(binding["future_option"]))
 }
 
+// TestRewriteClaudeRequestBody_AdaptiveThinkingNullDoesNotPanic verifies an explicit
+// JSON null is treated as an absent optional thinking configuration and forwarded. It
+// accepts the test context and reports all validation failures through that context.
+func TestRewriteClaudeRequestBody_AdaptiveThinkingNullDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"claude-fable-5-1",
+		"max_tokens":1024,
+		"thinking":null,
+		"messages":[{"role":"user","content":"hello"}]
+	}`)
+
+	result, err := rewriteClaudeRequestBody(raw, &ClaudeMessagesRequest{Model: "claude-fable-5-1"})
+	require.NoError(t, err)
+
+	var root map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result, &root))
+	require.Equal(t, "null", string(root["thinking"]))
+}
+
+// TestStripClaudeThinkingFromAssistantHistory_PreservedThinkingFallback verifies the
+// compatibility retry removes all provider-bound thinking while preserving useful output.
+// It accepts the test context and reports all validation failures through that context.
 func TestStripClaudeThinkingFromAssistantHistory_PreservedThinkingFallback(t *testing.T) {
 	t.Parallel()
 
@@ -170,6 +205,9 @@ func TestStripClaudeThinkingFromAssistantHistory_PreservedThinkingFallback(t *te
 	require.Contains(t, string(result), `"type":"tool_use"`)
 }
 
+// TestShouldRetryClaudeThinkingReplay verifies legacy replay recovery remains enabled
+// unless the validated caller explicitly selects strict prefix errors. It accepts the
+// test context and reports all validation failures through that context.
 func TestShouldRetryClaudeThinkingReplay(t *testing.T) {
 	t.Parallel()
 
@@ -180,13 +218,30 @@ func TestShouldRetryClaudeThinkingReplay(t *testing.T) {
 			"message":"messages.1.content.0: Invalid ` + "`signature`" + ` in ` + "`thinking`" + ` block. The block is bound to a different conversation."
 		}
 	}`)
-	legacyRequest := []byte(`{"thinking":{"type":"adaptive"},"messages":[]}`)
-	explicitErrorRequest := []byte(`{"thinking":{"type":"adaptive","block_binding":{"prefix_mismatch_behavior":"error"}},"messages":[]}`)
-	dropRequest := []byte(`{"thinking":{"type":"adaptive","block_binding":{"prefix_mismatch_behavior":"drop_block"}},"messages":[]}`)
+	legacyRequest := &ClaudeMessagesRequest{
+		Thinking: &relaymodel.Thinking{Type: "adaptive"},
+	}
+	explicitErrorRequest := &ClaudeMessagesRequest{
+		Thinking: &relaymodel.Thinking{
+			Type: "adaptive",
+			BlockBinding: &relaymodel.ThinkingBlockBinding{
+				PrefixMismatchBehavior: "error",
+			},
+		},
+	}
+	dropRequest := &ClaudeMessagesRequest{
+		Thinking: &relaymodel.Thinking{
+			Type: "adaptive",
+			BlockBinding: &relaymodel.ThinkingBlockBinding{
+				PrefixMismatchBehavior: "drop_block",
+			},
+		},
+	}
 
 	require.True(t, shouldRetryClaudeInvalidThinkingSignature(http.StatusBadRequest, newBindingError))
 	require.True(t, shouldRetryClaudeThinkingReplay(http.StatusBadRequest, newBindingError, legacyRequest))
 	require.False(t, shouldRetryClaudeThinkingReplay(http.StatusBadRequest, newBindingError, explicitErrorRequest))
 	require.True(t, shouldRetryClaudeThinkingReplay(http.StatusBadRequest, newBindingError, dropRequest))
+	require.True(t, shouldRetryClaudeThinkingReplay(http.StatusBadRequest, newBindingError, nil))
 	require.False(t, shouldRetryClaudeThinkingReplay(http.StatusInternalServerError, newBindingError, legacyRequest))
 }

--- a/relay/controller/claude_preserved_thinking_test.go
+++ b/relay/controller/claude_preserved_thinking_test.go
@@ -1,0 +1,192 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteAndSanitizeClaudeRequestBody_PreservesBoundThinkingBlocks(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"claude-fable-5-1",
+		"max_tokens":4096,
+		"thinking":{"type":"adaptive","block_binding":{"prefix_mismatch_behavior":"drop_block"}},
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hello"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"","signature":"sig==","future_field":{"kept":true}},
+				{"type":"redacted_thinking","data":"opaque==","future_field":{"kept":true}},
+				{"type":"future_thinking","payload":{"kept":true}},
+				{"type":"text","text":"done"}
+			]},
+			{"role":"user","content":[{"type":"text","text":"continue"}]}
+		]
+	}`)
+
+	result, stats, err := rewriteAndSanitizeClaudeRequestBody(raw, &ClaudeMessagesRequest{Model: "claude-fable-5-1"})
+	require.NoError(t, err)
+	require.Zero(t, stats.RemovedThinkingBlocks)
+	require.Zero(t, stats.RemovedAssistantMessages)
+
+	var root struct {
+		Thinking struct {
+			BlockBinding struct {
+				PrefixMismatchBehavior string `json:"prefix_mismatch_behavior"`
+			} `json:"block_binding"`
+		} `json:"thinking"`
+		Messages []struct {
+			Role    string            `json:"role"`
+			Content []json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(result, &root))
+	require.Equal(t, "drop_block", root.Thinking.BlockBinding.PrefixMismatchBehavior)
+	require.Len(t, root.Messages, 3)
+	require.Len(t, root.Messages[1].Content, 4)
+
+	wantTypes := []string{"thinking", "redacted_thinking", "future_thinking", "text"}
+	for i, rawBlock := range root.Messages[1].Content {
+		var block map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(rawBlock, &block))
+		var blockType string
+		require.NoError(t, json.Unmarshal(block["type"], &blockType))
+		require.Equal(t, wantTypes[i], blockType)
+		if i == 2 {
+			require.Contains(t, block, "payload")
+		} else if i < 2 {
+			require.Contains(t, block, "future_field")
+		}
+		if blockType == "thinking" {
+			require.Equal(t, `""`, string(block["thinking"]))
+			require.Equal(t, `"sig=="`, string(block["signature"]))
+		}
+		if blockType == "redacted_thinking" {
+			require.Equal(t, `"opaque=="`, string(block["data"]))
+		}
+	}
+}
+
+func TestRewriteAndSanitizeClaudeRequestBody_StripsOnlyUnsignedVisibleThinking(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"claude-fable-5-1",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"unsigned"},
+				{"type":"redacted_thinking","data":"opaque=="},
+				{"type":"thinking","thinking":"","signature":"sig=="},
+				{"type":"text","text":"answer"}
+			]}
+		]
+	}`)
+
+	result, stats, err := rewriteAndSanitizeClaudeRequestBody(raw, &ClaudeMessagesRequest{Model: "claude-fable-5-1"})
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.RemovedThinkingBlocks)
+	require.Equal(t, []string{"messages[0].content[0]"}, stats.Locations)
+
+	var root struct {
+		Messages []struct {
+			Content []struct {
+				Type      string  `json:"type"`
+				Signature *string `json:"signature,omitempty"`
+				Data      *string `json:"data,omitempty"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal(result, &root))
+	require.Len(t, root.Messages, 1)
+	require.Equal(t, []string{"redacted_thinking", "thinking", "text"}, []string{
+		root.Messages[0].Content[0].Type,
+		root.Messages[0].Content[1].Type,
+		root.Messages[0].Content[2].Type,
+	})
+	require.NotNil(t, root.Messages[0].Content[0].Data)
+	require.Equal(t, "opaque==", *root.Messages[0].Content[0].Data)
+	require.NotNil(t, root.Messages[0].Content[1].Signature)
+	require.Equal(t, "sig==", *root.Messages[0].Content[1].Signature)
+}
+
+func TestRewriteClaudeRequestBody_AdaptiveThinkingPreservesBindingAndFutureFields(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"claude-fable-5-1",
+		"max_tokens":1024,
+		"thinking":{
+			"type":"enabled",
+			"budget_tokens":2048,
+			"block_binding":{"prefix_mismatch_behavior":"error","future_option":true},
+			"display":"summarized",
+			"future_field":{"kept":true}
+		},
+		"messages":[{"role":"user","content":"hello"}]
+	}`)
+
+	result, err := rewriteClaudeRequestBody(raw, &ClaudeMessagesRequest{Model: "claude-fable-5-1"})
+	require.NoError(t, err)
+
+	var root map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result, &root))
+	var thinking map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(root["thinking"], &thinking))
+	require.Equal(t, `"adaptive"`, string(thinking["type"]))
+	require.NotContains(t, thinking, "budget_tokens")
+	require.Contains(t, thinking, "block_binding")
+	require.Contains(t, thinking, "display")
+	require.Contains(t, thinking, "future_field")
+
+	var binding map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(thinking["block_binding"], &binding))
+	require.Equal(t, `"error"`, string(binding["prefix_mismatch_behavior"]))
+	require.Equal(t, "true", string(binding["future_option"]))
+}
+
+func TestStripClaudeThinkingFromAssistantHistory_PreservedThinkingFallback(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"messages":[{"role":"assistant","content":[
+			{"type":"thinking","thinking":"","signature":"sig=="},
+			{"type":"redacted_thinking","data":"opaque=="},
+			{"type":"text","text":"answer"},
+			{"type":"tool_use","id":"toolu_1","name":"read","input":{}}
+		]}]
+	}`)
+
+	result, stats, err := stripClaudeThinkingFromAssistantHistory(raw)
+	require.NoError(t, err)
+	require.Equal(t, 2, stats.RemovedThinkingBlocks)
+	require.Zero(t, stats.RemovedAssistantMessages)
+	require.NotContains(t, string(result), `"type":"thinking"`)
+	require.NotContains(t, string(result), `"type":"redacted_thinking"`)
+	require.Contains(t, string(result), `"type":"text"`)
+	require.Contains(t, string(result), `"type":"tool_use"`)
+}
+
+func TestShouldRetryClaudeThinkingReplay(t *testing.T) {
+	t.Parallel()
+
+	newBindingError := []byte(`{
+		"type":"error",
+		"error":{
+			"type":"invalid_request_error",
+			"message":"messages.1.content.0: Invalid ` + "`signature`" + ` in ` + "`thinking`" + ` block. The block is bound to a different conversation."
+		}
+	}`)
+	legacyRequest := []byte(`{"thinking":{"type":"adaptive"},"messages":[]}`)
+	explicitErrorRequest := []byte(`{"thinking":{"type":"adaptive","block_binding":{"prefix_mismatch_behavior":"error"}},"messages":[]}`)
+	dropRequest := []byte(`{"thinking":{"type":"adaptive","block_binding":{"prefix_mismatch_behavior":"drop_block"}},"messages":[]}`)
+
+	require.True(t, shouldRetryClaudeInvalidThinkingSignature(http.StatusBadRequest, newBindingError))
+	require.True(t, shouldRetryClaudeThinkingReplay(http.StatusBadRequest, newBindingError, legacyRequest))
+	require.False(t, shouldRetryClaudeThinkingReplay(http.StatusBadRequest, newBindingError, explicitErrorRequest))
+	require.True(t, shouldRetryClaudeThinkingReplay(http.StatusBadRequest, newBindingError, dropRequest))
+	require.False(t, shouldRetryClaudeThinkingReplay(http.StatusInternalServerError, newBindingError, legacyRequest))
+}

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -185,9 +185,16 @@ type UserLocationApproximate struct {
 }
 
 // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#implementing-extended-thinking
+// ThinkingBlockBinding controls how Anthropic handles replayed thinking blocks
+// whose conversation prefix no longer matches the prefix they were generated from.
+type ThinkingBlockBinding struct {
+	PrefixMismatchBehavior string `json:"prefix_mismatch_behavior,omitempty" binding:"omitempty,oneof=error drop_block"`
+}
+
 type Thinking struct {
-	Type         string `json:"type"`
-	BudgetTokens *int   `json:"budget_tokens,omitempty" binding:"omitempty,min=1024"`
+	Type         string                `json:"type"`
+	BudgetTokens *int                  `json:"budget_tokens,omitempty" binding:"omitempty,min=1024"`
+	BlockBinding *ThinkingBlockBinding `json:"block_binding,omitempty"`
 }
 
 // IntPtr is a helper to create a pointer to an int value.


### PR DESCRIPTION
## Summary

- preserve signed `thinking`, `redacted_thinking`, and unknown future content blocks without silently rewriting bound Anthropic assistant history
- support `thinking.block_binding.prefix_mismatch_behavior` and negotiate `anthropic-beta: thinking-binding-controls-2026-08-01` only for Anthropic requests that use the control
- retain `input_transformations` metadata, including explicit empty arrays and streaming `message_start` payloads
- recognize preserved-thinking prefix-binding failures and retain the legacy one-time recovery path, while honoring an explicit `prefix_mismatch_behavior: "error"`
- preserve `block_binding` and unknown sibling fields when normalizing legacy manual thinking to adaptive thinking
- handle explicit `thinking: null` without panic or accidental thinking enablement

## Aggregator model-switch behavior

one-api must permit callers to reuse one conversation while changing the selected model or provider.

- **Anthropic to Anthropic:** preserve the complete assistant content array and exact block order. Anthropic remains the authority for model-binding compatibility and may discard blocks that the selected model cannot read.
- **Anthropic to DeepSeek:** translate visible thinking into DeepSeek-compatible reasoning, retain the portable thinking mode and budget, and remove Anthropic-only `block_binding` before serialization.
- **Anthropic to other OpenAI-compatible providers:** translate visible thinking into portable assistant reasoning, but do not forward Anthropic signatures, redacted payloads, or top-level binding controls.
- **Explicit strict policy:** a caller-selected `prefix_mismatch_behavior: "error"` remains authoritative and is never silently converted into a strip-and-retry flow.

This keeps normal model switching seamless without inventing a gateway-side model compatibility matrix or leaking provider-specific controls to another upstream.

## Review follow-up

The second commit addresses every actionable review thread:

- preserves `thinking: null` and adds a panic regression test
- removes the raw-body JSON reparse from retry-policy selection and reads the already validated typed request instead
- strips Anthropic-only binding controls from DeepSeek conversion while keeping portable reasoning semantics
- proves generic OpenAI-compatible conversion carries visible reasoning but no Anthropic signature or `block_binding`
- adds name-prefixed documentation for the new functions and behavior tests

## Behavioral coverage

- [x] converted and native Anthropic request behavior for `block_binding`
- [x] beta-header activation and case-insensitive deduplication
- [x] preservation of empty signed thinking, redacted data, and unknown content blocks
- [x] removal of only unsigned visible thinking blocks
- [x] adaptive normalization preserving binding and future fields
- [x] explicit `thinking: null`
- [x] non-streaming and streaming `input_transformations`
- [x] legacy one-time fallback and explicit fail-fast behavior
- [x] DeepSeek model-switch normalization without Anthropic-field leakage
- [x] generic OpenAI-compatible model-switch conversion without signature leakage
- [ ] full repository PR CI

## Validation

The follow-up commit was assembled against the exact current PR head and compared before the branch was advanced. The comparison contains only the intended production and regression-test changes. GitHub Actions `lint`, `pr-check`, CodeRabbit, and requested Codex review are the final acceptance gates for the updated head.

## Source

- https://support.claude.com/en/articles/16761192-preserved-thinking-changing-how-the-messages-api-handles-thinking-blocks-to-protect-against-distillation
