### PR TITLE
chore(gemini): refresh September 2026 model catalog

### DIFF
--- a/relay/adaptor/gemini/constants.go
+++ b/relay/adaptor/gemini/constants.go
@@ -7,18 +7,18 @@ import (
 	"github.com/Laisky/one-api/relay/adaptor/geminiOpenaiCompatible"
 )
 
-// ModelRatios uses the shared Gemini pricing from geminiOpenaiCompatible
+// ModelRatios uses the shared Gemini pricing from geminiOpenaiCompatible.
 var ModelRatios = geminiOpenaiCompatible.ModelRatios
 
-// ModelList derived from ModelRatios for backward compatibility
+// ModelList is derived from ModelRatios for backward compatibility.
 var ModelList = adaptor.GetModelListFromPricing(ModelRatios)
 
-// GeminiToolingDefaults reuses the Gemini OpenAI-compatible tooling defaults sourced from Google pricing (retrieved 2025-11-12).
+// GeminiToolingDefaults reuses the Gemini OpenAI-compatible tooling defaults sourced from Google pricing, verified 2026-09-02.
 var GeminiToolingDefaults = geminiOpenaiCompatible.GeminiToolingDefaults()
 
-// ModelsSupportSystemInstruction is the list of models that support system instruction.
+// ModelsSupportSystemInstruction lists models that accept system instructions.
 //
