### PR TITLE
chore(openai): add GPT-6 Astra model metadata

### DIFF
--- a/relay/adaptor/openai/adaptor_gpt6_astra_test.go
+++ b/relay/adaptor/openai/adaptor_gpt6_astra_test.go
@@ -1,0 +1,76 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// TestGetModelListFromPricingIncludesGPT6Astra verifies the new model is
+// discoverable through the adapter's generated model list.
+func TestGetModelListFromPricingIncludesGPT6Astra(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, adaptor.GetModelListFromPricing(ModelRatios), "gpt-6-astra")
+}
+
+// TestGPT6AstraPricingAndMetadata verifies the documented base pricing,
+// long-context surcharge, token limits, modalities, and capability metadata.
+func TestGPT6AstraPricingAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	cfg, ok := ModelRatios["gpt-6-astra"]
+	require.True(t, ok, "ModelRatios must contain gpt-6-astra")
+
+	require.InDelta(t, 10.0*ratio.MilliTokensUsd, cfg.Ratio, 1e-12)
+	require.InDelta(t, 5.0, cfg.CompletionRatio, 1e-9)
+	require.InDelta(t, 1.0*ratio.MilliTokensUsd, cfg.CachedInputRatio, 1e-12)
+	require.InDelta(t, 12.5*ratio.MilliTokensUsd, cfg.CacheWrite5mRatio, 1e-12)
+	require.Zero(t, cfg.CacheWrite1hRatio)
+	require.Equal(t, int32(1_050_000), cfg.ContextLength)
+	require.Equal(t, int32(128_000), cfg.MaxOutputTokens)
+	require.Equal(t, []string{"text", "image"}, cfg.InputModalities)
+	require.Equal(t, []string{"text"}, cfg.OutputModalities)
+	require.Contains(t, cfg.SupportedFeatures, "reasoning")
+	require.Contains(t, cfg.SupportedFeatures, "tools")
+	require.Contains(t, cfg.SupportedFeatures, "structured_outputs")
+	require.Contains(t, cfg.SupportedFeatures, "web_search")
+
+	require.Len(t, cfg.Tiers, 1)
+	tier := cfg.Tiers[0]
+	require.Equal(t, 272_001, tier.InputTokenThreshold)
+	require.InDelta(t, 20.0*ratio.MilliTokensUsd, tier.Ratio, 1e-12)
+	require.InDelta(t, 3.75, tier.CompletionRatio, 1e-9)
+	require.InDelta(t, 2.0*ratio.MilliTokensUsd, tier.CachedInputRatio, 1e-12)
+	require.InDelta(t, 25.0*ratio.MilliTokensUsd, tier.CacheWrite5mRatio, 1e-12)
+	require.Zero(t, tier.CacheWrite1hRatio)
+}
+
+// TestGPT6AstraReasoningEfforts verifies Astra accepts its documented effort
+// ladder while rejecting non-reasoning values that Astra does not support.
+func TestGPT6AstraReasoningEfforts(t *testing.T) {
+	t.Parallel()
+
+	cfg := ModelRatios["gpt-6-astra"]
+	require.Equal(t, gpt6AstraReasoningEfforts, cfg.SupportedReasoningEfforts)
+	require.Equal(t, "medium", defaultReasoningEffortForModel("gpt-6-astra"))
+	require.True(t, isModelSupportedReasoning("gpt-6-astra"))
+	require.False(t, isMediumOnlyReasoningModel("gpt-6-astra"))
+
+	for _, effort := range gpt6AstraReasoningEfforts {
+		require.Truef(t, isReasoningEffortAllowedForModel("gpt-6-astra", effort), "effort %q must be allowed", effort)
+
+		requested := effort
+		require.Equalf(t, effort, *normalizeReasoningEffortForModel("gpt-6-astra", &requested), "effort %q must pass through", effort)
+	}
+
+	for _, effort := range []string{"none", "minimal", "ultra"} {
+		require.Falsef(t, isReasoningEffortAllowedForModel("gpt-6-astra", effort), "effort %q must be rejected", effort)
+
+		requested := effort
+		require.Equalf(t, "medium", *normalizeReasoningEffortForModel("gpt-6-astra", &requested), "effort %q must fall back to the default", effort)
+	}
+}

