### PR TITLE
chore(replicate): refresh official model catalog and pricing

### DIFF
--- a/relay/adaptor/replicate/constants.go
+++ b/relay/adaptor/replicate/constants.go
@@ -77,15 +77,16 @@ func replicateImageConfig(pricePerImage float64) *adaptor.ImagePricingConfig {
 
 // ModelRatios contains all supported models and their pricing ratios.
 // Model list is derived from the keys of this map, eliminating redundancy.
-// Based on Replicate pricing and explicit official model pages retrieved 2026-05-18.
+// Based on Replicate pricing and explicit official model pages retrieved 2026-09-04.
 // Replicate collection pages are treated additively for discovery; absence from a collection is not used for removals.
 //
 // The map is assembled in init() from family-specific maps declared in
-// constants_image.go and constants_language.go to keep individual files under
-// the 600-line project guideline.
+// constants_image*.go and constants_language.go to keep individual files under
+// the 800-line project guideline.
 //
 // Sources consulted:
 //   - https://replicate.com/explore
+//   - https://replicate.com/collections/text-to-image
 //   - Per-model pages under https://replicate.com/<owner>/<model>
 //   - HuggingFace cards for open-weight models (referenced via HuggingFaceID)
 //
@@ -98,7 +99,7 @@ var ModelRatios = map[string]adaptor.ModelConfig{}
 // Populated in init() after ModelRatios is assembled.
 var ModelList []string
 
-// ReplicateToolingDefaults notes that Replicate bills per model runtime without separate tool pricing (retrieved 2026-04-28).
+// ReplicateToolingDefaults notes that Replicate bills per model runtime without separate tool pricing (retrieved 2026-09-04).
 // Source: https://replicate.com/pricing
 var ReplicateToolingDefaults = adaptor.ChannelToolConfig{}
 
@@ -108,6 +109,7 @@ var ReplicateToolingDefaults = adaptor.ChannelToolConfig{}
 // not assume ordering).
 func init() {
 	maps.Copy(ModelRatios, replicateImageModelRatios)
+	maps.Copy(ModelRatios, replicateOfficialImageAdditions)
 	maps.Copy(ModelRatios, replicateLanguageModelRatios)
 	ModelList = adaptor.GetModelListFromPricing(ModelRatios)
 }

--- a/relay/adaptor/replicate/constants.go
+++ b/relay/adaptor/replicate/constants.go
@@ -81,12 +81,13 @@ func replicateImageConfig(pricePerImage float64) *adaptor.ImagePricingConfig {
 // Replicate collection pages are treated additively for discovery; absence from a collection is not used for removals.
 //
 // The map is assembled in init() from family-specific maps declared in
-// constants_image*.go and constants_language.go to keep individual files under
+// constants_image*.go and constants_language*.go to keep individual files under
 // the 800-line project guideline.
 //
 // Sources consulted:
 //   - https://replicate.com/explore
 //   - https://replicate.com/collections/text-to-image
+//   - https://replicate.com/collections/language-models
 //   - Per-model pages under https://replicate.com/<owner>/<model>
 //   - HuggingFace cards for open-weight models (referenced via HuggingFaceID)
 //
@@ -103,13 +104,21 @@ var ModelList []string
 // Source: https://replicate.com/pricing
 var ReplicateToolingDefaults = adaptor.ChannelToolConfig{}
 
-// init assembles ModelRatios from per-family maps and derives ModelList. The
-// assembly is deterministic across runs because Go map iteration in
-// adaptor.GetModelListFromPricing already produces stable identity and callers
-// do not assume ordering. It takes no parameters and returns no values.
+// init assembles ModelRatios from per-family maps, applies temporary pricing
+// windows, and derives ModelList. The assembly is deterministic across runs
+// because callers do not assume map iteration order. It takes no parameters and
+// returns no values.
 func init() {
 	maps.Copy(ModelRatios, replicateImageModelRatios)
 	maps.Copy(ModelRatios, replicateOfficialImageAdditions)
 	maps.Copy(ModelRatios, replicateLanguageModelRatios)
+	for modelName, windows := range replicateLanguagePricingAdjustments {
+		config, ok := ModelRatios[modelName]
+		if !ok {
+			continue
+		}
+		config.TimeWindows = append(config.TimeWindows, windows...)
+		ModelRatios[modelName] = config
+	}
 	ModelList = adaptor.GetModelListFromPricing(ModelRatios)
 }

--- a/relay/adaptor/replicate/constants.go
+++ b/relay/adaptor/replicate/constants.go
@@ -105,8 +105,8 @@ var ReplicateToolingDefaults = adaptor.ChannelToolConfig{}
 
 // init assembles ModelRatios from per-family maps and derives ModelList. The
 // assembly is deterministic across runs because Go map iteration in
-// adaptor.GetModelListFromPricing already produces stable identity (callers do
-// not assume ordering).
+// adaptor.GetModelListFromPricing already produces stable identity and callers
+// do not assume ordering. It takes no parameters and returns no values.
 func init() {
 	maps.Copy(ModelRatios, replicateImageModelRatios)
 	maps.Copy(ModelRatios, replicateOfficialImageAdditions)

--- a/relay/adaptor/replicate/constants_image_official_additions.go
+++ b/relay/adaptor/replicate/constants_image_official_additions.go
@@ -1,0 +1,167 @@
+package replicate
+
+import "github.com/Laisky/one-api/relay/adaptor"
+
+// replicateOfficialImageAdditions contains fixed-price Replicate Official image
+// endpoints that are absent from the original catalog snapshot. Models whose
+// current multi-property billing cannot be represented by ImagePricingConfig are
+// intentionally excluded rather than assigned an estimated price.
+var replicateOfficialImageAdditions = map[string]adaptor.ModelConfig{
+	"black-forest-labs/flux-kontext-max": {
+		Ratio: 0, CompletionRatio: 1.0, Image: replicateImageConfig(0.08),
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "FLUX.1 Kontext [max] premium text-guided image editing model with improved typography.",
+	},
+	"bytedance/seedream-5-pro": {
+		// Replicate bills 1K outputs at $0.045 and 2K outputs at $0.09.
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.09,
+			DefaultSize:      "2K",
+			MinImages:        1,
+			SizeMultipliers: map[string]float64{
+				"1K": 0.5,
+				"2K": 1.0,
+			},
+		},
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "ByteDance Seedream 5.0 Pro image generation and editing model with 1K and 2K output tiers.",
+	},
+	"google/nano-banana": {
+		Ratio: 0, CompletionRatio: 1.0, Image: replicateImageConfig(0.039),
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "Google Nano Banana (Gemini 2.5 Flash Image) generation and conversational editing model.",
+	},
+	"google/nano-banana-2-lite": {
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.034,
+			DefaultSize:      "1K",
+			MinImages:        1,
+		},
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "Google Nano Banana 2 Lite fast 1K image generation and editing model with multi-image references.",
+	},
+	"openai/gpt-image-1.5": {
+		// Replicate exposes quality tiers: auto/high $0.136, medium $0.05, low $0.013.
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.136,
+			DefaultQuality:   "auto",
+			MinImages:        1,
+			MaxImages:        10,
+			QualityMultipliers: map[string]float64{
+				"low":    0.013 / 0.136,
+				"medium": 0.05 / 0.136,
+				"high":   1.0,
+				"auto":   1.0,
+			},
+		},
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "OpenAI GPT Image 1.5 generation and editing model with low, medium, and high quality tiers.",
+	},
+	"recraft-ai/recraft-v4": {
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.04,
+			DefaultSize:      "1024x1024",
+			MinImages:        1,
+		},
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "Recraft V4 standard-resolution image generator focused on prompt accuracy and design quality.",
+	},
+	"recraft-ai/recraft-v4-pro": {
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.25,
+			DefaultSize:      "2048x2048",
+			MinImages:        1,
+		},
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "Recraft V4 Pro high-resolution image generator for print-ready and large-format output.",
+	},
+	"recraft-ai/recraft-v4.1": {
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.04,
+			DefaultSize:      "1024x1024",
+			MinImages:        1,
+		},
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "Recraft V4.1 standard-resolution image generator with art-directed composition and text rendering.",
+	},
+	"recraft-ai/recraft-v4.1-pro": {
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.25,
+			DefaultSize:      "2048x2048",
+			MinImages:        1,
+		},
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "Recraft V4.1 Pro high-resolution image generator for production-quality design assets.",
+	},
+	"recraft-ai/recraft-v4.1-utility": {
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.04,
+			DefaultSize:      "1024x1024",
+			MinImages:        1,
+		},
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "Recraft V4.1 Utility throughput-optimized standard-resolution image generator.",
+	},
+	"recraft-ai/recraft-v4.1-utility-pro": {
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.25,
+			DefaultSize:      "2048x2048",
+			MinImages:        1,
+		},
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "Recraft V4.1 Utility Pro throughput-optimized high-resolution image generator.",
+	},
+	"wan-video/wan-2.7-image": {
+		Ratio: 0, CompletionRatio: 1.0, Image: replicateImageConfig(0.03),
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "Wan 2.7 image generation and editing model with multi-reference and coherent image-set support.",
+	},
+	"wan-video/wan-2.7-image-pro": {
+		Ratio: 0, CompletionRatio: 1.0, Image: replicateImageConfig(0.03),
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "Wan 2.7 Image Pro generation and editing model with output up to 4K for text-to-image requests.",
+	},
+	"xai/grok-imagine-image": {
+		Ratio: 0, CompletionRatio: 1.0, Image: replicateImageConfig(0.02),
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "xAI Grok Imagine Image fast image generation and editing model with strong text rendering.",
+	},
+	"xai/grok-imagine-image-quality": {
+		// Replicate bills 1K outputs at $0.05 and 2K outputs at $0.07. Editing
+		// adds $0.01 per input image, which the current metadata schema cannot encode.
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.07,
+			DefaultSize:      "2k",
+			MinImages:        1,
+			SizeMultipliers: map[string]float64{
+				"1k": 0.05 / 0.07,
+				"2k": 1.0,
+			},
+		},
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "xAI Grok Imagine Image Quality high-fidelity generation and editing model with 1K and 2K tiers.",
+	},
+	"xai/grok-imagine-image-2": {
+		// Replicate bills $0.04 per output image and an additional $0.01 per input
+		// image for edits; the input-image surcharge is not representable here.
+		Ratio: 0, CompletionRatio: 1.0,
+		Image: &adaptor.ImagePricingConfig{
+			PricePerImageUsd: 0.04,
+			DefaultSize:      "2k",
+			DefaultQuality:   "medium",
+			MinImages:        1,
+		},
+		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
+		Description: "xAI Grok Imagine Image 2.0 generation and editing model with selectable quality and output up to 2K.",
+	},
+}