-// https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions
+// Source: https://ai.google.dev/gemini-api/docs/models
 var ModelsSupportSystemInstruction = []string{
 	"gemini-2.5-flash", "gemini-2.5-flash-preview",
 	"gemini-2.5-flash-lite", "gemini-2.5-flash-lite-preview",
@@ -28,13 +28,13 @@ var ModelsSupportSystemInstruction = []string{
 	"gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-3-pro-image-preview",
 	"gemini-3.1-pro-preview", "gemini-3.1-pro-preview-customtools",
 	"gemini-3.1-flash-image-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview",
-	"gemini-3.5-flash",
+	"gemini-3.5-flash", "gemini-3.5-flash-lite",
+	"gemini-3.6-flash", "gemini-3.7-flash", "gemini-3.8-flash",
 	"gemini-robotics-er-1.6-preview",
 }
 
-// IsModelSupportSystemInstruction check if the model support system instruction.
-//
-// Because the main version of Go is 1.20, slice.Contains cannot be used
+// IsModelSupportSystemInstruction reports whether model accepts system instructions.
+// Parameters: model is the upstream Gemini model ID. Returns: true when system instructions are supported.
 func IsModelSupportSystemInstruction(model string) bool {
 	return slices.Contains(ModelsSupportSystemInstruction, model)
 }

--- a/relay/adaptor/gemini/models_202609_test.go
+++ b/relay/adaptor/gemini/models_202609_test.go
@@ -1,0 +1,36 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeminiSeptember2026NativeCatalog verifies that the native Gemini adaptor
+// exposes the new catalog entries and recognizes system-instruction-capable chat models.
+// Parameters: t is the current test handle. Returns: none.
+func TestGeminiSeptember2026NativeCatalog(t *testing.T) {
+	t.Parallel()
+
+	for _, model := range []string{
+		"gemini-3.8-flash",
+		"gemini-3.7-flash",
+		"gemini-3.6-flash",
+		"gemini-3.5-transcribe",
+		"gemini-3.5-transcribe-live",
+		"gemini-omni-1.1-flash",
+		"gemini-robotics-er-2-preview",
+		"gemini-robotics-er-2-streaming-preview",
+	} {
+		require.Contains(t, ModelList, model)
+	}
+
+	for _, model := range []string{
+		"gemini-3.8-flash",
+		"gemini-3.7-flash",
+		"gemini-3.6-flash",
+		"gemini-3.5-flash-lite",
+	} {
+		require.True(t, IsModelSupportSystemInstruction(model), model)
+	}
+}

--- a/relay/adaptor/geminiOpenaiCompatible/constants_test.go
+++ b/relay/adaptor/geminiOpenaiCompatible/constants_test.go
@@ -264,16 +264,17 @@ func TestGemini35FlashGAPricing(t *testing.T) {
 	require.Contains(t, geminiWebSearchModels, "gemini-3.5-flash")
 }
 
-// TestGemini36FlashPricing verifies Gemini 3.6 Flash pricing from Google Cloud Agent Platform.
-// Parameter t drives test execution, and the function returns no values.
+// TestGemini36FlashPricing verifies the current Gemini 3.6 Flash promotional pricing
+// while retaining the published limits and capabilities. Parameter t drives test execution,
+// and the function returns no values.
 func TestGemini36FlashPricing(t *testing.T) {
 	t.Parallel()
 
 	cfg, ok := ModelRatios["gemini-3.6-flash"]
 	require.True(t, ok, "gemini-3.6-flash missing from pricing map")
-	require.InDelta(t, 1.50*ratio.MilliTokensUsd, cfg.Ratio, 1e-12)
-	require.InDelta(t, 7.50/1.50, cfg.CompletionRatio, 1e-9)
-	require.InDelta(t, 0.15*ratio.MilliTokensUsd, cfg.CachedInputRatio, 1e-12)
+	require.InDelta(t, geminiFlashPromotionalInputUsd*ratio.MilliTokensUsd, cfg.Ratio, 1e-12)
+	require.InDelta(t, geminiFlashPromotionalOutputUsd/geminiFlashPromotionalInputUsd, cfg.CompletionRatio, 1e-9)
+	require.InDelta(t, geminiFlashPromotionalCacheUsd*ratio.MilliTokensUsd, cfg.CachedInputRatio, 1e-12)
 	require.EqualValues(t, 1_048_576, cfg.ContextLength)
 	require.EqualValues(t, 65536, cfg.MaxOutputTokens)
 	require.Equal(t, "medium", cfg.DefaultReasoningEffort)

--- a/relay/adaptor/geminiOpenaiCompatible/models_202609.go
+++ b/relay/adaptor/geminiOpenaiCompatible/models_202609.go
@@ -94,7 +94,7 @@ func geminiSeptember2026RoboticsConfig(streaming bool) adaptor.ModelConfig {
 	config := adaptor.ModelConfig{
 		Ratio:            2.00 * ratio.MilliTokensUsd,
 		CompletionRatio:  10.00 / 2.00,
-		ContextLength:    gemini1MContext,
+		ContextLength:    131_072,
 		MaxOutputTokens:  gemini3FlashMaxOutput,
 		InputModalities:  geminiInputMultimodal,
 		OutputModalities: geminiOutputText,
@@ -108,7 +108,7 @@ func geminiSeptember2026RoboticsConfig(streaming bool) adaptor.ModelConfig {
 		Description:                 "Gemini Robotics ER 2 preview for embodied reasoning, video progress understanding, spatial reasoning, and multi-robot orchestration.",
 	}
 	if streaming {
-		config.SupportedFeatures = []string{"tools", "reasoning"}
+		config.SupportedFeatures = []string{"tools", "web_search", "reasoning"}
 		config.Description = "Gemini Robotics ER 2 Streaming preview for low-latency bidirectional audio and video robotics agents over the Live API."
 		return config
 	}

--- a/relay/adaptor/geminiOpenaiCompatible/models_202609.go
+++ b/relay/adaptor/geminiOpenaiCompatible/models_202609.go
@@ -1,0 +1,194 @@
+package geminiOpenaiCompatible
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+const (
+	geminiFlashPromotionalInputUsd  = 0.75
+	geminiFlashPromotionalOutputUsd = 3.75
+	geminiFlashPromotionalCacheUsd  = 0.075
+	geminiFlashStandardInputUsd     = 1.50
+	geminiFlashStandardOutputUsd    = 7.50
+	geminiFlashStandardCacheUsd     = 0.15
+	geminiOmniVideoTokensPerSecond  = 5_792
+	geminiOmniVideoOutputUsd        = 17.50
+)
+
+var gemini37PlusReasoningEfforts = []string{"low", "medium", "high"}
+
+// geminiSeptember2026FlashConfig builds Gemini 3.6+ Flash metadata and the documented
+// promotional price transition. Parameters: description is the model summary and
+// reasoningEfforts lists accepted thinking levels. Returns: a complete model configuration.
+func geminiSeptember2026FlashConfig(description string, reasoningEfforts []string) adaptor.ModelConfig {
+	return adaptor.ModelConfig{
+		Ratio:            geminiFlashPromotionalInputUsd * ratio.MilliTokensUsd,
+		CompletionRatio:  geminiFlashPromotionalOutputUsd / geminiFlashPromotionalInputUsd,
+		CachedInputRatio: geminiFlashPromotionalCacheUsd * ratio.MilliTokensUsd,
+		TimeWindows: []adaptor.TimeWindow{
+			{
+				Name:     "standard-pricing-from-2027",
+				TimeZone: "UTC",
+				DateFrom: "2027-01-01",
+				Ranges: []adaptor.ClockRange{
+					{Start: "00:00", End: "00:00"},
+				},
+				Overlay: adaptor.ModelConfig{
+					Ratio:            geminiFlashStandardInputUsd * ratio.MilliTokensUsd,
+					CompletionRatio:  geminiFlashStandardOutputUsd / geminiFlashStandardInputUsd,
+					CachedInputRatio: geminiFlashStandardCacheUsd * ratio.MilliTokensUsd,
+				},
+			},
+		},
+		ContextLength:               gemini1MContext,
+		MaxOutputTokens:             gemini3FlashMaxOutput,
+		InputModalities:             geminiInputMultimodal,
+		OutputModalities:            geminiOutputText,
+		SupportedFeatures:           geminiFeatures25Plus,
+		SupportedSamplingParameters: geminiSamplingChat,
+		SupportedReasoningEfforts:   append([]string(nil), reasoningEfforts...),
+		DefaultReasoningEffort:      "medium",
+		MaxReasoningTokens:          gemini3LevelMaxThinkingBudget,
+		Description:                 description,
+	}
+}
+
+// geminiSeptember2026TranscribeConfig builds the pricing and modality metadata for
+// a Gemini 3.5 transcription endpoint. Parameters: inputUsd and outputUsd are paid-tier
+// prices per million tokens, and description summarizes the endpoint. Returns: a model configuration.
+func geminiSeptember2026TranscribeConfig(inputUsd float64, outputUsd float64, description string) adaptor.ModelConfig {
+	return adaptor.ModelConfig{
+		Ratio:           inputUsd * ratio.MilliTokensUsd,
+		CompletionRatio: outputUsd / inputUsd,
+		Audio: &adaptor.AudioPricingConfig{
+			PromptRatio:           1,
+			PromptTokensPerSecond: 25,
+		},
+		InputModalities:  []string{"audio"},
+		OutputModalities: geminiOutputText,
+		Description:      description,
+	}
+}
+
+// geminiSeptember2026OmniConfig builds the shared Gemini Omni Flash pricing and
+// video metadata. Parameters: description summarizes lifecycle status. Returns: a model configuration.
+func geminiSeptember2026OmniConfig(description string) adaptor.ModelConfig {
+	return adaptor.ModelConfig{
+		Ratio:           1.50 * ratio.MilliTokensUsd,
+		CompletionRatio: 9.00 / 1.50,
+		Video: &adaptor.VideoPricingConfig{
+			PerSecondUsd:   geminiOmniVideoOutputUsd * geminiOmniVideoTokensPerSecond / 1_000_000,
+			BaseResolution: "1280x720",
+		},
+		ContextLength:    gemini1MContext,
+		InputModalities:  []string{"text", "image", "video"},
+		OutputModalities: []string{"video"},
+		Description:      description,
+	}
+}
+
+// geminiSeptember2026RoboticsConfig builds Gemini Robotics ER 2 metadata.
+// Parameters: streaming selects the Live API endpoint. Returns: a model configuration.
+func geminiSeptember2026RoboticsConfig(streaming bool) adaptor.ModelConfig {
+	config := adaptor.ModelConfig{
+		Ratio:            2.00 * ratio.MilliTokensUsd,
+		CompletionRatio:  10.00 / 2.00,
+		ContextLength:    gemini1MContext,
+		MaxOutputTokens:  gemini3FlashMaxOutput,
+		InputModalities:  geminiInputMultimodal,
+		OutputModalities: geminiOutputText,
+		SupportedFeatures: []string{
+			"tools", "json_mode", "structured_outputs", "web_search", "reasoning",
+		},
+		SupportedSamplingParameters: geminiSamplingChat,
+		SupportedReasoningEfforts:   gemini37PlusReasoningEfforts,
+		DefaultReasoningEffort:      "medium",
+		MaxReasoningTokens:          gemini3LevelMaxThinkingBudget,
+		Description:                 "Gemini Robotics ER 2 preview for embodied reasoning, video progress understanding, spatial reasoning, and multi-robot orchestration.",
+	}
+	if streaming {
+		config.SupportedFeatures = []string{"tools", "reasoning"}
+		config.Description = "Gemini Robotics ER 2 Streaming preview for low-latency bidirectional audio and video robotics agents over the Live API."
+		return config
+	}
+	config.CachedInputRatio = 0.20 * ratio.MilliTokensUsd
+	return config
+}
+
+var geminiSeptember2026ModelRatios = map[string]adaptor.ModelConfig{
+	"gemini-3.8-flash": geminiSeptember2026FlashConfig(
+		"Gemini 3.8 Flash stable model for long-horizon software engineering, autonomous agents, and complex enterprise workflows.",
+		gemini37PlusReasoningEfforts,
+	),
+	"gemini-3.7-flash": geminiSeptember2026FlashConfig(
+		"Gemini 3.7 Flash stable model for coding, agentic tool use, and reliable multi-step execution.",
+		gemini37PlusReasoningEfforts,
+	),
+	"gemini-3.6-flash": geminiSeptember2026FlashConfig(
+		"Gemini 3.6 Flash stable multimodal reasoning model optimized for rapid agentic and coding loops.",
+		gemini3FlashReasoningEfforts,
+	),
+	"gemini-3.5-transcribe": geminiSeptember2026TranscribeConfig(
+		2.00,
+		12.00,
+		"Gemini 3.5 Transcribe stable audio-to-text model with language detection, diarization, word timestamps, smart transcription, and vocabulary biasing.",
+	),
+	"gemini-3.5-transcribe-live": geminiSeptember2026TranscribeConfig(
+		3.50,
+		21.00,
+		"Gemini 3.5 Transcribe Live stable low-latency streaming audio-to-text model over the Live API.",
+	),
+	"gemini-omni-1.1-flash": geminiSeptember2026OmniConfig(
+		"Gemini Omni 1.1 Flash stable video generation and editing model with native video output.",
+	),
+	"gemini-omni-flash-preview": geminiSeptember2026OmniConfig(
+		"Gemini Omni Flash preview video model; scheduled shutdown September 30, 2026. Use gemini-omni-1.1-flash.",
+	),
+	"gemini-robotics-er-2-preview":           geminiSeptember2026RoboticsConfig(false),
+	"gemini-robotics-er-2-streaming-preview": geminiSeptember2026RoboticsConfig(true),
+}
+
+var geminiSeptember2026LifecycleDescriptions = map[string]string{
+	"gemini-embedding-001":           "Gemini Embedding text model; scheduled shutdown May 14, 2028. Use gemini-embedding-2 for new workloads.",
+	"gemini-3.1-flash-lite":          "Gemini 3.1 Flash-Lite stable cost-efficient multimodal model; scheduled shutdown May 7, 2027. Use gemini-3.5-flash-lite.",
+	"gemini-3-flash-preview":         "Gemini 3 Flash preview multimodal reasoning model. Google recommends gemini-3.6-flash for stable production workloads; no shutdown date is announced.",
+	"gemini-2.5-pro":                 "Gemini 2.5 Pro stable multimodal reasoning model with a 1M-token context window.",
+	"gemini-2.5-flash":               "Gemini 2.5 Flash stable multimodal reasoning model optimized for latency and cost.",
+	"gemini-2.5-flash-lite":          "Gemini 2.5 Flash-Lite stable cost-efficient multimodal model.",
+	"gemini-2.0-flash":               "Gemini 2.0 Flash was shut down June 1, 2026. Use gemini-3.6-flash.",
+	"gemini-2.0-flash-lite":          "Gemini 2.0 Flash-Lite was shut down June 1, 2026. Use gemini-3.1-flash-lite.",
+	"gemini-robotics-er-1.6-preview": "Gemini Robotics ER 1.6 preview was shut down August 31, 2026. Use gemini-robotics-er-2-preview or gemini-robotics-er-2-streaming-preview.",
+}
+
+// refreshGeminiSeptember2026LifecycleMetadata corrects stale lifecycle descriptions
+// without changing the pricing or capability metadata already attached to existing entries.
+// Parameters: none. Returns: none.
+func refreshGeminiSeptember2026LifecycleMetadata() {
+	for model, description := range geminiSeptember2026LifecycleDescriptions {
+		config, ok := ModelRatios[model]
+		if !ok {
+			continue
+		}
+		config.Description = description
+		ModelRatios[model] = config
+	}
+}
+
+// init installs the September 2026 Gemini catalog, refreshes lifecycle metadata,
+// and rebuilds the derived model list. Parameters: none. Returns: none.
+func init() {
+	for model, config := range geminiSeptember2026ModelRatios {
+		ModelRatios[model] = config
+	}
+	for _, model := range []string{
+		"gemini-3.8-flash",
+		"gemini-3.7-flash",
+		"gemini-robotics-er-2-preview",
+		"gemini-robotics-er-2-streaming-preview",
+	} {
+		geminiWebSearchModels[model] = struct{}{}
+	}
+	refreshGeminiSeptember2026LifecycleMetadata()
+	ModelList = adaptor.GetModelListFromPricing(ModelRatios)
+}

--- a/relay/adaptor/geminiOpenaiCompatible/models_202609_pricing_boundary_test.go
+++ b/relay/adaptor/geminiOpenaiCompatible/models_202609_pricing_boundary_test.go
@@ -1,0 +1,63 @@
+package geminiOpenaiCompatible
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/billing/ratio"
+	"github.com/Laisky/one-api/relay/pricing"
+)
+
+// TestGeminiSeptember2026FlashPricingBoundary verifies the production pricing
+// resolver against Google's fixed published values immediately before and at
+// the 2027 UTC transition for every affected model. Parameters: t is the current
+// test handle. Returns: none.
+func TestGeminiSeptember2026FlashPricingBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		effectiveAt     time.Time
+		inputUsd        float64
+		outputUsd       float64
+		cachedInputUsd  float64
+		completionRatio float64
+	}{
+		{
+			name:            "promotional-last-instant",
+			effectiveAt:     time.Date(2026, time.December, 31, 23, 59, 59, 999_999_999, time.UTC),
+			inputUsd:        0.75,
+			outputUsd:       3.75,
+			cachedInputUsd:  0.075,
+			completionRatio: 5,
+		},
+		{
+			name:            "standard-first-instant",
+			effectiveAt:     time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC),
+			inputUsd:        1.50,
+			outputUsd:       7.50,
+			cachedInputUsd:  0.15,
+			completionRatio: 5,
+		},
+	}
+
+	for _, model := range []string{"gemini-3.6-flash", "gemini-3.7-flash", "gemini-3.8-flash"} {
+		t.Run(model, func(t *testing.T) {
+			t.Parallel()
+
+			config, ok := ModelRatios[model]
+			require.True(t, ok, "%s missing from pricing map", model)
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					resolved := pricing.ApplyTimeWindow(config, tt.effectiveAt)
+					require.InDelta(t, tt.inputUsd*ratio.MilliTokensUsd, resolved.Ratio, 1e-12)
+					require.InDelta(t, tt.completionRatio, resolved.CompletionRatio, 1e-12)
+					require.InDelta(t, tt.outputUsd*ratio.MilliTokensUsd, resolved.Ratio*resolved.CompletionRatio, 1e-12)
+					require.InDelta(t, tt.cachedInputUsd*ratio.MilliTokensUsd, resolved.CachedInputRatio, 1e-12)
+				})
+			}
+		})
+	}
+}

