### PR TITLE
feat(fireworks): refresh serverless model catalog

### DIFF
--- a/relay/adaptor/fireworks/constants.go
+++ b/relay/adaptor/fireworks/constants.go
@@ -5,16 +5,16 @@ import (
 )
 
 // Reusable metadata fragments. Fireworks publishes per-model cards at
-// https://app.fireworks.ai/models/<provider>/<slug> that report serverless
+// https://fireworks.ai/models/<provider>/<slug> that report serverless
 // availability, pricing, context length, Hugging Face lineage, calibration,
 // modalities, and function-calling support. The values below were verified
-// against the live model library and model cards on 2026-08-18 and standardized
+// against the live model library and model cards on 2026-09-04 and standardized
 // to the OpenRouter-compatible vocabulary expected by adaptor.ModelConfig.
 //
 // Sources:
-//   - https://app.fireworks.ai/models
-//   - https://fireworks.ai/pricing
-//   - Per-model cards under https://app.fireworks.ai/models/<provider>/<slug>
+//   - https://fireworks.ai/models?modelTypes=Serverless
+//   - https://docs.fireworks.ai/serverless/pricing
+//   - Per-model cards under https://fireworks.ai/models/<provider>/<slug>
 var (
 	// fwTextOnlyModalities advertises a chat model that consumes and emits text only.
 	fwTextOnlyModalities = []string{"text"}
@@ -78,8 +78,9 @@ var (
 // embedding entries retain the model IDs accepted by their older endpoints.
 //
 // Per-model serverless prices and availability are sourced from the live model
-// library and individual cards (verified 2026-08-18). Generic dedicated
-// deployment buckets remain documented at https://fireworks.ai/pricing.
+// library, serverless pricing table, and individual cards (verified 2026-09-04).
+// Generic dedicated deployment buckets remain documented at
+// https://fireworks.ai/pricing.
 //
 // Capability metadata (context length, modalities, Hugging Face lineage, and
 // quantization where explicitly published) is sourced from the model cards and

--- a/relay/adaptor/fireworks/models_catalog_test.go
+++ b/relay/adaptor/fireworks/models_catalog_test.go
@@ -8,42 +8,44 @@ import (
 	"github.com/Laisky/one-api/relay/billing/ratio"
 )
 
+// TestCurrentServerlessCatalogPricing verifies every model currently tagged
+// Serverless by Fireworks has the published standard-tier price and context.
 func TestCurrentServerlessCatalogPricing(t *testing.T) {
 	t.Parallel()
 
-	// This table mirrors the Serverless-tagged entries in the Fireworks model
-	// library on 2026-08-18. Historical/dedicated models may remain in
-	// ModelRatios for backward compatibility, but every current serverless ID
-	// must be present with its published standard-tier pricing.
-	tests := map[string]struct {
+	// This table mirrors the 20 Serverless-tagged entries in the Fireworks model
+	// library on 2026-09-04. Historical and dedicated-only models may remain in
+	// ModelRatios for backward compatibility, but they do not belong here.
+	currentServerlessModels := map[string]struct {
 		inputUSD     float64
 		cachedUSD    float64
 		outputUSD    float64
 		contextLimit int32
 	}{
-		"accounts/fireworks/models/deepseek-v4-pro-0813":           {1.32, 0.044, 3.96, 1048576},
-		"accounts/fireworks/models/muse-glimmer-30b":               {0.35, 0.04, 1.50, 131072},
-		"accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {0.05, 0.01, 0.20, 262144},
-		"accounts/fireworks/models/qwen3p8-max":                    {2.00, 0.25, 6.00, 0},
-		"accounts/fireworks/models/deepseek-v4-flash-0731":         {0.14, 0.028, 0.28, 1048576},
+		"accounts/fireworks/models/glm-5p3-flash":                  {0.15, 0.03, 0.50, 1048576},
+		"accounts/fireworks/models/glm-5p3":                        {1.40, 0.26, 4.40, 1048576},
 		"accounts/fireworks/models/kimi-k3":                        {3.00, 0.30, 15.00, 1048576},
+		"accounts/fireworks/models/deepseek-v4-pro-0813":           {1.32, 0.044, 3.96, 1048576},
+		"accounts/fireworks/models/qwen3p8-2p4t-a95b":              {2.00, 0.25, 6.00, 262144},
+		"accounts/fireworks/models/muse-glimmer-30b":               {0.35, 0.04, 1.50, 131072},
+		"accounts/fireworks/models/deepseek-v4-flash-0731":         {0.22, 0.007, 0.66, 1048576},
 		"accounts/fireworks/models/glm-5p2":                        {1.40, 0.14, 4.40, 1048576},
 		"accounts/fireworks/models/kimi-k2p7-code":                 {0.95, 0.19, 4.00, 262144},
-		"accounts/fireworks/models/minimax-m3":                     {0.30, 0.059, 1.20, 524288},
-		"accounts/fireworks/models/qwen3p7-plus":                   {0.40, 0.08, 1.60, 262144},
-		"accounts/fireworks/models/deepseek-v4-pro":                {1.74, 0.145, 3.48, 1048576},
-		"accounts/fireworks/models/kimi-k2p6":                      {0.95, 0.16, 4.00, 262144},
+		"accounts/fireworks/models/minimax-m3":                     {0.30, 0.06, 1.20, 512000},
 		"accounts/fireworks/models/minimax-m2p7":                   {0.30, 0.059, 1.20, 196608},
-		"accounts/fireworks/models/gpt-oss-120b":                   {0.15, 0.014, 0.60, 131072},
-		"accounts/fireworks/models/gpt-oss-20b":                    {0.07, 0.035, 0.30, 131072},
-		"accounts/fireworks/models/nemotron-3-ultra-nvfp4":         {0.60, 0.119, 2.40, 262144},
-		"accounts/fireworks/models/qwen3p8-2p4t-a95b":              {2.00, 0.25, 6.00, 262144},
+		"accounts/fireworks/models/gpt-oss-120b":                   {0.15, 0.015, 0.60, 131072},
+		"accounts/fireworks/models/nemotron-3-ultra-nvfp4":         {0.60, 0.12, 2.40, 262144},
+		"accounts/fireworks/models/deepseek-v4-flash-vision-exp":   {0.22, 0.007, 0.66, 1048576},
+		"accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {0.05, 0.01, 0.20, 262144},
 		"accounts/fireworks/models/inkling":                        {1.00, 0.17, 4.05, 1048576},
+		"accounts/fireworks/models/qwen3p7-plus":                   {0.40, 0.08, 1.60, 262144},
+		"accounts/fireworks/models/kimi-k2p6":                      {0.95, 0.16, 4.00, 262144},
 		"accounts/fireworks/models/qwen3-reranker-8b":              {0.20, 0, 0.20, 40960},
 		"accounts/fireworks/models/qwen3-embedding-8b":             {0.10, 0, 0.10, 40960},
 	}
+	require.Len(t, currentServerlessModels, 20)
 
-	for modelID, want := range tests {
+	for modelID, want := range currentServerlessModels {
 		modelID, want := modelID, want
 		t.Run(modelID, func(t *testing.T) {
 			t.Parallel()
@@ -54,27 +56,32 @@ func TestCurrentServerlessCatalogPricing(t *testing.T) {
 			require.InDelta(t, want.inputUSD, got.Ratio/ratio.MilliTokensUsd, 1e-12)
 			require.InDelta(t, want.cachedUSD, got.CachedInputRatio/ratio.MilliTokensUsd, 1e-12)
 			require.InDelta(t, want.outputUSD, got.Ratio*got.CompletionRatio/ratio.MilliTokensUsd, 1e-12)
-			if want.contextLimit > 0 {
-				require.Equal(t, want.contextLimit, got.ContextLength)
-			}
+			require.Equal(t, want.contextLimit, got.ContextLength)
 			require.NotEmpty(t, got.Description)
 		})
 	}
 }
 
+// TestCurrentServerlessCatalogCapabilities verifies modality, tool support, and
+// canonical model-path metadata for the current Fireworks catalog.
 func TestCurrentServerlessCatalogCapabilities(t *testing.T) {
 	t.Parallel()
 
 	for _, modelID := range []string{
-		"accounts/fireworks/models/muse-glimmer-30b",
-		"accounts/fireworks/models/qwen3p8-max",
+		"accounts/fireworks/models/glm-5p3-flash",
 		"accounts/fireworks/models/kimi-k3",
+		"accounts/fireworks/models/muse-glimmer-30b",
+		"accounts/fireworks/models/deepseek-v4-flash-vision-exp",
+		"accounts/fireworks/models/kimi-k2p7-code",
 		"accounts/fireworks/models/inkling",
+		"accounts/fireworks/models/qwen3p7-plus",
+		"accounts/fireworks/models/kimi-k2p6",
 	} {
 		require.Contains(t, ModelRatios[modelID].InputModalities, "image", "model=%s", modelID)
 	}
 
+	require.Equal(t, fwTextOnlyModalities, ModelRatios["accounts/fireworks/models/glm-5p3"].InputModalities)
 	require.Equal(t, fwTextOnlyModalities, ModelRatios["accounts/fireworks/models/minimax-m3"].InputModalities)
-	require.NotContains(t, ModelRatios["accounts/fireworks/models/gpt-oss-20b"].SupportedFeatures, "tools")
 	require.Contains(t, ModelRatios["accounts/fireworks/models/gpt-oss-120b"].SupportedFeatures, "tools")
+	require.NotContains(t, ModelRatios, "accounts/fireworks/models/qwen3p8-max")
 }

--- a/relay/adaptor/fireworks/models_deepseek.go
+++ b/relay/adaptor/fireworks/models_deepseek.go
@@ -6,9 +6,10 @@ import (
 )
 
 // deepseekModels contains DeepSeek family models served by Fireworks. Sources:
-//   - https://app.fireworks.ai/models/fireworks/deepseek-v4-pro-0813
-//   - https://app.fireworks.ai/models/fireworks/deepseek-v4-flash-0731
-//   - Historical per-model cards under https://app.fireworks.ai/models/{fireworks,deepseek-ai}/...
+//   - https://fireworks.ai/models/deepseek-ai/deepseek-v4-pro-0813
+//   - https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-0731
+//   - https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-vision-exp
+//   - Historical per-model cards under https://fireworks.ai/models/{fireworks,deepseek-ai}/...
 var deepseekModels = map[string]adaptor.ModelConfig{
 	// Official DeepSeek V4 releases (August 2026).
 	"accounts/fireworks/models/deepseek-v4-pro-0813": {
@@ -26,9 +27,9 @@ var deepseekModels = map[string]adaptor.ModelConfig{
 		Description:                 "Official DeepSeek V4 Pro release (1.6T MoE) with DSpark speculative decoding, 1M-token context, stronger production agent performance, and function calling.",
 	},
 	"accounts/fireworks/models/deepseek-v4-flash-0731": {
-		Ratio:                       0.14 * ratio.MilliTokensUsd,
-		CompletionRatio:             0.28 / 0.14,
-		CachedInputRatio:            0.028 * ratio.MilliTokensUsd,
+		Ratio:                       0.22 * ratio.MilliTokensUsd,
+		CompletionRatio:             0.66 / 0.22,
+		CachedInputRatio:            0.007 * ratio.MilliTokensUsd,
 		ContextLength:               1048576,
 		MaxOutputTokens:             131072,
 		InputModalities:             fwTextOnlyModalities,
@@ -39,8 +40,20 @@ var deepseekModels = map[string]adaptor.ModelConfig{
 		HuggingFaceID:               "deepseek-ai/DeepSeek-V4-Flash-0731",
 		Description:                 "Official DeepSeek V4 Flash release (304B MoE) with DSpark speculative decoding, 1M-token context, enhanced agentic capability, and function calling.",
 	},
+	"accounts/fireworks/models/deepseek-v4-flash-vision-exp": {
+		Ratio:                       0.22 * ratio.MilliTokensUsd,
+		CompletionRatio:             0.66 / 0.22,
+		CachedInputRatio:            0.007 * ratio.MilliTokensUsd,
+		ContextLength:               1048576,
+		InputModalities:             fwTextImageInModalities,
+		OutputModalities:            fwTextOnlyModalities,
+		SupportedFeatures:           fwReasoningFeatures,
+		SupportedSamplingParameters: fwChatSamplingParams,
+		HuggingFaceID:               "deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+		Description:                 "Experimental DeepSeek V4 Flash multimodal release (305B MoE) with image input, DSpark speculative decoding, 1M-token context, and function calling.",
+	},
 
-	// DeepSeek V4 Pro preview — $1.74 in / $3.48 out, discounted cached input listed separately.
+	// DeepSeek V4 Pro preview — retained for on-demand compatibility.
 	"accounts/fireworks/models/deepseek-v4-pro": {
 		Ratio:                       1.74 * ratio.MilliTokensUsd,
 		CompletionRatio:             3.48 / 1.74,
@@ -53,7 +66,7 @@ var deepseekModels = map[string]adaptor.ModelConfig{
 		SupportedSamplingParameters: fwReasoningSamplingParams,
 		Quantization:                "fp16",
 		HuggingFaceID:               "deepseek-ai/DeepSeek-V4-Pro",
-		Description:                 "DeepSeek V4 Pro preview (1.6T MoE) with hybrid attention and 1M-token context. Still listed on Fireworks serverless as of 2026-08-18, but superseded by deepseek-v4-pro-0813.",
+		Description:                 "DeepSeek V4 Pro preview (1.6T MoE) with hybrid attention and 1M-token context. Fireworks now marks this preview as on-demand only; use deepseek-v4-pro-0813 for serverless inference.",
 	},
 
 	// DeepSeek V3 family — $0.56 in / $1.68 out, 50% cached discount.
@@ -131,6 +144,6 @@ var deepseekModels = map[string]adaptor.ModelConfig{
 		SupportedSamplingParameters: fwChatSamplingParams,
 		Quantization:                "fp8",
 		HuggingFaceID:               "deepseek-ai/DeepSeek-V4-Flash",
-		Description:                 "DeepSeek V4 Flash preview with 1M-token context. No longer listed as serverless on 2026-08-18 and superseded by deepseek-v4-flash-0731; retained for dedicated/on-demand deployments.",
+		Description:                 "DeepSeek V4 Flash preview with 1M-token context. No longer listed as serverless and superseded by deepseek-v4-flash-0731; retained for dedicated/on-demand deployments.",
 	},
 }

--- a/relay/adaptor/fireworks/models_glm.go
+++ b/relay/adaptor/fireworks/models_glm.go
@@ -6,11 +6,13 @@ import (
 )
 
 // glmModels contains Z.ai GLM family models served by Fireworks (GLM-4.7,
-// GLM-5, GLM-5.1, GLM-5.2). Sources:
-//   - https://app.fireworks.ai/models/fireworks/glm-4p7
-//   - https://app.fireworks.ai/models/fireworks/glm-5
-//   - https://app.fireworks.ai/models/fireworks/glm-5p1
-//   - https://app.fireworks.ai/models/fireworks/glm-5p2
+// GLM-5, GLM-5.1, GLM-5.2, GLM-5.3, and GLM-5.3-Flash). Sources:
+//   - https://fireworks.ai/models/fireworks/glm-4p7
+//   - https://fireworks.ai/models/fireworks/glm-5
+//   - https://fireworks.ai/models/fireworks/glm-5p1
+//   - https://fireworks.ai/models/fireworks/glm-5p2
+//   - https://fireworks.ai/models/fireworks/glm-5p3
+//   - https://fireworks.ai/models/fireworks/glm-5p3-flash
 var glmModels = map[string]adaptor.ModelConfig{
 	"accounts/fireworks/models/glm-4p7": {
 		Ratio:                       0.60 * ratio.MilliTokensUsd,
@@ -51,7 +53,7 @@ var glmModels = map[string]adaptor.ModelConfig{
 		SupportedSamplingParameters: fwChatSamplingParams,
 		Quantization:                "fp8",
 		HuggingFaceID:               "zai-org/GLM-5.1-FP8",
-		Description:                 "Z.ai GLM-5.1 (754B MoE) for agentic engineering and sustained long-horizon work. No longer listed as serverless on 2026-08-18; retained for dedicated/on-demand deployments, with GLM 5.2 as the current serverless successor.",
+		Description:                 "Z.ai GLM-5.1 (754B MoE) for agentic engineering and sustained long-horizon work. No longer listed as serverless; retained for dedicated/on-demand deployments and superseded by newer GLM releases.",
 	},
 	"accounts/fireworks/models/glm-5p2": {
 		Ratio:                       1.40 * ratio.MilliTokensUsd,
@@ -66,5 +68,30 @@ var glmModels = map[string]adaptor.ModelConfig{
 		Quantization:                "fp8",
 		HuggingFaceID:               "zai-org/GLM-5.2",
 		Description:                 "Z.ai GLM-5.2 (743B MoE) flagship with 1M-token context for long-horizon agentic engineering and coding.",
+	},
+	"accounts/fireworks/models/glm-5p3": {
+		Ratio:                       1.40 * ratio.MilliTokensUsd,
+		CompletionRatio:             4.40 / 1.40,
+		CachedInputRatio:            0.26 * ratio.MilliTokensUsd,
+		ContextLength:               1048576,
+		MaxOutputTokens:             131072,
+		InputModalities:             fwTextOnlyModalities,
+		OutputModalities:            fwTextOnlyModalities,
+		SupportedFeatures:           fwReasoningFeatures,
+		SupportedSamplingParameters: fwChatSamplingParams,
+		HuggingFaceID:               "zai-org/GLM-5.3",
+		Description:                 "Z.ai GLM-5.3 (743B MoE) improves complex coding and long-horizon agent work through post-training while retaining the GLM-5.2 base architecture and 1M-token context.",
+	},
+	"accounts/fireworks/models/glm-5p3-flash": {
+		Ratio:                       0.15 * ratio.MilliTokensUsd,
+		CompletionRatio:             0.50 / 0.15,
+		CachedInputRatio:            0.03 * ratio.MilliTokensUsd,
+		ContextLength:               1048576,
+		InputModalities:             fwTextImageInModalities,
+		OutputModalities:            fwTextOnlyModalities,
+		SupportedFeatures:           fwReasoningFeatures,
+		SupportedSamplingParameters: fwChatSamplingParams,
+		HuggingFaceID:               "zai-org/GLM-5.3-Flash",
+		Description:                 "Z.ai GLM-5.3-Flash is a 320B native multimodal model with 18B active parameters, 1M-token context, function calling, and lower-cost long-context inference.",
 	},
 }

--- a/relay/adaptor/fireworks/models_gpt_oss.go
+++ b/relay/adaptor/fireworks/models_gpt_oss.go
@@ -6,14 +6,14 @@ import (
 )
 
 // gptOssModels contains OpenAI gpt-oss open-weight models hosted on Fireworks
-// (gpt-oss-120b, gpt-oss-20b). Sources:
-//   - https://app.fireworks.ai/models/fireworks/gpt-oss-120b
-//   - https://app.fireworks.ai/models/fireworks/gpt-oss-20b
+// (gpt-oss-120b and the on-demand-only gpt-oss-20b). Sources:
+//   - https://fireworks.ai/models/fireworks/gpt-oss-120b
+//   - https://fireworks.ai/models/fireworks/gpt-oss-20b
 var gptOssModels = map[string]adaptor.ModelConfig{
 	"accounts/fireworks/models/gpt-oss-120b": {
 		Ratio:                       0.15 * ratio.MilliTokensUsd,
 		CompletionRatio:             0.60 / 0.15,
-		CachedInputRatio:            0.014 * ratio.MilliTokensUsd,
+		CachedInputRatio:            0.015 * ratio.MilliTokensUsd,
 		ContextLength:               131072,
 		MaxOutputTokens:             131072,
 		InputModalities:             fwTextOnlyModalities,
@@ -48,6 +48,6 @@ var gptOssModels = map[string]adaptor.ModelConfig{
 		DefaultReasoningEffort:    "medium",
 		Quantization:              "fp16",
 		HuggingFaceID:             "openai/gpt-oss-20b",
-		Description:               "OpenAI gpt-oss-20b compact open-weight MoE reasoning model for lower-latency agentic and developer use cases; Fireworks serverless does not expose function calling for this endpoint.",
+		Description:               "OpenAI gpt-oss-20b compact open-weight MoE reasoning model for lower-latency and specialized use cases. Fireworks now marks this model as on-demand only and does not expose function calling for the endpoint.",
 	},
 }

--- a/relay/adaptor/fireworks/models_minimax.go
+++ b/relay/adaptor/fireworks/models_minimax.go
@@ -7,9 +7,9 @@ import (
 
 // minimaxModels contains MiniMax family models served by Fireworks (M2.5, M2.7, M3).
 // Sources:
-//   - https://app.fireworks.ai/models/fireworks/minimax-m2p5
-//   - https://app.fireworks.ai/models/fireworks/minimax-m2p7
-//   - https://app.fireworks.ai/models/fireworks/minimax-m3
+//   - https://fireworks.ai/models/fireworks/minimax-m2p5
+//   - https://fireworks.ai/models/fireworks/minimax-m2p7
+//   - https://fireworks.ai/models/fireworks/minimax-m3
 var minimaxModels = map[string]adaptor.ModelConfig{
 	"accounts/fireworks/models/minimax-m2p5": {
 		Ratio:                       0.30 * ratio.MilliTokensUsd,
@@ -40,13 +40,13 @@ var minimaxModels = map[string]adaptor.ModelConfig{
 		Description:                 "MiniMax M2.7 (228.7B MoE) agentic model for complex agent harnesses, dynamic tool search, and elaborate productivity tasks.",
 	},
 
-	// MiniMax M3 — $0.30 in / $1.20 out, cached $0.059.
+	// MiniMax M3 — $0.30 input / $0.06 cached input / $1.20 output.
 	"accounts/fireworks/models/minimax-m3": {
 		Ratio:                       0.30 * ratio.MilliTokensUsd,
 		CompletionRatio:             1.20 / 0.30,
-		CachedInputRatio:            0.059 * ratio.MilliTokensUsd,
-		ContextLength:               524288,
-		MaxOutputTokens:             524288,
+		CachedInputRatio:            0.06 * ratio.MilliTokensUsd,
+		ContextLength:               512000,
+		MaxOutputTokens:             512000,
 		InputModalities:             fwTextOnlyModalities,
 		OutputModalities:            fwTextOnlyModalities,
 		SupportedFeatures:           fwReasoningFeatures,

--- a/relay/adaptor/fireworks/models_nvidia.go
+++ b/relay/adaptor/fireworks/models_nvidia.go
@@ -7,8 +7,8 @@ import (
 
 // nvidiaModels contains NVIDIA models served by Fireworks (Nemotron family).
 // Sources:
-//   - https://app.fireworks.ai/models/fireworks/nemotron-lightning-3p5-30b-a3b
-//   - https://app.fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4
+//   - https://fireworks.ai/models/fireworks/nemotron-lightning-3p5-30b-a3b
+//   - https://fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4
 var nvidiaModels = map[string]adaptor.ModelConfig{
 	"accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
 		Ratio:                       0.05 * ratio.MilliTokensUsd,
@@ -22,11 +22,11 @@ var nvidiaModels = map[string]adaptor.ModelConfig{
 		Description:                 "NVIDIA Nemotron Lightning 3.5 30B A3B serverless text model with 262K context and function calling.",
 	},
 
-	// Nemotron-3 Ultra 550B NVFP4 — $0.60 in / $2.40 out.
+	// Nemotron-3 Ultra 550B NVFP4 — $0.60 input / $0.12 cached input / $2.40 output.
 	"accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
 		Ratio:                       0.60 * ratio.MilliTokensUsd,
 		CompletionRatio:             2.40 / 0.60,
-		CachedInputRatio:            0.119 * ratio.MilliTokensUsd,
+		CachedInputRatio:            0.12 * ratio.MilliTokensUsd,
 		ContextLength:               262144,
 		MaxOutputTokens:             32768,
 		InputModalities:             fwTextOnlyModalities,
@@ -35,6 +35,6 @@ var nvidiaModels = map[string]adaptor.ModelConfig{
 		SupportedSamplingParameters: fwReasoningSamplingParams,
 		Quantization:                "nvfp4",
 		HuggingFaceID:               "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
-		Description:                 "NVIDIA Nemotron-3 Ultra 550B NVFP4 reasoning MoE on Fireworks, 262K context, $0.60/$2.40 per 1M.",
+		Description:                 "NVIDIA Nemotron-3 Ultra 550B NVFP4 reasoning MoE on Fireworks with 262K context and function calling.",
 	},
 }

--- a/relay/adaptor/fireworks/models_qwen.go
+++ b/relay/adaptor/fireworks/models_qwen.go
@@ -9,17 +9,8 @@ import (
 // Reranker and embedding members of the Qwen3 family live in models_rerank.go
 // and models_embedding.go respectively.
 var qwenModels = map[string]adaptor.ModelConfig{
-	"accounts/fireworks/models/qwen3p8-max": {
-		Ratio:                       2.00 * ratio.MilliTokensUsd,
-		CompletionRatio:             6.00 / 2.00,
-		CachedInputRatio:            0.25 * ratio.MilliTokensUsd,
-		InputModalities:             fwTextImageInModalities,
-		OutputModalities:            fwTextOnlyModalities,
-		SupportedFeatures:           fwChatFeatures,
-		SupportedSamplingParameters: fwChatSamplingParams,
-		HuggingFaceID:               "Qwen/Qwen3.8-2.4T-A95B",
-		Description:                 "Fireworks Qwen 3.8 Max serverless endpoint for multimodal, long-horizon coding, professional work, research, and agentic tasks. The Fireworks card does not currently publish a context limit.",
-	},
+	// Fireworks publishes qwen3p8-2p4t-a95b as the canonical API model path.
+	// The former qwen3p8-max catalog alias is intentionally not exposed.
 	"accounts/fireworks/models/qwen3p8-2p4t-a95b": {
 		Ratio:                       2.00 * ratio.MilliTokensUsd,
 		CompletionRatio:             6.00 / 2.00,


### PR DESCRIPTION
## Summary

Refresh the Fireworks adaptor model catalog against the official Serverless model library, pricing table, and individual model cards as of **2026-09-04**.

The official Serverless library still contains **20 base models**, but three entries have changed since the previous 2026-08-18 refresh.

## New Serverless model IDs

- `accounts/fireworks/models/glm-5p3`
- `accounts/fireworks/models/glm-5p3-flash`
- `accounts/fireworks/models/deepseek-v4-flash-vision-exp`

The new entries include current standard-tier pricing, cached-input pricing, context limits, modalities, function-calling metadata, Hugging Face lineage, and descriptions published by Fireworks.

## Catalog and lifecycle corrections

- Remove the obsolete `accounts/fireworks/models/qwen3p8-max` catalog alias; Fireworks now publishes `accounts/fireworks/models/qwen3p8-2p4t-a95b` as the canonical API model path.
- Remove `deepseek-v4-pro` and `gpt-oss-20b` from the **current Serverless regression table**, because their live model cards now mark Serverless as unsupported.
- Retain the underlying `deepseek-v4-pro` and `gpt-oss-20b` metadata for existing on-demand/dedicated configurations, while updating their lifecycle descriptions.

## Pricing and context corrections

- DeepSeek V4 Flash 0731: `$0.22 / $0.007 / $0.66` per 1M input/cached-input/output tokens.
- MiniMax M3: cached input `$0.06 / 1M`; Fireworks context limit `512,000` tokens.
- GPT-OSS 120B: cached input `$0.015 / 1M`.
- Nemotron 3 Ultra NVFP4: cached input `$0.12 / 1M`.

## Tests

- Updated the Serverless catalog regression table to the exact 20 models currently shown by Fireworks.
- Added coverage for the new vision-capable models, GLM 5.3 text-only modality, canonical Qwen model-path handling, pricing, cached-input pricing, context limits, and descriptions.
- Applied `gofmt` to all changed Go files.
- Passed an isolated Fireworks package harness:
  - `go test ./relay/adaptor/fireworks`
  - `go vet ./relay/adaptor/fireworks`

The full repository checks (`go vet ./...`, `go test -race ./...`, and the Modern frontend build) were not run locally because the execution environment could not clone/download the repository and its full dependency graph. GitHub Actions should be treated as the authoritative full-repository validation.

## Official sources

- Serverless model library: https://fireworks.ai/models?modelTypes=Serverless
- Serverless pricing: https://docs.fireworks.ai/serverless/pricing
- GLM 5.3: https://fireworks.ai/models/fireworks/glm-5p3
- GLM 5.3 Flash: https://fireworks.ai/models/fireworks/glm-5p3-flash
- DeepSeek V4 Flash Vision Exp: https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-vision-exp
- Qwen3.8 canonical model path: https://fireworks.ai/models/fireworks/qwen3p8-max
- DeepSeek V4 Pro lifecycle: https://fireworks.ai/models/fireworks/deepseek-v4-pro
- GPT-OSS 20B lifecycle: https://fireworks.ai/models/fireworks/gpt-oss-20b
- MiniMax M3: https://fireworks.ai/models/fireworks/minimax-m3
- GPT-OSS 120B: https://fireworks.ai/models/fireworks/gpt-oss-120b
- Nemotron 3 Ultra NVFP4: https://fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for GLM-5.3, GLM-5.3 Flash, and DeepSeek V4 Flash Vision.
  - Added image-input capability for the new DeepSeek vision model.

- **Updates**
  - Refreshed the Fireworks serverless model catalog, pricing, context limits, and capability metadata.
  - Updated pricing and cached-input rates for several models.
  - Clarified availability and feature details for models offered only on demand.

- **Removals**
  - Removed the Qwen3 8B Max catalog alias from exposed serverless models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->