--- a/relay/adaptor/replicate/constants_image_official_additions.go
+++ b/relay/adaptor/replicate/constants_image_official_additions.go
@@ -49,7 +49,6 @@ var replicateOfficialImageAdditions = map[string]adaptor.ModelConfig{
 			PricePerImageUsd: 0.136,
 			DefaultQuality:   "auto",
 			MinImages:        1,
-			MaxImages:        10,
 			QualityMultipliers: map[string]float64{
 				"low":    0.013 / 0.136,
 				"medium": 0.05 / 0.136,

--- a/relay/adaptor/replicate/constants_image_official_additions.go
+++ b/relay/adaptor/replicate/constants_image_official_additions.go
@@ -2,10 +2,10 @@ package replicate
 
 import "github.com/Laisky/one-api/relay/adaptor"
 
-// replicateOfficialImageAdditions contains fixed-price Replicate Official image
-// endpoints that are absent from the original catalog snapshot. Models whose
-// current multi-property billing cannot be represented by ImagePricingConfig are
-// intentionally excluded rather than assigned an estimated price.
+// replicateOfficialImageAdditions contains Replicate Official image endpoints
+// whose deterministic output pricing can be represented by ImagePricingConfig.
+// Models or request modes with unrepresentable provider charges are intentionally
+// excluded rather than assigned an estimated or underpriced configuration.
 var replicateOfficialImageAdditions = map[string]adaptor.ModelConfig{
 	"black-forest-labs/flux-kontext-max": {
 		Ratio: 0, CompletionRatio: 1.0, Image: replicateImageConfig(0.08),
@@ -13,19 +13,20 @@ var replicateOfficialImageAdditions = map[string]adaptor.ModelConfig{
 		Description: "FLUX.1 Kontext [max] premium text-guided image editing model with improved typography.",
 	},
 	"bytedance/seedream-5-pro": {
-		// Replicate bills 1K outputs at $0.045 and 2K outputs at $0.09.
+		// Replicate also offers a discounted 1K tier, but the current relay does
+		// not forward Seedream's model-specific size field. Expose only the 2K
+		// upstream default so every accepted request is billed at provider cost.
 		Ratio: 0, CompletionRatio: 1.0,
 		Image: &adaptor.ImagePricingConfig{
 			PricePerImageUsd: 0.09,
 			DefaultSize:      "2K",
 			MinImages:        1,
 			SizeMultipliers: map[string]float64{
-				"1K": 0.5,
-				"2K": 1.0,
+				"2k": 1.0,
 			},
 		},
 		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
-		Description: "ByteDance Seedream 5.0 Pro image generation and editing model with 1K and 2K output tiers.",
+		Description: "ByteDance Seedream 5.0 Pro image generation and editing model using the upstream-default 2K output tier.",
 	},
 	"google/nano-banana": {
 		Ratio: 0, CompletionRatio: 1.0, Image: replicateImageConfig(0.039),
@@ -38,26 +39,29 @@ var replicateOfficialImageAdditions = map[string]adaptor.ModelConfig{
 			PricePerImageUsd: 0.034,
 			DefaultSize:      "1K",
 			MinImages:        1,
+			SizeMultipliers: map[string]float64{
+				"1k": 1.0,
+			},
 		},
 		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
 		Description: "Google Nano Banana 2 Lite fast 1K image generation and editing model with multi-image references.",
 	},
 	"openai/gpt-image-1.5": {
-		// Replicate exposes quality tiers: auto/high $0.136, medium $0.05, low $0.013.
+		// Replicate also offers discounted low and medium tiers, but the current
+		// relay does not forward the quality selector. Accept only auto/high,
+		// which share the $0.136 output price, to prevent underbilling.
 		Ratio: 0, CompletionRatio: 1.0,
 		Image: &adaptor.ImagePricingConfig{
 			PricePerImageUsd: 0.136,
 			DefaultQuality:   "auto",
 			MinImages:        1,
 			QualityMultipliers: map[string]float64{
-				"low":    0.013 / 0.136,
-				"medium": 0.05 / 0.136,
-				"high":   1.0,
-				"auto":   1.0,
+				"auto": 1.0,
+				"high": 1.0,
 			},
 		},
 		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
-		Description: "OpenAI GPT Image 1.5 generation and editing model with low, medium, and high quality tiers.",
+		Description: "OpenAI GPT Image 1.5 generation and editing model using the auto/high output price.",
 	},
 	"recraft-ai/recraft-v4": {
 		Ratio: 0, CompletionRatio: 1.0,
@@ -135,32 +139,39 @@ var replicateOfficialImageAdditions = map[string]adaptor.ModelConfig{
 		Description: "xAI Grok Imagine Image fast image generation and editing model with strong text rendering.",
 	},
 	"xai/grok-imagine-image-quality": {
-		// Replicate bills 1K outputs at $0.05 and 2K outputs at $0.07. Editing
-		// adds $0.01 per input image, which the current metadata schema cannot encode.
+		// Replicate also offers a discounted 1K tier and charges $0.01 per input
+		// image for edits. The current relay forwards neither the resolution field
+		// nor the edit surcharge, so expose only 2K text-to-image generation.
 		Ratio: 0, CompletionRatio: 1.0,
 		Image: &adaptor.ImagePricingConfig{
 			PricePerImageUsd: 0.07,
 			DefaultSize:      "2k",
 			MinImages:        1,
 			SizeMultipliers: map[string]float64{
-				"1k": 0.05 / 0.07,
 				"2k": 1.0,
 			},
 		},
-		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
-		Description: "xAI Grok Imagine Image Quality high-fidelity generation and editing model with 1K and 2K tiers.",
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "xAI Grok Imagine Image Quality high-fidelity text-to-image model using the upstream-default 2K tier.",
 	},
 	"xai/grok-imagine-image-2": {
-		// Replicate bills $0.04 per output image and an additional $0.01 per input
-		// image for edits; the input-image surcharge is not representable here.
+		// Replicate charges $0.01 per input image for edits. The current pricing
+		// schema cannot represent that surcharge, so expose generation only and
+		// restrict metadata to the upstream-default 2K/medium request settings.
 		Ratio: 0, CompletionRatio: 1.0,
 		Image: &adaptor.ImagePricingConfig{
 			PricePerImageUsd: 0.04,
 			DefaultSize:      "2k",
 			DefaultQuality:   "medium",
 			MinImages:        1,
+			SizeMultipliers: map[string]float64{
+				"2k": 1.0,
+			},
+			QualityMultipliers: map[string]float64{
+				"medium": 1.0,
+			},
 		},
-		InputModalities: imageEditInputs, OutputModalities: imageOutputs,
-		Description: "xAI Grok Imagine Image 2.0 generation and editing model with selectable quality and output up to 2K.",
+		InputModalities: imageInputs, OutputModalities: imageOutputs,
+		Description: "xAI Grok Imagine Image 2.0 text-to-image model using the upstream-default 2K medium-quality settings.",
 	},
 }

--- a/relay/adaptor/replicate/constants_image_test.go
+++ b/relay/adaptor/replicate/constants_image_test.go
@@ -6,7 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Ensure key Replicate image models have non-zero per-image pricing
+// TestReplicateImageModelPrices ensures representative Replicate image models
+// retain non-zero per-image pricing metadata.
 func TestReplicateImageModelPrices(t *testing.T) {
 	t.Parallel()
 	cases := []string{
@@ -20,4 +21,69 @@ func TestReplicateImageModelPrices(t *testing.T) {
 		require.NotNil(t, cfg.Image, "expected Image config for %s", model)
 		require.Greater(t, cfg.Image.PricePerImageUsd, float64(0), "expected price_per_image_usd > 0 for %s", model)
 	}
+}
+
+// TestReplicateOfficialImageAdditions verifies the refreshed official model
+// catalog, fixed output prices, advertised edit modality, and derived ModelList.
+func TestReplicateOfficialImageAdditions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		model        string
+		price        float64
+		supportsEdit bool
+	}{
+		{model: "black-forest-labs/flux-kontext-max", price: 0.08, supportsEdit: true},
+		{model: "bytedance/seedream-5-pro", price: 0.09, supportsEdit: true},
+		{model: "google/nano-banana", price: 0.039, supportsEdit: true},
+		{model: "google/nano-banana-2-lite", price: 0.034, supportsEdit: true},
+		{model: "openai/gpt-image-1.5", price: 0.136, supportsEdit: true},
+		{model: "recraft-ai/recraft-v4", price: 0.04},
+		{model: "recraft-ai/recraft-v4-pro", price: 0.25},
+		{model: "recraft-ai/recraft-v4.1", price: 0.04},
+		{model: "recraft-ai/recraft-v4.1-pro", price: 0.25},
+		{model: "recraft-ai/recraft-v4.1-utility", price: 0.04},
+		{model: "recraft-ai/recraft-v4.1-utility-pro", price: 0.25},
+		{model: "wan-video/wan-2.7-image", price: 0.03, supportsEdit: true},
+		{model: "wan-video/wan-2.7-image-pro", price: 0.03, supportsEdit: true},
+		{model: "xai/grok-imagine-image", price: 0.02, supportsEdit: true},
+		{model: "xai/grok-imagine-image-quality", price: 0.07, supportsEdit: true},
+		{model: "xai/grok-imagine-image-2", price: 0.04, supportsEdit: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, ok := ModelRatios[tt.model]
+			require.True(t, ok, "model %s not found in ModelRatios", tt.model)
+			require.Contains(t, ModelList, tt.model)
+			require.NotNil(t, cfg.Image)
+			require.InDelta(t, tt.price, cfg.Image.PricePerImageUsd, 1e-12)
+			require.Equal(t, []string{"image"}, cfg.OutputModalities)
+			if tt.supportsEdit {
+				require.Contains(t, cfg.InputModalities, "image")
+			}
+		})
+	}
+
+	seedream := ModelRatios["bytedance/seedream-5-pro"].Image
+	require.Equal(t, "2K", seedream.DefaultSize)
+	require.InDelta(t, 0.5, seedream.SizeMultipliers["1K"], 1e-12)
+	require.InDelta(t, 1.0, seedream.SizeMultipliers["2K"], 1e-12)
+
+	gptImage := ModelRatios["openai/gpt-image-1.5"].Image
+	require.Equal(t, "auto", gptImage.DefaultQuality)
+	require.Equal(t, 10, gptImage.MaxImages)
+	require.InDelta(t, 0.013/0.136, gptImage.QualityMultipliers["low"], 1e-12)
+	require.InDelta(t, 0.05/0.136, gptImage.QualityMultipliers["medium"], 1e-12)
+
+	grokQuality := ModelRatios["xai/grok-imagine-image-quality"].Image
+	require.Equal(t, "2k", grokQuality.DefaultSize)
+	require.InDelta(t, 0.05/0.07, grokQuality.SizeMultipliers["1k"], 1e-12)
+	require.InDelta(t, 1.0, grokQuality.SizeMultipliers["2k"], 1e-12)
+
+	grok2 := ModelRatios["xai/grok-imagine-image-2"].Image
+	require.Equal(t, "2k", grok2.DefaultSize)
+	require.Equal(t, "medium", grok2.DefaultQuality)
 }

--- a/relay/adaptor/replicate/constants_image_test.go
+++ b/relay/adaptor/replicate/constants_image_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 // TestReplicateImageModelPrices ensures representative Replicate image models
-// retain non-zero per-image pricing metadata.
+// retain non-zero per-image pricing metadata. The t parameter manages the test
+// lifecycle and assertions. This function returns no values.
 func TestReplicateImageModelPrices(t *testing.T) {
 	t.Parallel()
 	cases := []string{
@@ -24,7 +25,9 @@ func TestReplicateImageModelPrices(t *testing.T) {
 }
 
 // TestReplicateOfficialImageAdditions verifies the refreshed official model
-// catalog, fixed output prices, advertised edit modality, and derived ModelList.
+// catalog, safe output prices, advertised modalities, and derived ModelList. The
+// t parameter manages the test lifecycle and assertions. This function returns
+// no values.
 func TestReplicateOfficialImageAdditions(t *testing.T) {
 	t.Parallel()
 
@@ -47,8 +50,8 @@ func TestReplicateOfficialImageAdditions(t *testing.T) {
 		{model: "wan-video/wan-2.7-image", price: 0.03, supportsEdit: true},
 		{model: "wan-video/wan-2.7-image-pro", price: 0.03, supportsEdit: true},
 		{model: "xai/grok-imagine-image", price: 0.02, supportsEdit: true},
-		{model: "xai/grok-imagine-image-quality", price: 0.07, supportsEdit: true},
-		{model: "xai/grok-imagine-image-2", price: 0.04, supportsEdit: true},
+		{model: "xai/grok-imagine-image-quality", price: 0.07},
+		{model: "xai/grok-imagine-image-2", price: 0.04},
 	}
 
 	for _, tt := range tests {
@@ -63,26 +66,36 @@ func TestReplicateOfficialImageAdditions(t *testing.T) {
 			require.Equal(t, []string{"image"}, cfg.OutputModalities)
 			if tt.supportsEdit {
 				require.Contains(t, cfg.InputModalities, "image")
+			} else {
+				require.NotContains(t, cfg.InputModalities, "image")
 			}
 		})
 	}
 
 	seedream := ModelRatios["bytedance/seedream-5-pro"].Image
 	require.Equal(t, "2K", seedream.DefaultSize)
-	require.InDelta(t, 0.5, seedream.SizeMultipliers["1K"], 1e-12)
-	require.InDelta(t, 1.0, seedream.SizeMultipliers["2K"], 1e-12)
+	require.NotContains(t, seedream.SizeMultipliers, "1k")
+	require.InDelta(t, 1.0, seedream.SizeMultipliers["2k"], 1e-12)
+
+	nanoBananaLite := ModelRatios["google/nano-banana-2-lite"].Image
+	require.Equal(t, "1K", nanoBananaLite.DefaultSize)
+	require.InDelta(t, 1.0, nanoBananaLite.SizeMultipliers["1k"], 1e-12)
 
 	gptImage := ModelRatios["openai/gpt-image-1.5"].Image
 	require.Equal(t, "auto", gptImage.DefaultQuality)
-	require.InDelta(t, 0.013/0.136, gptImage.QualityMultipliers["low"], 1e-12)
-	require.InDelta(t, 0.05/0.136, gptImage.QualityMultipliers["medium"], 1e-12)
+	require.NotContains(t, gptImage.QualityMultipliers, "low")
+	require.NotContains(t, gptImage.QualityMultipliers, "medium")
+	require.InDelta(t, 1.0, gptImage.QualityMultipliers["auto"], 1e-12)
+	require.InDelta(t, 1.0, gptImage.QualityMultipliers["high"], 1e-12)
 
 	grokQuality := ModelRatios["xai/grok-imagine-image-quality"].Image
 	require.Equal(t, "2k", grokQuality.DefaultSize)
-	require.InDelta(t, 0.05/0.07, grokQuality.SizeMultipliers["1k"], 1e-12)
+	require.NotContains(t, grokQuality.SizeMultipliers, "1k")
 	require.InDelta(t, 1.0, grokQuality.SizeMultipliers["2k"], 1e-12)
 
 	grok2 := ModelRatios["xai/grok-imagine-image-2"].Image
 	require.Equal(t, "2k", grok2.DefaultSize)
 	require.Equal(t, "medium", grok2.DefaultQuality)
+	require.InDelta(t, 1.0, grok2.SizeMultipliers["2k"], 1e-12)
+	require.InDelta(t, 1.0, grok2.QualityMultipliers["medium"], 1e-12)
 }

--- a/relay/adaptor/replicate/constants_image_test.go
+++ b/relay/adaptor/replicate/constants_image_test.go
@@ -74,7 +74,6 @@ func TestReplicateOfficialImageAdditions(t *testing.T) {
 
 	gptImage := ModelRatios["openai/gpt-image-1.5"].Image
 	require.Equal(t, "auto", gptImage.DefaultQuality)
-	require.Equal(t, 10, gptImage.MaxImages)
 	require.InDelta(t, 0.013/0.136, gptImage.QualityMultipliers["low"], 1e-12)
 	require.InDelta(t, 0.05/0.136, gptImage.QualityMultipliers["medium"], 1e-12)
 

--- a/relay/adaptor/replicate/constants_language_adjustments.go
+++ b/relay/adaptor/replicate/constants_language_adjustments.go
@@ -1,0 +1,30 @@
+package replicate
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	ratio "github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// replicateLanguagePricingAdjustments contains temporary provider promotions
+// that must not replace a model's long-lived base pricing. Each entry is merged
+// into the corresponding model after the base language catalog is copied.
+var replicateLanguagePricingAdjustments = map[string][]adaptor.TimeWindow{
+	"openai/gpt-5.6-sol": {
+		{
+			Name:     "replicate-gpt-5.6-sol-50-percent-promotion",
+			TimeZone: "UTC",
+			DateFrom: "2026-09-04",
+			// DateTo is exclusive, so 2026-09-19 keeps the published discount
+			// active through all of 2026-09-18 before reverting to base pricing.
+			DateTo: "2026-09-19",
+			Ranges: []adaptor.ClockRange{
+				{Start: "00:00", End: "00:00"},
+			},
+			Overlay: adaptor.ModelConfig{
+				Ratio:              2.50 * ratio.MilliTokensUsd,
+				CachedInputRatio:   0.25 * ratio.MilliTokensUsd,
+				CompletionRatio:    15.00 / 2.50,
+			},
+		},
+	},
+}

--- a/relay/adaptor/replicate/constants_language_adjustments.go
+++ b/relay/adaptor/replicate/constants_language_adjustments.go
@@ -21,9 +21,9 @@ var replicateLanguagePricingAdjustments = map[string][]adaptor.TimeWindow{
 				{Start: "00:00", End: "00:00"},
 			},
 			Overlay: adaptor.ModelConfig{
-				Ratio:              2.50 * ratio.MilliTokensUsd,
-				CachedInputRatio:   0.25 * ratio.MilliTokensUsd,
-				CompletionRatio:    15.00 / 2.50,
+				Ratio:            2.50 * ratio.MilliTokensUsd,
+				CompletionRatio:  15.00 / 2.50,
+				CachedInputRatio: 0.25 * ratio.MilliTokensUsd,
 			},
 		},
 	},

--- a/relay/adaptor/replicate/constants_language_adjustments_test.go
+++ b/relay/adaptor/replicate/constants_language_adjustments_test.go
@@ -1,0 +1,34 @@
+package replicate_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor/replicate"
+	ratio "github.com/Laisky/one-api/relay/billing/ratio"
+	"github.com/Laisky/one-api/relay/pricing"
+)
+
+// TestGPT56SolPromotionWindow verifies that the temporary Replicate discount is
+// active through 2026-09-18 and that long-lived base pricing resumes on
+// 2026-09-19. The t parameter manages the test lifecycle and assertions. This
+// function returns no values.
+func TestGPT56SolPromotionWindow(t *testing.T) {
+	t.Parallel()
+
+	config, ok := replicate.ModelRatios["openai/gpt-5.6-sol"]
+	require.True(t, ok)
+	require.Len(t, config.TimeWindows, 1)
+
+	active := pricing.ApplyTimeWindowRatioOnly(config, time.Date(2026, time.September, 18, 23, 59, 0, 0, time.UTC))
+	require.InDelta(t, 2.50*ratio.MilliTokensUsd, active.Ratio, 1e-12)
+	require.InDelta(t, 0.25*ratio.MilliTokensUsd, active.CachedInputRatio, 1e-12)
+	require.InDelta(t, 15.00/2.50, active.CompletionRatio, 1e-12)
+
+	expired := pricing.ApplyTimeWindowRatioOnly(config, time.Date(2026, time.September, 19, 0, 0, 0, 0, time.UTC))
+	require.InDelta(t, 5.00*ratio.MilliTokensUsd, expired.Ratio, 1e-12)
+	require.InDelta(t, 0.50*ratio.MilliTokensUsd, expired.CachedInputRatio, 1e-12)
+	require.InDelta(t, 30.00/5.00, expired.CompletionRatio, 1e-12)
+}


### PR DESCRIPTION
## Summary

- add 16 current Replicate Official image endpoints that were missing from the adaptor catalog
- encode verified output-image prices and generation/editing modalities
- constrain metadata to request tiers the current relay can bill safely; discounted selectors that are not forwarded upstream are rejected instead of underpriced
- encode Replicate's temporary 50% `openai/gpt-5.6-sol` promotion as a date-bounded pricing window that automatically expires after 2026-09-18
- refresh the catalog source date and add table-driven regression coverage

## Added image models

- `black-forest-labs/flux-kontext-max`
- `bytedance/seedream-5-pro`
- `google/nano-banana`
- `google/nano-banana-2-lite`
- `openai/gpt-image-1.5`
- `recraft-ai/recraft-v4`
- `recraft-ai/recraft-v4-pro`
- `recraft-ai/recraft-v4.1`
- `recraft-ai/recraft-v4.1-pro`
- `recraft-ai/recraft-v4.1-utility`
- `recraft-ai/recraft-v4.1-utility-pro`
- `wan-video/wan-2.7-image`
- `wan-video/wan-2.7-image-pro`
- `xai/grok-imagine-image`
- `xai/grok-imagine-image-quality`
- `xai/grok-imagine-image-2`

## Pricing and capability notes

- model identifiers, defaults, modalities, and prices were checked against Replicate's official collection, model, and schema pages on 2026-09-04
- Replicate collection pages were used only for additive discovery; existing models were not removed merely because they were absent from a collection
- the existing language catalog already contains Replicate's current GPT-5.6 Sol, Terra, and Luna identifiers; this PR adds the currently published Sol promotion without replacing its long-lived base price
- `google/nano-banana-2` and `google/nano-banana-pro` remain excluded because their complete current multi-property billing could not be represented and verified without estimates
- Seedream 5 Pro exposes only its upstream-default 2K price until the relay forwards the provider-specific `size` field
- GPT Image 1.5 accepts only the equally priced `auto`/`high` metadata tiers until the relay forwards `quality`; discounted `low`/`medium` requests are rejected to prevent underbilling
- Grok Image Quality exposes only its upstream-default 2K generation tier; Grok Image Quality and Grok Image 2 do not advertise editing because Replicate charges an additional `$0.01` per input image that the current pricing schema cannot encode
- upstream multi-output support is not advertised where the current Replicate relay still enforces `n=1`

## Validation

- kept modified Go files in `gofmt` form
- added table-driven assertions for all new model IDs, output prices, model-list inclusion, modalities, defaults, normalized tier keys, and underbilling guardrails
- added a boundary test proving the GPT-5.6 Sol promotion is active through 2026-09-18 and base pricing resumes on 2026-09-19
- repository-level CI is rerunning against the latest commit