--- a/relay/adaptor/geminiOpenaiCompatible/models_202609_test.go
+++ b/relay/adaptor/geminiOpenaiCompatible/models_202609_test.go
@@ -1,0 +1,107 @@
+package geminiOpenaiCompatible
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// TestGeminiSeptember2026FlashCatalog verifies Gemini 3.6, 3.7, and 3.8
+// pricing, limits, reasoning levels, search pricing eligibility, and the 2027 price transition.
+// Parameters: t is the current test handle. Returns: none.
+func TestGeminiSeptember2026FlashCatalog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		model            string
+		reasoningEfforts []string
+	}{
+		{model: "gemini-3.6-flash", reasoningEfforts: gemini3FlashReasoningEfforts},
+		{model: "gemini-3.7-flash", reasoningEfforts: gemini37PlusReasoningEfforts},
+		{model: "gemini-3.8-flash", reasoningEfforts: gemini37PlusReasoningEfforts},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			t.Parallel()
+
+			config, ok := ModelRatios[tt.model]
+			require.True(t, ok)
+			require.InDelta(t, 0.75*ratio.MilliTokensUsd, config.Ratio, 1e-12)
+			require.InDelta(t, 3.75/0.75, config.CompletionRatio, 1e-12)
+			require.InDelta(t, 0.075*ratio.MilliTokensUsd, config.CachedInputRatio, 1e-12)
+			require.EqualValues(t, 1_048_576, config.ContextLength)
+			require.EqualValues(t, 65_536, config.MaxOutputTokens)
+			require.Equal(t, tt.reasoningEfforts, config.SupportedReasoningEfforts)
+			require.Contains(t, geminiWebSearchModels, tt.model)
+			require.Contains(t, ModelList, tt.model)
+
+			require.Len(t, config.TimeWindows, 1)
+			window := config.TimeWindows[0]
+			require.Equal(t, "UTC", window.TimeZone)
+			require.Equal(t, "2027-01-01", window.DateFrom)
+			require.Len(t, window.Ranges, 1)
+			require.Equal(t, "00:00", window.Ranges[0].Start)
+			require.Equal(t, "00:00", window.Ranges[0].End)
+			require.InDelta(t, 1.50*ratio.MilliTokensUsd, window.Overlay.Ratio, 1e-12)
+			require.InDelta(t, 7.50/1.50, window.Overlay.CompletionRatio, 1e-12)
+			require.InDelta(t, 0.15*ratio.MilliTokensUsd, window.Overlay.CachedInputRatio, 1e-12)
+		})
+	}
+}
+
+// TestGeminiSeptember2026SpecializedCatalog verifies the newly published
+// transcription, Omni, and Robotics ER 2 endpoints and their paid-tier pricing.
+// Parameters: t is the current test handle. Returns: none.
+func TestGeminiSeptember2026SpecializedCatalog(t *testing.T) {
+	t.Parallel()
+
+	transcribe := ModelRatios["gemini-3.5-transcribe"]
+	require.InDelta(t, 2.00*ratio.MilliTokensUsd, transcribe.Ratio, 1e-12)
+	require.InDelta(t, 12.00/2.00, transcribe.CompletionRatio, 1e-12)
+	require.Equal(t, []string{"audio"}, transcribe.InputModalities)
+	require.Equal(t, []string{"text"}, transcribe.OutputModalities)
+	require.NotNil(t, transcribe.Audio)
+	require.InDelta(t, 25.0, transcribe.Audio.PromptTokensPerSecond, 1e-12)
+
+	transcribeLive := ModelRatios["gemini-3.5-transcribe-live"]
+	require.InDelta(t, 3.50*ratio.MilliTokensUsd, transcribeLive.Ratio, 1e-12)
+	require.InDelta(t, 21.00/3.50, transcribeLive.CompletionRatio, 1e-12)
+
+	omni := ModelRatios["gemini-omni-1.1-flash"]
+	require.InDelta(t, 1.50*ratio.MilliTokensUsd, omni.Ratio, 1e-12)
+	require.InDelta(t, 9.00/1.50, omni.CompletionRatio, 1e-12)
+	require.Equal(t, []string{"video"}, omni.OutputModalities)
+	require.NotNil(t, omni.Video)
+	require.InDelta(t, 0.10136, omni.Video.PerSecondUsd, 1e-12)
+	require.Equal(t, "1280x720", omni.Video.BaseResolution)
+
+	robotics := ModelRatios["gemini-robotics-er-2-preview"]
+	require.InDelta(t, 2.00*ratio.MilliTokensUsd, robotics.Ratio, 1e-12)
+	require.InDelta(t, 10.00/2.00, robotics.CompletionRatio, 1e-12)
+	require.InDelta(t, 0.20*ratio.MilliTokensUsd, robotics.CachedInputRatio, 1e-12)
+	require.Contains(t, geminiWebSearchModels, "gemini-robotics-er-2-preview")
+
+	roboticsStreaming := ModelRatios["gemini-robotics-er-2-streaming-preview"]
+	require.InDelta(t, 2.00*ratio.MilliTokensUsd, roboticsStreaming.Ratio, 1e-12)
+	require.InDelta(t, 10.00/2.00, roboticsStreaming.CompletionRatio, 1e-12)
+	require.Zero(t, roboticsStreaming.CachedInputRatio)
+}
+
+// TestGeminiSeptember2026LifecycleMetadata verifies corrected replacement and
+// shutdown guidance for existing catalog entries. Parameters: t is the current test handle.
+// Returns: none.
+func TestGeminiSeptember2026LifecycleMetadata(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, ModelRatios["gemini-embedding-001"].Description, "May 14, 2028")
+	require.Contains(t, ModelRatios["gemini-3.1-flash-lite"].Description, "May 7, 2027")
+	require.Contains(t, ModelRatios["gemini-3-flash-preview"].Description, "gemini-3.6-flash")
+	require.NotContains(t, ModelRatios["gemini-2.5-pro"].Description, "2026-10-16")
+	require.NotContains(t, ModelRatios["gemini-2.5-flash"].Description, "2026-10-16")
+	require.NotContains(t, ModelRatios["gemini-2.5-flash-lite"].Description, "2026-10-16")
+	require.Contains(t, ModelRatios["gemini-robotics-er-1.6-preview"].Description, "August 31, 2026")
+	require.Contains(t, ModelRatios["gemini-omni-flash-preview"].Description, "September 30, 2026")
+}