--- a/relay/adaptor/openai/constants.go
+++ b/relay/adaptor/openai/constants.go
@@ -9,7 +9,7 @@ import (
 // per-family files stay focused and readable. Model list is derived from the keys of
 // this map, eliminating redundancy.
 //
-// Pricing sources verified 2026-09-01:
+// Pricing sources verified 2026-09-03:
 //   - https://developers.openai.com/api/docs/pricing
 //   - https://developers.openai.com/api/docs/models
 var ModelRatios = applyOpenAIModelCatalog202609(mergeModelRatios(
@@ -20,6 +20,7 @@ var ModelRatios = applyOpenAIModelCatalog202609(mergeModelRatios(
 	gpt45ModelRatios,
 	gpt41ModelRatios,
 	gpt5ModelRatios,
+	gpt6ModelRatios,
 	oSeriesModelRatios,
 	specializedModelRatios,
 	embeddingModelRatios,
@@ -81,7 +82,7 @@ func standardSamplingParameters() []string {
 }
 
 // reasoningSamplingParameters returns the constrained sampling-parameter set
-// supported by OpenAI's reasoning models (o-series, gpt-5 family). Reasoning
+// supported by OpenAI's reasoning models (o-series and GPT-5/GPT-6 families). Reasoning
 // models reject temperature, top_p, frequency_penalty, and presence_penalty.
 func reasoningSamplingParameters() []string {
 	return []string{"seed", "max_tokens"}

--- a/relay/adaptor/openai/constants_gpt6.go
+++ b/relay/adaptor/openai/constants_gpt6.go
@@ -1,0 +1,46 @@
+package openai
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// gpt6AstraReasoningEfforts is the complete reasoning-effort ladder accepted by
+// GPT-6 Astra. Unlike GPT-5.6, Astra does not support "none" or its legacy
+// "minimal" alias.
+var gpt6AstraReasoningEfforts = []string{"low", "medium", "high", "xhigh", "max"}
+
+// gpt6AstraLongContextTier represents the surcharge applied when a GPT-6 Astra
+// request contains more than 272K input tokens. OpenAI bills the full request at
+// 2x input and cache rates and 1.5x output in this tier.
+var gpt6AstraLongContextTier = adaptor.ModelRatioTier{
+	Ratio:               20.0 * ratio.MilliTokensUsd,
+	CompletionRatio:     75.0 / 20.0,
+	CachedInputRatio:    2.0 * ratio.MilliTokensUsd,
+	CacheWrite5mRatio:   25.0 * ratio.MilliTokensUsd,
+	InputTokenThreshold: 272_001,
+}
+
+// gpt6ModelRatios captures pricing and metadata for the GPT-6 family.
+//
+// Sources verified 2026-09-03:
+//   - https://developers.openai.com/api/docs/models/gpt-6-astra
+//   - https://developers.openai.com/api/docs/guides/latest-model
+var gpt6ModelRatios = map[string]adaptor.ModelConfig{
+	"gpt-6-astra": {
+		Ratio:                       10.0 * ratio.MilliTokensUsd,
+		CompletionRatio:             50.0 / 10.0,
+		CachedInputRatio:            1.0 * ratio.MilliTokensUsd,
+		CacheWrite5mRatio:           12.5 * ratio.MilliTokensUsd,
+		Tiers:                       []adaptor.ModelRatioTier{gpt6AstraLongContextTier},
+		ContextLength:               1_050_000,
+		MaxOutputTokens:             128_000,
+		InputModalities:             []string{"text", "image"},
+		OutputModalities:            []string{"text"},
+		SupportedFeatures:           append([]string{"web_search"}, gpt5ReasoningFeatures...),
+		SupportedSamplingParameters: reasoningSamplingParameters(),
+		SupportedReasoningEfforts:   gpt6AstraReasoningEfforts,
+		DefaultReasoningEffort:      "medium",
+		Description:                 "GPT-6 Astra: flagship reasoning model for complex end-to-end work with cache-write and long-context billing.",
+	},
+}


### PR DESCRIPTION
## Summary

- add `gpt-6-astra` to the OpenAI model catalog
- encode documented standard pricing and the `>272K`-input long-context tier, including cached-input and cache-write billing
- register the 1.05M context window, 128K maximum output, text/image input modalities, and supported capabilities
- preserve Astra's documented reasoning-effort ladder (`low`, `medium`, `high`, `xhigh`, `max`) while rejecting unsupported `none`/`minimal` values
- add regression tests for discoverability, pricing, long-context thresholds, metadata, and reasoning-effort normalization

## Validation

- `gofmt` on all changed Go files
- targeted adapter compile/test harness: `go test ./relay/adaptor/openai`

## Official sources

- https://developers.openai.com/api/docs/models
- https://developers.openai.com/api/docs/models/gpt-6-astra
- https://developers.openai.com/api/docs/guides/latest-model


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the GPT-6 Astra model.
  - GPT-6 Astra now supports long-context requests with tiered billing.
  - Added configurable reasoning effort levels, with medium selected by default.
  - Added support for reasoning and web search capabilities.
  - Added model metadata covering token limits, input/output modalities, sampling options, and pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->