--- a/relay/adaptor/geminiOpenaiCompatible/models_202609_test.go
+++ b/relay/adaptor/geminiOpenaiCompatible/models_202609_test.go
@@ -78,16 +78,36 @@ func TestGeminiSeptember2026SpecializedCatalog(t *testing.T) {
 	require.InDelta(t, 0.10136, omni.Video.PerSecondUsd, 1e-12)
 	require.Equal(t, "1280x720", omni.Video.BaseResolution)
 
-	robotics := ModelRatios["gemini-robotics-er-2-preview"]
-	require.InDelta(t, 2.00*ratio.MilliTokensUsd, robotics.Ratio, 1e-12)
-	require.InDelta(t, 10.00/2.00, robotics.CompletionRatio, 1e-12)
-	require.InDelta(t, 0.20*ratio.MilliTokensUsd, robotics.CachedInputRatio, 1e-12)
-	require.Contains(t, geminiWebSearchModels, "gemini-robotics-er-2-preview")
+	roboticsTests := []struct {
+		model             string
+		cachedInputUsd    float64
+		expectedFeatures []string
+	}{
+		{
+			model:             "gemini-robotics-er-2-preview",
+			cachedInputUsd:    0.20,
+			expectedFeatures: []string{"tools", "json_mode", "structured_outputs", "web_search", "reasoning"},
+		},
+		{
+			model:             "gemini-robotics-er-2-streaming-preview",
+			expectedFeatures: []string{"tools", "web_search", "reasoning"},
+		},
+	}
 
-	roboticsStreaming := ModelRatios["gemini-robotics-er-2-streaming-preview"]
-	require.InDelta(t, 2.00*ratio.MilliTokensUsd, roboticsStreaming.Ratio, 1e-12)
-	require.InDelta(t, 10.00/2.00, roboticsStreaming.CompletionRatio, 1e-12)
-	require.Zero(t, roboticsStreaming.CachedInputRatio)
+	for _, tt := range roboticsTests {
+		t.Run(tt.model, func(t *testing.T) {
+			config, ok := ModelRatios[tt.model]
+			require.True(t, ok, "%s missing from pricing map", tt.model)
+			require.InDelta(t, 2.00*ratio.MilliTokensUsd, config.Ratio, 1e-12)
+			require.InDelta(t, 10.00/2.00, config.CompletionRatio, 1e-12)
+			require.InDelta(t, tt.cachedInputUsd*ratio.MilliTokensUsd, config.CachedInputRatio, 1e-12)
+			require.EqualValues(t, 131_072, config.ContextLength)
+			require.EqualValues(t, 65_536, config.MaxOutputTokens)
+			require.ElementsMatch(t, tt.expectedFeatures, config.SupportedFeatures)
+			require.Contains(t, config.SupportedFeatures, "web_search")
+			require.Contains(t, geminiWebSearchModels, tt.model)
+		})
+	}
 }
 
 // TestGeminiSeptember2026LifecycleMetadata verifies corrected replacement and


### PR DESCRIPTION
## Summary

- add the current Gemini 3.6, 3.7, and 3.8 Flash model entries
- model Google’s temporary 2026 Flash pricing and automatically switch to the published standard pricing on January 1, 2027
- add Gemini 3.5 Transcribe, Gemini 3.5 Transcribe Live, Gemini Omni 1.1 Flash, and Gemini Robotics ER 2 endpoints
- update web-search eligibility and native Gemini system-instruction support
- correct stale lifecycle metadata for Gemini 2.x/3.x, Embedding, Omni, and Robotics models
- add focused regression tests for model registration, pricing, capabilities, lifecycle guidance, and the scheduled price transition

## Official sources

- https://ai.google.dev/gemini-api/docs/models
- https://ai.google.dev/gemini-api/docs/pricing
- https://ai.google.dev/gemini-api/docs/deprecations

The Google documentation was verified on September 2, 2026.

## Reviewer follow-up

- reproduced the Robotics ER 2 context-limit and streaming Search-grounding findings with behavior tests, then fixed them and retained the reproductions as regression coverage
- investigated the scheduled-pricing comment with boundary and mutation tests
- confirmed that the predicted January 1, 2027 CI failure was a false-positive detail because `ModelRatios` retains base pricing and the canonical request-time resolver applies the dated overlay
- confirmed the valid assertion-coupling issue: expectations that reuse production constants cannot independently catch an incorrect published price
- added `TestGeminiSeptember2026FlashPricingBoundary`, which invokes `pricing.ApplyTimeWindow` for Gemini 3.6, 3.7, and 3.8 Flash immediately before and at the UTC transition and asserts fixed published input, output, completion, and cached-input values
- resolved all review threads after CodeRabbit verified the regression

## Validation

- `gofmt` applied to all changed Go files
- focused behavior, mutation, package, and `go vet` checks passed
- GitHub Actions `lint` run #1443 passed
- GitHub Actions `pr-check` run #552 passed, including repository-wide `go vet` and integration tests
- CodeRabbit follow-up status passed
