### PR TITLE
feat(openai): add GPT Image 2.5 Sunburst and Flare model information

### DIFF
--- a/.github/workflows/image-billing-regression.yml
+++ b/.github/workflows/image-billing-regression.yml
@@ -1,0 +1,40 @@
+name: Image billing regression
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - '.github/workflows/image-billing-regression.yml'
+      - 'relay/controller/image*.go'
+      - 'relay/adaptor/openai/constants*.go'
+      - 'relay/adaptor/openai/image*.go'
+      - 'relay/adaptor/openai/model.go'
+      - 'relay/model/*.go'
+      - 'relay/billing/ratio/*.go'
+      - 'model/token*.go'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-billing-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image-billing:
+    name: GPT Image billing behavior
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+      - name: Set up Go
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Run image billing regressions
+        env:
+          CGO_ENABLED: '1'
+        run: go test -race -count=1 -timeout=5m ./relay/adaptor/openai ./relay/controller -run 'Test(GPTImage25|Image)'

--- a/.github/workflows/image-billing-regression.yml
+++ b/.github/workflows/image-billing-regression.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v7.0.0
         with:

--- a/docs/usage/openai-image25-billing.md
+++ b/docs/usage/openai-image25-billing.md
@@ -1,0 +1,73 @@
+# GPT Image 2.5 billing
+
+Applies to `gpt-image-2.5-sunburst`, `gpt-image-2.5-flare`, and their
+`2026-09-08` snapshots on the existing Images API path.
+
+## Configure before enabling traffic
+
+The catalog contains official token prices, not an official per-image price.
+OpenAI warns against copying GPT Image 2 per-image estimates to these models.
+A one-token estimate is not a safe image reservation.
+
+For each enabled ID, explicitly set its `image.price_per_image_usd` in the
+channel's existing `model_configs`. For this family only, this field is an
+**operator-defined advance reservation and incomplete-usage fallback tariff**,
+not an additional render fee. Choose it for the image counts, sizes, and quality
+levels offered by the channel. No default dollar amount is invented by the relay.
+A price-only override preserves the catalog request defaults (`auto` size/quality,
+32,000-character prompt, and 1–10 images) instead of reverting to legacy defaults.
+An absent, nonpositive, nonfinite, or unrepresentable reservation produces
+`503 image_billing_not_configured` before any paid upstream request.
+
+Reservation is `ceil(tariff × tier × group multiplier × quota/USD)` per image,
+multiplied by the requested count. Both user and limited-token quota use the
+existing pre-consumption path before HTTP dispatch. This is an advance estimate,
+not a provider cost ceiling: actual usage can exceed it and require an additional
+debit under the existing quota policy. Configure adequate reserves and balances.
+
+## Settlement
+
+With billable output usage, the token charge **replaces** the advance reservation.
+Unused reserved quota is refunded using a signed post-consumption adjustment.
+No fixed render fee is added. The original model rates and settlement rules for
+older image models remain unchanged.
+
+The Images response decoder preserves `cached_tokens` and
+`cached_tokens_details.{text_tokens,image_tokens}`. Explicit cache buckets are
+used as reported, not apportioned by the ratio of total text/image input.
+Single-modality aggregate cache counts can be allocated exactly. Mixed-modality
+cached input with no split, inconsistent counts, or missing output usage is not
+presented as a measured token charge: settlement retains the configured fallback.
+Logs distinguish `billing_source=provider_tokens` from `configured_fallback` and
+record the reserved amount separately.
+
+For compatible endpoints with input totals but incomplete modality details,
+unclassified input is billed at the text-input rate instead of being discarded.
+This is a compatibility pricing fallback, not a claim about the actual modality;
+accurate mixed-modality billing requires a complete upstream breakdown.
+
+Existing upstream-error/refund handling is preserved. This change does not add
+streaming image generation or the Responses image-generation tool.
+
+## Behavioral regression coverage
+
+`image25_review_test.go` covers wire JSON conversion, asymmetric caches,
+totals-only/partial input, ambiguous usage, and reservation replacement.
+`image25_relay_review_test.go` uses a local HTTP upstream and SQLite to verify
+admission, physical pre-debits, signed refunds, and persisted log/request costs.
+`image25_policy_test.go` covers invalid reservation values and delta boundaries.
+
+Run the focused CI gate locally with the repository's Go toolchain:
+
+```sh
+go test -race -count=1 -timeout=5m ./relay/adaptor/openai ./relay/controller -run 'Test(GPTImage25|Image)'
+```
+
+The dedicated workflow does not replace the existing full vet, race-test, or
+frontend gates. Tests use local fixtures; no paid OpenAI request is required.
+
+Sources checked 2026-09-09:
+- https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
+- https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
+- https://developers.openai.com/api/reference/resources/images/methods/generate
+- https://developers.openai.com/api/docs/guides/image-generation

--- a/docs/usage/openai-image25-billing.md
+++ b/docs/usage/openai-image25-billing.md
@@ -16,6 +16,7 @@ not an additional render fee. Choose it for the image counts, sizes, and quality
 levels offered by the channel. No default dollar amount is invented by the relay.
 A price-only override preserves the catalog request defaults (`auto` size/quality,
 32,000-character prompt, and 1–10 images) instead of reverting to legacy defaults.
+The prompt limit counts Unicode code points, not UTF-8 bytes.
 An absent, nonpositive, nonfinite, or unrepresentable reservation produces
 `503 image_billing_not_configured` before any paid upstream request.
 
@@ -25,12 +26,21 @@ existing pre-consumption path before HTTP dispatch. This is an advance estimate,
 not a provider cost ceiling: actual usage can exceed it and require an additional
 debit under the existing quota policy. Configure adequate reserves and balances.
 
-## Settlement
+## Settlement and channel pricing
 
 With billable output usage, the token charge **replaces** the advance reservation.
 Unused reserved quota is refunded using a signed post-consumption adjustment.
-No fixed render fee is added. The original model rates and settlement rules for
-older image models remain unchanged.
+No fixed render fee is added. The existing tariff tables and settlement formulas
+for older image models are retained.
+
+Channel token prices are resolved at request start, including existing time-window
+rules; usage-based tiers are selected during settlement. `ratio` prices text input,
+`completion_ratio` multiplies it for output, and `cached_input_ratio` prices cached
+text. The existing `image.prompt_ratio` multiplies both uncached and cached text
+rates for the corresponding image-input buckets. This schema has no independent
+cached-image price field. Missing optional overrides inherit provider defaults;
+negative cached-input pricing retains the existing free-cache convention.
+Configuring only a reservation does not replace official token rates with zeros.
 
 The Images response decoder preserves `cached_tokens` and
 `cached_tokens_details.{text_tokens,image_tokens}`. Explicit cache buckets are
@@ -54,8 +64,10 @@ streaming image generation or the Responses image-generation tool.
 `image25_review_test.go` covers wire JSON conversion, asymmetric caches,
 totals-only/partial input, ambiguous usage, and reservation replacement.
 `image25_relay_review_test.go` uses a local HTTP upstream and SQLite to verify
-admission, physical pre-debits, signed refunds, and persisted log/request costs.
-`image25_policy_test.go` covers invalid reservation values and delta boundaries.
+admission, physical pre-debits, signed refunds, channel token-price overrides,
+and persisted log/request costs. `image25_unicode_review_test.go` covers ASCII,
+CJK, and emoji at and beyond the character boundary. `image25_policy_test.go`
+covers invalid reservation values, defaults, and delta boundaries.
 
 Run the focused CI gate locally with the repository's Go toolchain:
 

--- a/relay/adaptor/openai/constants.go
+++ b/relay/adaptor/openai/constants.go
@@ -9,7 +9,7 @@ import (
 // per-family files stay focused and readable. Model list is derived from the keys of
 // this map, eliminating redundancy.
 //
-// Pricing sources verified 2026-09-03:
+// Pricing sources verified 2026-09-03; GPT Image 2.5 additions verified 2026-09-09:
 //   - https://developers.openai.com/api/docs/pricing
 //   - https://developers.openai.com/api/docs/models
 var ModelRatios = applyOpenAIModelCatalog202609(mergeModelRatios(
@@ -26,6 +26,7 @@ var ModelRatios = applyOpenAIModelCatalog202609(mergeModelRatios(
 	embeddingModelRatios,
 	audioModelRatios,
 	imageModelRatios,
+	image25ModelRatios,
 	videoModelRatios,
 ))
 

--- a/relay/adaptor/openai/constants_image25.go
+++ b/relay/adaptor/openai/constants_image25.go
@@ -1,0 +1,53 @@
+package openai
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// image25ModelRatios describes the GPT Image 2.5 aliases and official snapshots.
+// Sources verified 2026-09-09:
+//   - https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
+//   - https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
+//   - https://developers.openai.com/api/docs/guides/image-generation
+//   - https://developers.openai.com/api/reference/resources/images/methods/generate
+//
+// Both models charge USD 5/1.25 per million uncached/cached text input tokens,
+// USD 8/2 per million uncached/cached image input tokens, and USD 30 per million
+// image output tokens. The image controller maintains these five billing buckets.
+// Equal token rates do not imply equal costs per image. Do not copy GPT Image 2
+// render estimates or add a fixed render fee on top of actual output-token usage.
+var image25ModelRatios = map[string]adaptor.ModelConfig{
+	"gpt-image-2.5-sunburst": newGPTImage25Config(
+		"GPT Image 2.5 Sunburst: high-quality image generation and precision editing; supports low, medium, high, xhigh, max, and auto quality."),
+	"gpt-image-2.5-sunburst-2026-09-08": newGPTImage25Config(
+		"GPT Image 2.5 Sunburst snapshot (2026-09-08): high-quality image generation and precision editing; supports low, medium, high, xhigh, max, and auto quality."),
+	"gpt-image-2.5-flare": newGPTImage25Config(
+		"GPT Image 2.5 Flare: fast, high-quality everyday image generation and editing; supports low, medium, high, xhigh, max, and auto quality."),
+	"gpt-image-2.5-flare-2026-09-08": newGPTImage25Config(
+		"GPT Image 2.5 Flare snapshot (2026-09-08): fast, high-quality everyday image generation and editing; supports low, medium, high, xhigh, max, and auto quality."),
+}
+
+// newGPTImage25Config creates independent metadata for one GPT Image 2.5 model.
+// Parameters: description identifies the alias or snapshot. Returns: token-only
+// pricing and Image API defaults without undocumented context or output limits.
+func newGPTImage25Config(description string) adaptor.ModelConfig {
+	return adaptor.ModelConfig{
+		Ratio:            5 * billingratio.MilliTokensUsd,
+		CachedInputRatio: 1.25 * billingratio.MilliTokensUsd,
+		CompletionRatio:  30.0 / 5.0, // Image output, not text output.
+		Image: &adaptor.ImagePricingConfig{
+			// Leave PricePerImageUsd and tier multipliers unset: the controller
+			// reconciles actual image-token usage instead of a fixed render fee.
+			PromptRatio:      8.0 / 5.0,
+			DefaultSize:      "auto",
+			DefaultQuality:   "auto",
+			PromptTokenLimit: 32000, // Image API prompt-length limit; not context tokens.
+			MinImages:        1,
+			MaxImages:        10,
+		},
+		InputModalities:  []string{"text", "image"},
+		OutputModalities: []string{"image"},
+		Description:      description,
+	}
+}

--- a/relay/adaptor/openai/constants_image25_test.go
+++ b/relay/adaptor/openai/constants_image25_test.go
@@ -1,0 +1,78 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// TestGPTImage25Catalog verifies the four documented aliases and snapshots.
+// Parameters: t is the test runner. Returns: none; inconsistent metadata fails the test.
+func TestGPTImage25Catalog(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		"gpt-image-2.5-sunburst",
+		"gpt-image-2.5-sunburst-2026-09-08",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-flare-2026-09-08",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg, ok := ModelRatios[name]
+			require.True(t, ok)
+			require.Contains(t, ModelList, name)
+			require.InDelta(t, 5*billingratio.MilliTokensUsd, cfg.Ratio, 1e-12)
+			require.InDelta(t, 1.25*billingratio.MilliTokensUsd, cfg.CachedInputRatio, 1e-12)
+			require.InDelta(t, 30*billingratio.MilliTokensUsd, cfg.Ratio*cfg.CompletionRatio, 1e-12)
+			require.Equal(t, []string{"text", "image"}, cfg.InputModalities)
+			require.Equal(t, []string{"image"}, cfg.OutputModalities)
+			require.Zero(t, cfg.ContextLength, "do not invent a context window")
+			require.Zero(t, cfg.MaxOutputTokens, "do not invent an output-token limit")
+			require.Empty(t, cfg.SupportedReasoningEfforts)
+			require.Empty(t, cfg.SupportedFeatures)
+			require.Empty(t, cfg.Tiers)
+			require.NotEmpty(t, cfg.Description)
+
+			require.NotNil(t, cfg.Image)
+			require.True(t, cfg.Image.HasData(), "token-only image metadata must remain discoverable")
+			require.Zero(t, cfg.Image.PricePerImageUsd, "actual output-token billing must not add a render fee")
+			require.InDelta(t, 8.0/5.0, cfg.Image.PromptRatio, 1e-12)
+			require.Equal(t, "auto", cfg.Image.DefaultSize)
+			require.Equal(t, "auto", cfg.Image.DefaultQuality)
+			require.Equal(t, 32000, cfg.Image.PromptTokenLimit)
+			require.Equal(t, 1, cfg.Image.MinImages)
+			require.Equal(t, 10, cfg.Image.MaxImages)
+			require.Empty(t, cfg.Image.SizeMultipliers)
+			require.Empty(t, cfg.Image.QualityMultipliers)
+			require.Empty(t, cfg.Image.QualitySizeMultipliers)
+		})
+	}
+}
+
+// TestGPTImage25SnapshotParity verifies that snapshots retain their alias metadata.
+// Parameters: t is the test runner. Returns: none; unexpected differences fail the test.
+func TestGPTImage25SnapshotParity(t *testing.T) {
+	t.Parallel()
+	for _, alias := range []string{"gpt-image-2.5-sunburst", "gpt-image-2.5-flare"} {
+		base := ModelRatios[alias]
+		snapshot := ModelRatios[alias+"-2026-09-08"]
+		base.Description = ""
+		snapshot.Description = ""
+		require.Equal(t, base, snapshot, alias)
+	}
+}
+
+// TestNewGPTImage25ConfigIsolation verifies that configurations do not share mutable state.
+// Parameters: t is the test runner. Returns: none; shared pointers or slices fail the test.
+func TestNewGPTImage25ConfigIsolation(t *testing.T) {
+	t.Parallel()
+	first := newGPTImage25Config("first")
+	second := newGPTImage25Config("second")
+	first.Image.DefaultQuality = "high"
+	first.InputModalities[0] = "modified"
+	first.OutputModalities[0] = "modified"
+	require.Equal(t, "auto", second.Image.DefaultQuality)
+	require.Equal(t, []string{"text", "image"}, second.InputModalities)
+	require.Equal(t, []string{"image"}, second.OutputModalities)
+}

--- a/relay/adaptor/openai/model.go
+++ b/relay/adaptor/openai/model.go
@@ -246,19 +246,24 @@ type ImageUsage struct {
 
 // ImageUsageInputTokensDetails is the details of input tokens for image request
 type ImageUsageInputTokensDetails struct {
-	TextTokens  int `json:"text_tokens"`
-	ImageTokens int `json:"image_tokens"`
+	CachedTokens        int                             `json:"cached_tokens,omitempty"`
+	CachedTokensDetails *model.UsageCachedTokensDetails `json:"cached_tokens_details,omitempty"`
+	TextTokens          int                             `json:"text_tokens"`
+	ImageTokens         int                             `json:"image_tokens"`
 }
 
-// Convert2GeneralUsage converts ImageUsage to model.Usage
+// Convert2GeneralUsage preserves image token totals and cached modality buckets.
+// Parameters: u is the decoded Images API usage. Returns: normalized relay usage.
 func (u *ImageUsage) Convert2GeneralUsage() *model.Usage {
 	return &model.Usage{
 		PromptTokens:     u.InputTokens,
 		CompletionTokens: u.OutputTokens,
 		TotalTokens:      u.TotalTokens,
 		PromptTokensDetails: &model.UsagePromptTokensDetails{
-			ImageTokens: u.InputTokensDetails.ImageTokens,
-			TextTokens:  u.InputTokensDetails.TextTokens,
+			CachedTokens:        u.InputTokensDetails.CachedTokens,
+			CachedTokensDetails: u.InputTokensDetails.CachedTokensDetails,
+			ImageTokens:         u.InputTokensDetails.ImageTokens,
+			TextTokens:          u.InputTokensDetails.TextTokens,
 		},
 	}
 }

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -67,6 +66,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	}
 
 	imagePricingCfg, _ := pricing.ResolveImagePricing(imageRequest.Model, channelModelConfigs, adaptor, meta.StartTime)
+	imagePricingCfg = completeGPTImage25Defaults(imageRequest.Model, imagePricingCfg)
 	applyImageDefaults(imageRequest, imagePricingCfg)
 
 	bizErr := validateImageRequest(imageRequest, meta, imagePricingCfg)
@@ -160,7 +160,8 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		imageCostRatio = override
 	}
 
-	// Determine if this model is billed per image (Image.PricePerImageUsd) or per token (Ratio)
+	// PricePerImageUsd is a render price for legacy models, but an explicit
+	// reservation/fallback tariff for GPT Image 2.5 (see docs/usage/openai-image25-billing.md).
 	imagePriceUsd := 0.0
 	if imagePricingCfg != nil {
 		imagePriceUsd = imagePricingCfg.PricePerImageUsd
@@ -174,6 +175,9 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 	billedCount := requestedCount
 	if meta.ChannelType == channeltype.Replicate && billedCount > 1 {
 		billedCount = 1
+	}
+	if err := validateGPTImage25Billing(imageModel, imagePriceUsd, imageCostRatio, groupRatio, billedCount); err != nil {
+		return openai.ErrorWrapper(err, "image_billing_not_configured", http.StatusServiceUnavailable)
 	}
 	perImageBilling := imagePriceUsd > 0
 	baseQuota := calculateImageBaseQuota(imagePriceUsd, ratio, imageCostRatio, groupRatio, billedCount)
@@ -191,7 +195,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		return openai.ErrorWrapper(errors.New("user quota is not enough"), "insufficient_user_quota", http.StatusForbidden)
 	}
 
-	// If using per-image billing, pre-consume the estimated quota now
+	// Pre-consume legacy render charges or the configured GPT Image 2.5 reserve.
 	if perImageBilling && usedQuota > 0 {
 		preConsumedQuota = usedQuota
 		if err := model.PreConsumeTokenQuota(ctx, meta.TokenId, preConsumedQuota); err != nil {
@@ -250,13 +254,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 
 		// Post-billing: reconcile pre-consumed quota with actual usage
 		markBillingReconciled(c)
-		quotaDelta := usedQuota
-		if preConsumedQuota > 0 {
-			quotaDelta = usedQuota - preConsumedQuota
-		}
-		if quotaDelta < 0 {
-			quotaDelta = 0
-		}
+		quotaDelta := imagePostConsumeDelta(imageModel, usedQuota, preConsumedQuota)
 		err := model.PostConsumeTokenQuota(bgCtx, meta.TokenId, quotaDelta)
 		if err != nil {
 			lg.Error("error consuming token remain quota", zap.Error(err))
@@ -361,7 +359,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		promptTokens = usage.PromptTokens
 		completionTokens = usage.CompletionTokens
 
-		// Universal reconciliation: if we have reliable usage, compute token quota and add it to per-image base.
+		// Reconcile provider usage using the model-specific render/reservation policy.
 		summary := finalizeImageQuota(baseQuota, perImageBilling, imageModel, meta.ActualModelName, usage, groupRatio)
 		tokenQuota = summary.TokenQuota
 		tokenQuotaFloat = summary.TokenQuotaFloat
@@ -437,291 +435,6 @@ func reconcileImageFailureBilling(
 	}
 }
 
-// gptImageTokenBucketPricing stores USD per 1M token prices for GPT Image models.
-type gptImageTokenBucketPricing struct {
-	inputTextUSD        float64
-	cachedInputTextUSD  float64
-	inputImageUSD       float64
-	cachedInputImageUSD float64
-	outputImageUSD      float64
-}
-
-var gptImageTokenBucketPrices = map[string]gptImageTokenBucketPricing{
-	// https://platform.openai.com/docs/models/gpt-image-1
-	"gpt-image-1": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       10.0,
-		cachedInputImageUSD: 2.5,
-		outputImageUSD:      40.0,
-	},
-	// https://platform.openai.com/docs/models/gpt-image-1-mini
-	"gpt-image-1-mini": {
-		inputTextUSD:        2.0,
-		cachedInputTextUSD:  0.20,
-		inputImageUSD:       2.5,
-		cachedInputImageUSD: 0.25,
-		outputImageUSD:      8.0,
-	},
-	// https://platform.openai.com/docs/models/chatgpt-image-latest
-	"chatgpt-image-latest": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      32.0,
-	},
-	// https://platform.openai.com/docs/models/gpt-image-1.5
-	"gpt-image-1.5": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      32.0,
-	},
-	"gpt-image-1.5-2025-12-16": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      32.0,
-	},
-	// https://platform.openai.com/docs/models/gpt-image-2
-	"gpt-image-2": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      30.0,
-	},
-	"gpt-image-2-2026-04-21": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      30.0,
-	},
-	// GPT Image 2.5 token rates verified 2026-09-09 (not per-image estimates).
-	// https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
-	// https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
-	"gpt-image-2.5-sunburst": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      30.0,
-	},
-	"gpt-image-2.5-sunburst-2026-09-08": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      30.0,
-	},
-	"gpt-image-2.5-flare": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      30.0,
-	},
-	"gpt-image-2.5-flare-2026-09-08": {
-		inputTextUSD:        5.0,
-		cachedInputTextUSD:  1.25,
-		inputImageUSD:       8.0,
-		cachedInputImageUSD: 2.0,
-		outputImageUSD:      30.0,
-	},
-}
-
-// computeGptImageTokenQuota calculates quota for GPT image family models using five billing buckets:
-// input text, cached input text, input image, cached input image, and output image tokens.
-// Prices are expressed in USD per 1M tokens and multiplied by the groupRatio (quota multiplier) before returning quota units.
-func computeGptImageTokenQuota(modelName string, usage *relaymodel.Usage, groupRatio float64) float64 {
-	if usage == nil {
-		return 0
-	}
-	pricing, ok := gptImageTokenBucketPrices[modelName]
-	if !ok {
-		return 0
-	}
-
-	var textIn, imageIn, cachedIn int
-	if usage.PromptTokensDetails != nil {
-		textIn = usage.PromptTokensDetails.TextTokens
-		imageIn = usage.PromptTokensDetails.ImageTokens
-		cachedIn = usage.PromptTokensDetails.CachedTokens
-	}
-	if textIn < 0 {
-		textIn = 0
-	}
-	if imageIn < 0 {
-		imageIn = 0
-	}
-	if cachedIn < 0 {
-		cachedIn = 0
-	}
-	totalIn := textIn + imageIn
-	if cachedIn > totalIn {
-		cachedIn = totalIn
-	}
-	cachedText := 0
-	cachedImage := 0
-	if cachedIn > 0 && totalIn > 0 {
-		cachedText = min(max(int(math.Round(float64(cachedIn)*(float64(textIn)/float64(totalIn)))), 0), cachedIn)
-		cachedImage = cachedIn - cachedText
-	}
-	normalText := max(textIn-cachedText, 0)
-	normalImage := max(imageIn-cachedImage, 0)
-	outTokens := max(usage.CompletionTokens, 0)
-
-	quota := 0.0
-	quota += float64(normalText) * pricing.inputTextUSD * billingratio.MilliTokensUsd
-	quota += float64(cachedText) * pricing.cachedInputTextUSD * billingratio.MilliTokensUsd
-	quota += float64(normalImage) * pricing.inputImageUSD * billingratio.MilliTokensUsd
-	quota += float64(cachedImage) * pricing.cachedInputImageUSD * billingratio.MilliTokensUsd
-	quota += float64(outTokens) * pricing.outputImageUSD * billingratio.MilliTokensUsd
-
-	if groupRatio > 0 {
-		quota *= groupRatio
-	}
-	return quota
-}
-
-// computeImageUsageQuota routes to the correct usage-based cost function per model.
-// Returns 0 when usage is missing or the model has no token pricing rule.
-func computeImageUsageQuota(modelName string, usage *relaymodel.Usage, groupRatio float64) float64 {
-	if usage == nil {
-		return 0
-	}
-	// Basic reliability check: some providers may omit usage entirely
-	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && (usage.PromptTokensDetails == nil) {
-		return 0
-	}
-	// The bucket table is the allowlist; keep dispatch in sync with every priced
-	// alias and snapshot without maintaining a second model-name list.
-	return computeGptImageTokenQuota(modelName, usage, groupRatio)
-}
-
-// imageQuotaSummary tracks the breakdown of image billing across fixed per-image components and token-based usage.
-type imageQuotaSummary struct {
-	BaseQuota       int64
-	TokenQuota      int64
-	TokenQuotaFloat float64
-	TotalQuota      int64
-}
-
-// calculateImageBaseQuota derives the upfront quota reservation for an image request.
-// When per-image billing is enabled, the quota scales with the billed image count and tier multiplier.
-// For token-only models, the base quota falls back to the model ratio estimation.
-func calculateImageBaseQuota(imagePriceUsd, ratio, imageCostRatio, groupRatio float64, count int) int64 {
-	if count <= 0 {
-		return 0
-	}
-	if imagePriceUsd > 0 {
-		perImageQuota := math.Ceil(imagePriceUsd * billingratio.QuotaPerUsd * imageCostRatio * groupRatio)
-		if perImageQuota <= 0 {
-			return 0
-		}
-		return int64(perImageQuota) * int64(count)
-	}
-	if ratio <= 0 {
-		return 0
-	}
-	perImageQuota := math.Ceil(ratio * imageCostRatio)
-	if perImageQuota <= 0 {
-		return 0
-	}
-	return int64(perImageQuota) * int64(count)
-}
-
-// finalizeImageQuota merges token usage data with the reserved base quota to produce the final billed amount.
-// Token usage augments per-image pricing, ensuring prompt and output buckets are not skipped.
-func finalizeImageQuota(baseQuota int64, perImageBilling bool, imageModel string, actualModel string, usage *relaymodel.Usage, groupRatio float64) imageQuotaSummary {
-	summary := imageQuotaSummary{
-		BaseQuota:  baseQuota,
-		TotalQuota: baseQuota,
-	}
-	if usage == nil {
-		return summary
-	}
-
-	tokenQuotaFloat := computeImageUsageQuota(imageModel, usage, groupRatio)
-	if tokenQuotaFloat < 0 {
-		tokenQuotaFloat = 0
-	}
-	tokenQuota := int64(math.Ceil(tokenQuotaFloat))
-	if tokenQuota < 0 {
-		tokenQuota = 0
-	}
-	summary.TokenQuotaFloat = tokenQuotaFloat
-	summary.TokenQuota = tokenQuota
-
-	if perImageBilling {
-		if tokenQuota > 0 {
-			summary.TotalQuota += tokenQuota
-		}
-		return summary
-	}
-
-	if tokenQuota > 0 {
-		summary.TotalQuota = tokenQuota
-		return summary
-	}
-
-	fallbackFloat := computeLegacyImageTokenQuota(actualModel, usage, groupRatio)
-	if fallbackFloat > 0 {
-		fallbackQuota := int64(math.Ceil(fallbackFloat))
-		if fallbackQuota < 0 {
-			fallbackQuota = 0
-		}
-		summary.TokenQuotaFloat = fallbackFloat
-		summary.TokenQuota = fallbackQuota
-		summary.TotalQuota = baseQuota + fallbackQuota
-	}
-
-	return summary
-}
-
-// computeLegacyImageTokenQuota handles legacy token billing paths for image models lacking detailed bucket pricing.
-func computeLegacyImageTokenQuota(modelName string, usage *relaymodel.Usage, groupRatio float64) float64 {
-	if usage == nil || usage.PromptTokensDetails == nil {
-		return 0
-	}
-	switch modelName {
-	case "gpt-image-1", "gpt-image-1-mini":
-		textTokens := usage.PromptTokensDetails.TextTokens
-		if textTokens < 0 {
-			textTokens = 0
-		}
-		imageTokens := usage.PromptTokensDetails.ImageTokens
-		if imageTokens < 0 {
-			imageTokens = 0
-		}
-		quota := float64(textTokens)*5*billingratio.MilliTokensUsd + float64(imageTokens)*10*billingratio.MilliTokensUsd
-		if groupRatio > 0 {
-			quota *= groupRatio
-		}
-		return quota
-	case "chatgpt-image-latest", "gpt-image-1.5", "gpt-image-1.5-2025-12-16", "gpt-image-2", "gpt-image-2-2026-04-21":
-		textTokens := usage.PromptTokensDetails.TextTokens
-		if textTokens < 0 {
-			textTokens = 0
-		}
-		imageTokens := usage.PromptTokensDetails.ImageTokens
-		if imageTokens < 0 {
-			imageTokens = 0
-		}
-		quota := float64(textTokens)*5*billingratio.MilliTokensUsd + float64(imageTokens)*8*billingratio.MilliTokensUsd
-		if groupRatio > 0 {
-			quota *= groupRatio
-		}
-		return quota
-	default:
-		return 0
-	}
-}
-
 // imageBillingLogParams captures the attributes required to build a user-facing billing log entry for image requests.
 type imageBillingLogParams struct {
 	OriginModel     string
@@ -770,7 +483,14 @@ func formatImageBillingLog(params imageBillingLogParams) string {
 	fmt.Fprintf(&builder, " total_usd=%.4f", totalUsd)
 	fmt.Fprintf(&builder, " group_rate=%.2f", params.GroupRatio)
 
-	if params.ImagePriceUsd > 0 {
+	if isGPTImage25Model(params.Model) {
+		source := "provider_tokens"
+		if params.TokenQuota == 0 {
+			source = "configured_fallback"
+		}
+		fmt.Fprintf(&builder, " billing_source=%s reserved_usd=%.4f fallback_unit_usd=%.4f",
+			source, float64(params.BaseQuota)/billingratio.QuotaPerUsd, params.ImagePriceUsd*params.ImageTier)
+	} else if params.ImagePriceUsd > 0 {
 		unitUsd := params.ImagePriceUsd * params.ImageTier
 		baseUsd := float64(params.BaseQuota) / billingratio.QuotaPerUsd
 		fmt.Fprintf(&builder, " unit_usd=%.4f tier=%.2f base_usd=%.4f", unitUsd, params.ImageTier, baseUsd)

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -501,6 +501,37 @@ var gptImageTokenBucketPrices = map[string]gptImageTokenBucketPricing{
 		cachedInputImageUSD: 2.0,
 		outputImageUSD:      30.0,
 	},
+	// GPT Image 2.5 token rates verified 2026-09-09 (not per-image estimates).
+	// https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
+	// https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
+	"gpt-image-2.5-sunburst": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	"gpt-image-2.5-sunburst-2026-09-08": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	"gpt-image-2.5-flare": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	"gpt-image-2.5-flare-2026-09-08": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
 }
 
 // computeGptImageTokenQuota calculates quota for GPT image family models using five billing buckets:
@@ -567,13 +598,9 @@ func computeImageUsageQuota(modelName string, usage *relaymodel.Usage, groupRati
 	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && (usage.PromptTokensDetails == nil) {
 		return 0
 	}
-	switch modelName {
-	case "gpt-image-1", "gpt-image-1-mini", "chatgpt-image-latest", "gpt-image-1.5", "gpt-image-1.5-2025-12-16", "gpt-image-2", "gpt-image-2-2026-04-21":
-		return computeGptImageTokenQuota(modelName, usage, groupRatio)
-	default:
-		// Add more models here as they publish token pricing for image buckets
-		return 0
-	}
+	// The bucket table is the allowlist; keep dispatch in sync with every priced
+	// alias and snapshot without maintaining a second model-name list.
+	return computeGptImageTokenQuota(modelName, usage, groupRatio)
 }
 
 // imageQuotaSummary tracks the breakdown of image billing across fixed per-image components and token-based usage.

--- a/relay/controller/image.go
+++ b/relay/controller/image.go
@@ -219,6 +219,8 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		}
 	}
 
+	imageUsageConfig := resolveGPTImage25UsageConfig(imageModel, channelModelConfigs, channelModelRatio, pricingAdaptor, meta.StartTime)
+
 	// do request
 	resp, err := adaptor.DoRequest(c, meta, requestBody)
 	if err != nil {
@@ -347,7 +349,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		if usage != nil {
 			promptTokens = usage.PromptTokens
 			completionTokens = usage.CompletionTokens
-			summary := finalizeImageQuota(baseQuota, perImageBilling, imageModel, meta.ActualModelName, usage, groupRatio)
+			summary := finalizeImageQuota(baseQuota, perImageBilling, imageModel, meta.ActualModelName, usage, groupRatio, imageUsageConfig)
 			tokenQuota = summary.TokenQuota
 			tokenQuotaFloat = summary.TokenQuotaFloat
 			usedQuota = summary.TotalQuota
@@ -360,7 +362,7 @@ func RelayImageHelper(c *gin.Context, relayMode int) *relaymodel.ErrorWithStatus
 		completionTokens = usage.CompletionTokens
 
 		// Reconcile provider usage using the model-specific render/reservation policy.
-		summary := finalizeImageQuota(baseQuota, perImageBilling, imageModel, meta.ActualModelName, usage, groupRatio)
+		summary := finalizeImageQuota(baseQuota, perImageBilling, imageModel, meta.ActualModelName, usage, groupRatio, imageUsageConfig)
 		tokenQuota = summary.TokenQuota
 		tokenQuotaFloat = summary.TokenQuotaFloat
 		usedQuota = summary.TotalQuota
@@ -414,7 +416,6 @@ func reconcileImageFailureBilling(
 			lg.Error("CRITICAL BILLING AUDIT: image upstream error refund failed",
 				zap.Error(err),
 				zap.Int64("pre_consumed_quota", preConsumedQuota),
-				zap.String("reason", reason),
 			)
 		}
 	}

--- a/relay/controller/image25_billing.go
+++ b/relay/controller/image25_billing.go
@@ -1,0 +1,114 @@
+package controller
+
+import (
+	"math"
+
+	"github.com/Laisky/errors/v2"
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+)
+
+// isGPTImage25Model identifies the four verified token-priced image IDs.
+// Parameters: name is the mapped provider model. Returns: whether this policy applies.
+func isGPTImage25Model(name string) bool {
+	switch name {
+	case "gpt-image-2.5-sunburst", "gpt-image-2.5-sunburst-2026-09-08",
+		"gpt-image-2.5-flare", "gpt-image-2.5-flare-2026-09-08":
+		return true
+	default:
+		return false
+	}
+}
+
+// imagePostConsumeDelta computes the remaining debit or reservation refund.
+// Parameters: name selects the billing policy; used and reserved are quota units.
+// Returns: a signed delta for GPT Image 2.5, preserving legacy settlement elsewhere.
+func imagePostConsumeDelta(name string, used, reserved int64) int64 {
+	delta := used - reserved
+	if delta < 0 && !isGPTImage25Model(name) {
+		return 0
+	}
+	return delta
+}
+
+// computeGPTImage25TokenQuota prices normalized provider usage without inventing
+// a proportional cache split. Parameters: usage carries token counts, prices are
+// USD per million tokens, and group is the quota multiplier. Returns: quota units,
+// or zero when the provider's buckets are inconsistent or ambiguous.
+func computeGPTImage25TokenQuota(usage *relaymodel.Usage, prices gptImageTokenBucketPricing, group float64) float64 {
+	if usage == nil || usage.PromptTokens < 0 || usage.CompletionTokens < 0 || group <= 0 || math.IsNaN(group) || math.IsInf(group, 0) {
+		return 0
+	}
+	var textIn, imageIn, cached int
+	var cacheDetails *relaymodel.UsageCachedTokensDetails
+	if d := usage.PromptTokensDetails; d != nil {
+		textIn, imageIn, cached = d.TextTokens, d.ImageTokens, d.CachedTokens
+		cacheDetails = d.CachedTokensDetails
+	}
+	if textIn < 0 || imageIn < 0 || cached < 0 || textIn > int(^uint(0)>>1)-imageIn {
+		return 0
+	}
+	total := textIn + imageIn
+	if usage.PromptTokens > 0 {
+		if total > usage.PromptTokens {
+			return 0
+		}
+		// Compatibility fallback: bill unclassified input at the text rate rather
+		// than silently dropping it. This is not a claim about its actual modality.
+		textIn += usage.PromptTokens - total
+		total = usage.PromptTokens
+	}
+	if cached > total {
+		return 0
+	}
+	cachedText, cachedImage := 0, 0
+	if cacheDetails != nil {
+		cachedText, cachedImage = cacheDetails.TextTokens, cacheDetails.ImageTokens
+		if cachedText < 0 || cachedText > textIn || cachedImage < 0 || cachedImage > imageIn {
+			return 0
+		}
+		// A supplied aggregate must agree with the modality-specific buckets.
+		// Some compatible endpoints omit the aggregate but supply the split.
+		if cached > 0 && cachedText+cachedImage != cached {
+			return 0
+		}
+	} else if cached > 0 {
+		switch {
+		case imageIn == 0:
+			cachedText = cached
+		case textIn == 0:
+			cachedImage = cached
+		default:
+			// The split is unknowable: use the explicitly configured fallback
+			// during settlement instead of claiming a guessed token charge.
+			return 0
+		}
+	}
+	quota := (float64(textIn-cachedText)*prices.inputTextUSD +
+		float64(cachedText)*prices.cachedInputTextUSD +
+		float64(imageIn-cachedImage)*prices.inputImageUSD +
+		float64(cachedImage)*prices.cachedInputImageUSD +
+		float64(usage.CompletionTokens)*prices.outputImageUSD) * billingratio.MilliTokensUsd * group
+	if math.IsNaN(quota) || math.IsInf(quota, 0) || quota >= float64(uint64(1)<<63) {
+		return 0
+	}
+	return quota
+}
+
+// validateGPTImage25Billing checks admission before quota lookup or upstream I/O.
+// Parameters: name is the mapped model; fallbackUSD, tier, group, and count define
+// the operator's reservation/fallback tariff. Returns: a configuration error when
+// no positive, finite, representable reservation exists; nil for other models.
+func validateGPTImage25Billing(name string, fallbackUSD, tier, group float64, count int) error {
+	if !isGPTImage25Model(name) {
+		return nil
+	}
+	if fallbackUSD <= 0 || tier <= 0 || group <= 0 || count <= 0 {
+		return errors.New("GPT Image 2.5 requires a positive image.price_per_image_usd reservation/fallback tariff in channel model_configs; this is operator policy, not an official per-image price")
+	}
+	perImage := math.Ceil(fallbackUSD * billingratio.QuotaPerUsd * tier * group)
+	if math.IsNaN(perImage) || math.IsInf(perImage, 0) || perImage <= 0 || perImage >= float64(uint64(1)<<63)/float64(count) {
+		return errors.New("GPT Image 2.5 reservation/fallback tariff must produce finite, representable quota")
+	}
+	return nil
+}

--- a/relay/controller/image25_defaults.go
+++ b/relay/controller/image25_defaults.go
@@ -1,0 +1,37 @@
+package controller
+
+import (
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/adaptor/openai"
+)
+
+// completeGPTImage25Defaults preserves request defaults with a price-only override.
+// Parameters: name is the mapped model and cfg is resolved channel pricing.
+// Returns: a private copy with unspecified request defaults filled from the catalog;
+// other models retain their existing configuration and pricing is never invented.
+func completeGPTImage25Defaults(name string, cfg *adaptor.ImagePricingConfig) *adaptor.ImagePricingConfig {
+	if !isGPTImage25Model(name) || cfg == nil {
+		return cfg
+	}
+	defaults := openai.ModelRatios[name].Image
+	if defaults == nil {
+		return cfg
+	}
+	out := cfg.Clone()
+	if out.DefaultSize == "" {
+		out.DefaultSize = defaults.DefaultSize
+	}
+	if out.DefaultQuality == "" {
+		out.DefaultQuality = defaults.DefaultQuality
+	}
+	if out.PromptTokenLimit == 0 {
+		out.PromptTokenLimit = defaults.PromptTokenLimit
+	}
+	if out.MinImages == 0 {
+		out.MinImages = defaults.MinImages
+	}
+	if out.MaxImages == 0 {
+		out.MaxImages = defaults.MaxImages
+	}
+	return out
+}

--- a/relay/controller/image25_policy_test.go
+++ b/relay/controller/image25_policy_test.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor"
+)
+
+// TestGPTImage25ReservationPolicy rejects missing or unrepresentable reserves.
+// Parameters: t runs the table. Returns: none; other model policies stay unchanged.
+func TestGPTImage25ReservationPolicy(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name               string
+		price, tier, group float64
+		count              int
+	}{
+		{"missing", 0, 1, 1, 1},
+		{"negative", -1, 1, 1, 1},
+		{"nan", math.NaN(), 1, 1, 1},
+		{"infinite", math.Inf(1), 1, 1, 1},
+		{"zero_tier", 0.1, 0, 1, 1},
+		{"zero_group", 0.1, 1, 0, 1},
+		{"invalid_count", 0.1, 1, 1, 0},
+		{"overflow", math.MaxFloat64, 1, 1, 10},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Error(t, validateGPTImage25Billing("gpt-image-2.5-sunburst", tc.price, tc.tier, tc.group, tc.count))
+		})
+	}
+	require.NoError(t, validateGPTImage25Billing("gpt-image-2.5-flare", 0.1, 1, 1.5, 10))
+	require.NoError(t, validateGPTImage25Billing("dall-e-3", 0, 0, 0, 0))
+}
+
+// TestGPTImage25SignedSettlement protects refunds of unused reservations.
+// Parameters: t runs debit/refund cases. Returns: none; legacy negative deltas stay clamped.
+func TestGPTImage25SignedSettlement(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, int64(-32_500), imagePostConsumeDelta("gpt-image-2.5-sunburst", 17_500, 50_000))
+	require.Zero(t, imagePostConsumeDelta("gpt-image-2.5-flare", 50_000, 50_000))
+	require.Equal(t, int64(100_000), imagePostConsumeDelta("gpt-image-2.5-flare", 150_000, 50_000))
+	require.Zero(t, imagePostConsumeDelta("dall-e-3", 17_500, 50_000))
+}
+
+// TestGPTImage25PriceOnlyOverrideKeepsRequestDefaults checks that configuring a
+// reserve does not regress Image API defaults. Parameters: t runs the assertions.
+// Returns: none; the original channel configuration must remain unmodified.
+func TestGPTImage25PriceOnlyOverrideKeepsRequestDefaults(t *testing.T) {
+	t.Parallel()
+	input := &adaptor.ImagePricingConfig{PricePerImageUsd: 0.1}
+	got := completeGPTImage25Defaults("gpt-image-2.5-sunburst", input)
+	require.Equal(t, 0.1, got.PricePerImageUsd)
+	require.Equal(t, "auto", got.DefaultSize)
+	require.Equal(t, "auto", got.DefaultQuality)
+	require.Equal(t, 32000, got.PromptTokenLimit)
+	require.Equal(t, 1, got.MinImages)
+	require.Equal(t, 10, got.MaxImages)
+	require.Empty(t, input.DefaultQuality)
+	require.Zero(t, input.MaxImages)
+	input.DefaultQuality = "high"
+	input.MaxImages = 2
+	got = completeGPTImage25Defaults("gpt-image-2.5-flare", input)
+	require.Equal(t, "high", got.DefaultQuality)
+	require.Equal(t, 2, got.MaxImages)
+	require.Same(t, input, completeGPTImage25Defaults("dall-e-3", input))
+}

--- a/relay/controller/image25_pricing.go
+++ b/relay/controller/image25_pricing.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"time"
+
+	"github.com/Laisky/one-api/model"
+	"github.com/Laisky/one-api/relay/adaptor"
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/pricing"
+)
+
+// resolveGPTImage25UsageConfig captures effective pricing at request start.
+// Parameters: name selects the model, configs/ratios contain channel overrides,
+// provider supplies defaults, and at anchors time windows. Returns: a private
+// configuration with unspecified fields inherited and explicit overrides retained.
+func resolveGPTImage25UsageConfig(name string, configs map[string]model.ModelConfigLocal, ratios map[string]float64, provider adaptor.Adaptor, at time.Time) adaptor.ModelConfig {
+	if !isGPTImage25Model(name) {
+		return adaptor.ModelConfig{}
+	}
+	base, _ := pricing.ResolveModelConfig(name, nil, provider, at)
+	resolved, _ := pricing.ResolveModelConfig(name, configs, provider, at)
+	base.Ratio = pricing.ResolveModelRatioAt(name, configs, ratios, provider, at)
+	base.CompletionRatio = pricing.ResolveCompletionRatioAt(name, configs, nil, provider, at)
+	if resolved.CachedInputRatio != 0 {
+		base.CachedInputRatio = resolved.CachedInputRatio
+	}
+	if len(resolved.Tiers) > 0 {
+		base.Tiers = resolved.Tiers
+	}
+	if resolved.Image != nil && resolved.Image.PromptRatio != 0 {
+		if base.Image == nil {
+			base.Image = &adaptor.ImagePricingConfig{}
+		}
+		base.Image.PromptRatio = resolved.Image.PromptRatio
+	}
+	return base
+}
+
+// computeGPTImage25ConfiguredQuota honors channel prices across all token buckets.
+// Parameters: usage is normalized provider usage, cfg is request-start pricing,
+// and group scales quota. Returns: billable quota, or zero for unusable usage.
+func computeGPTImage25ConfiguredQuota(usage *relaymodel.Usage, cfg adaptor.ModelConfig, group float64) float64 {
+	if usage == nil {
+		return 0
+	}
+	effective := pricing.ResolveEffectivePricingForUsageFromConfig(usage.PromptTokens, usage.CompletionTokens, cfg)
+	imageRatio := 8.0 / 5.0
+	if cfg.Image != nil && cfg.Image.PromptRatio != 0 {
+		imageRatio = cfg.Image.PromptRatio
+	}
+	cached := effective.CachedInputRatio
+	if cached == 0 {
+		cached = effective.InputRatio
+	} else if cached < 0 {
+		cached = 0
+	}
+	prices := gptImageTokenBucketPricing{
+		inputTextUSD:        effective.InputRatio / billingratio.MilliTokensUsd,
+		cachedInputTextUSD:  cached / billingratio.MilliTokensUsd,
+		inputImageUSD:       effective.InputRatio * imageRatio / billingratio.MilliTokensUsd,
+		cachedInputImageUSD: cached * imageRatio / billingratio.MilliTokensUsd,
+		outputImageUSD:      effective.OutputRatio / billingratio.MilliTokensUsd,
+	}
+	return computeGPTImage25TokenQuota(usage, prices, group)
+}

--- a/relay/controller/image25_relay_review_test.go
+++ b/relay/controller/image25_relay_review_test.go
@@ -46,6 +46,7 @@ func TestGPTImage25ReviewRelayAccounting(t *testing.T) {
 		{"missing_usage", "gpt-image-2.5-flare", `null`, 0.1, 1_000_000, 1, 200, 50_000, 50_000, true},
 		{"empty_usage", "gpt-image-2.5-sunburst", `{}`, 0.1, 1_000_000, 1, 200, 50_000, 50_000, true},
 		{"ambiguous_cache_split", "gpt-image-2.5-flare", `{"input_tokens":2000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":1000,"cached_tokens":1000}}`, 0.1, 1_000_000, 1, 200, 50_000, 50_000, true},
+		{"channel_pricing_override", "gpt-image-2.5-sunburst", cachedUsage, 0.1, 1_000_000, 1, 200, 50_000, 26_000, false},
 		{"legacy_per_image_control", "dall-e-3", `{}`, 0, 1_000_000, 1, 200, 20_000, 20_000, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -83,6 +84,9 @@ func TestGPTImage25ReviewRelayAccounting(t *testing.T) {
 			channel := &model.Channel{Id: 1, Type: channeltype.OpenAI, Name: "image25-review", Status: model.ChannelStatusEnabled}
 			if tc.tariff > 0 {
 				pricingJSON := fmt.Sprintf(`{%q:{"image":{"price_per_image_usd":%g}}}`, tc.model, tc.tariff)
+				if tc.name == "channel_pricing_override" {
+					pricingJSON = fmt.Sprintf(`{%q:{"ratio":5,"completion_ratio":4,"cached_input_ratio":0.5,"image":{"price_per_image_usd":0.1,"prompt_ratio":2}}}`, tc.model)
+				}
 				channel.ModelConfigs = &pricingJSON
 			}
 			require.NoError(t, model.DB.Create(channel).Error)

--- a/relay/controller/image25_relay_review_test.go
+++ b/relay/controller/image25_relay_review_test.go
@@ -1,0 +1,150 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gmw "github.com/Laisky/gin-middlewares/v7"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/common/config"
+	"github.com/Laisky/one-api/common/ctxkey"
+	"github.com/Laisky/one-api/common/logger"
+	"github.com/Laisky/one-api/model"
+	"github.com/Laisky/one-api/relay/channeltype"
+	metalib "github.com/Laisky/one-api/relay/meta"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+// TestGPTImage25ReviewRelayAccounting checks admission, actual pre-debit, HTTP
+// decoding, final balances, and persisted costs together. Parameters: t runs the
+// cases. Returns: none. It is serial because the existing fixture swaps global DBs.
+func TestGPTImage25ReviewRelayAccounting(t *testing.T) {
+	const cachedUsage = `{"input_tokens":2000,"output_tokens":1000,"total_tokens":3000,"input_tokens_details":{"text_tokens":1000,"image_tokens":1000,"cached_tokens":1000,"cached_tokens_details":{"text_tokens":0,"image_tokens":1000}}}`
+	for _, tc := range []struct {
+		name, model, usage string
+		tariff             float64
+		balance            int64
+		count, status      int
+		reserved, charged  int64
+		fallback           bool
+	}{
+		{"unconfigured_sunburst", "gpt-image-2.5-sunburst", `{}`, 0, 1_000_000, 1, 503, 0, 0, false},
+		{"unconfigured_sunburst_snapshot", "gpt-image-2.5-sunburst-2026-09-08", `{}`, 0, 1_000_000, 1, 503, 0, 0, false},
+		{"unconfigured_flare", "gpt-image-2.5-flare", `{}`, 0, 1_000_000, 1, 503, 0, 0, false},
+		{"unconfigured_flare_snapshot", "gpt-image-2.5-flare-2026-09-08", `{}`, 0, 1_000_000, 1, 503, 0, 0, false},
+		{"insufficient_credit", "gpt-image-2.5-sunburst", cachedUsage, 0.1, 3, 1, 403, 0, 0, false},
+		{"reserve_then_refund_unused", "gpt-image-2.5-sunburst", cachedUsage, 0.1, 1_000_000, 2, 200, 100_000, 18_500, false},
+		{"charge_above_reserve", "gpt-image-2.5-flare", `{"input_tokens":1000,"output_tokens":10000}`, 0.1, 1_000_000, 1, 200, 50_000, 152_500, false},
+		{"missing_usage", "gpt-image-2.5-flare", `null`, 0.1, 1_000_000, 1, 200, 50_000, 50_000, true},
+		{"empty_usage", "gpt-image-2.5-sunburst", `{}`, 0.1, 1_000_000, 1, 200, 50_000, 50_000, true},
+		{"ambiguous_cache_split", "gpt-image-2.5-flare", `{"input_tokens":2000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":1000,"cached_tokens":1000}}`, 0.1, 1_000_000, 1, 200, 50_000, 50_000, true},
+		{"legacy_per_image_control", "dall-e-3", `{}`, 0, 1_000_000, 1, 200, 20_000, 20_000, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := setupCacheBillingLogTest(t)
+			defer cleanup()
+			require.NoError(t, model.DB.AutoMigrate(&model.Channel{}, &model.UserRequestCost{}))
+			require.NoError(t, model.DB.Model(&model.User{}).Where("id = ?", 1).Update("quota", tc.balance).Error)
+			require.NoError(t, model.DB.Model(&model.Token{}).Where("id = ?", 1).Update("remain_quota", tc.balance).Error)
+			oldLog := config.IsLogConsumeEnabled()
+			config.SetLogConsumeEnabled(true)
+			defer config.SetLogConsumeEnabled(oldLog)
+			oldBatch := config.BatchUpdateEnabled
+			config.BatchUpdateEnabled = false
+			defer func() { config.BatchUpdateEnabled = oldBatch }()
+
+			var calls atomic.Int32
+			var atUpstreamUser, atUpstreamToken atomic.Int64
+			var upstreamDBError atomic.Bool
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				var user model.User
+				var token model.Token
+				if model.DB.First(&user, 1).Error != nil || model.DB.First(&token, 1).Error != nil {
+					upstreamDBError.Store(true)
+				}
+				atUpstreamUser.Store(user.Quota)
+				atUpstreamToken.Store(token.RemainQuota)
+				w.Header().Set("Content-Type", "application/json")
+				_, err := fmt.Fprintf(w, `{"created":1,"data":[{"b64_json":"AQ=="}],"usage":%s}`, tc.usage)
+				if err != nil {
+					upstreamDBError.Store(true)
+				}
+			}))
+			defer upstream.Close()
+			channel := &model.Channel{Id: 1, Type: channeltype.OpenAI, Name: "image25-review", Status: model.ChannelStatusEnabled}
+			if tc.tariff > 0 {
+				pricingJSON := fmt.Sprintf(`{%q:{"image":{"price_per_image_usd":%g}}}`, tc.model, tc.tariff)
+				channel.ModelConfigs = &pricingJSON
+			}
+			require.NoError(t, model.DB.Create(channel).Error)
+			if tc.tariff > 0 {
+				pricing := channel.GetModelPriceConfigsWithContext(context.Background())
+				require.NotNil(t, pricing[tc.model].Image, "the real channel parser must recognize the test override")
+				require.Equal(t, tc.tariff, pricing[tc.model].Image.PricePerImageUsd)
+			}
+			body := fmt.Sprintf(`{"model":%q,"prompt":"A lighthouse","n":%d}`, tc.model, tc.count)
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			gmw.SetLogger(c, logger.Logger)
+			requestID := "image25-review-" + tc.name
+			c.Set(ctxkey.Id, 1)
+			c.Set(ctxkey.TokenId, 1)
+			c.Set(ctxkey.TokenName, "relay-cache-log-token")
+			c.Set(ctxkey.ChannelId, 1)
+			c.Set(ctxkey.ChannelRatio, 1.0)
+			c.Set(ctxkey.ChannelModel, channel)
+			c.Set(ctxkey.ContentType, "application/json")
+			c.Set(ctxkey.RequestId, requestID)
+			mode := relaymode.GetByPath("/v1/images/generations")
+			metalib.Set2Context(c, &metalib.Meta{
+				Mode: mode, ChannelType: channeltype.OpenAI, APIType: channeltype.ToAPIType(channeltype.OpenAI),
+				ChannelId: 1, UserId: 1, TokenId: 1, TokenName: "relay-cache-log-token",
+				BaseURL: upstream.URL, APIKey: "test-only", OriginModelName: tc.model,
+				ActualModelName: tc.model, RequestURLPath: "/v1/images/generations", StartTime: time.Now(),
+			})
+			gotErr := RelayImageHelper(c, mode)
+			if tc.status != http.StatusOK {
+				require.NotNil(t, gotErr)
+				require.Equal(t, tc.status, gotErr.StatusCode)
+				if tc.status == http.StatusServiceUnavailable {
+					require.Equal(t, "image_billing_not_configured", gotErr.Code)
+				}
+				require.Zero(t, calls.Load(), "rejected requests must never reach a paid upstream")
+			} else {
+				require.Nil(t, gotErr)
+				require.Equal(t, http.StatusOK, recorder.Code)
+				require.Contains(t, recorder.Body.String(), "AQ==")
+				require.Equal(t, int32(1), calls.Load())
+				require.False(t, upstreamDBError.Load())
+				require.Equal(t, tc.balance-tc.reserved, atUpstreamUser.Load(), "reserve user quota before HTTP")
+				require.Equal(t, tc.balance-tc.reserved, atUpstreamToken.Load(), "reserve token quota before HTTP")
+				var cost model.UserRequestCost
+				require.NoError(t, model.DB.Where("request_id = ?", requestID).First(&cost).Error)
+				require.Equal(t, tc.charged, cost.Quota)
+				var entry model.Log
+				require.NoError(t, model.LOG_DB.Where("request_id = ? AND type = ?", requestID, model.LogTypeConsume).First(&entry).Error)
+				require.Equal(t, int(tc.charged), entry.Quota)
+				if tc.fallback {
+					require.Contains(t, entry.Content, "billing_source=configured_fallback")
+				}
+			}
+			var user model.User
+			var token model.Token
+			require.NoError(t, model.DB.First(&user, 1).Error)
+			require.NoError(t, model.DB.First(&token, 1).Error)
+			require.Equal(t, tc.balance-tc.charged, user.Quota)
+			require.Equal(t, tc.balance-tc.charged, token.RemainQuota)
+		})
+	}
+}

--- a/relay/controller/image25_review_test.go
+++ b/relay/controller/image25_review_test.go
@@ -1,0 +1,73 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor/openai"
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// TestGPTImage25ReviewWireUsage exercises the provider JSON boundary rather than
+// constructing already-normalized usage. Parameters: t runs the cases. Returns: none.
+func TestGPTImage25ReviewWireUsage(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		body string
+		usd  float64
+	}{
+		{"uncached_control", `{"input_tokens":2000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":1000}}`, 0.043},
+		{"cached_text", `{"input_tokens":1000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":0,"cached_tokens":1000}}`, 0.03125},
+		{"cached_image", `{"input_tokens":1000,"output_tokens":1000,"input_tokens_details":{"text_tokens":0,"image_tokens":1000,"cached_tokens":1000}}`, 0.032},
+		{"only_images_cached", `{"input_tokens":2000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":1000,"cached_tokens":1000,"cached_tokens_details":{"text_tokens":0,"image_tokens":1000}}}`, 0.037},
+		{"only_text_cached", `{"input_tokens":2000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":1000,"cached_tokens":1000,"cached_tokens_details":{"text_tokens":1000,"image_tokens":0}}}`, 0.03925},
+		{"unequal_cache_buckets", `{"input_tokens":1200,"output_tokens":100,"input_tokens_details":{"text_tokens":200,"image_tokens":1000,"cached_tokens":400,"cached_tokens_details":{"text_tokens":200,"image_tokens":200}}}`, 0.01005},
+		{"totals_only", `{"input_tokens":1000,"output_tokens":1000}`, 0.035},
+		{"partial_modality_details", `{"input_tokens":1000,"output_tokens":1000,"input_tokens_details":{"text_tokens":100,"image_tokens":200}}`, 0.0356},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var upstream openai.ImageUsage
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &upstream))
+			usage := upstream.Convert2GeneralUsage()
+			for _, name := range []string{
+				"gpt-image-2.5-sunburst", "gpt-image-2.5-sunburst-2026-09-08",
+				"gpt-image-2.5-flare", "gpt-image-2.5-flare-2026-09-08",
+			} {
+				for _, group := range []float64{1, 1.5} {
+					require.InDelta(t, tc.usd*billingratio.QuotaPerUsd*group,
+						computeImageUsageQuota(name, usage, group), 1e-8, name)
+				}
+			}
+		})
+	}
+}
+
+// TestGPTImage25ReviewReservationIsNotAnExtraFee verifies token settlement with
+// an operator-configured reserve. Parameters: t runs the assertion. Returns: none.
+func TestGPTImage25ReviewReservationIsNotAnExtraFee(t *testing.T) {
+	t.Parallel()
+	var upstream openai.ImageUsage
+	require.NoError(t, json.Unmarshal([]byte(`{"input_tokens":1000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":0}}`), &upstream))
+	got := finalizeImageQuota(50_000, true, "gpt-image-2.5-sunburst", "gpt-image-2.5-sunburst", upstream.Convert2GeneralUsage(), 1)
+	require.Equal(t, int64(17_500), got.TotalQuota, "the reserve is replaced, never added to actual token cost")
+}
+
+// TestGPTImage25ReviewIncompleteUsageKeepsConfiguredFallback covers absent,
+// partial, and ambiguous provider usage. Parameters: t runs the cases. Returns: none.
+func TestGPTImage25ReviewIncompleteUsageKeepsConfiguredFallback(t *testing.T) {
+	t.Parallel()
+	for _, body := range []string{
+		`{}`, `null`,
+		`{"input_tokens":1000,"output_tokens":0,"input_tokens_details":{"text_tokens":1000}}`,
+		`{"input_tokens":2000,"output_tokens":1000,"input_tokens_details":{"text_tokens":1000,"image_tokens":1000,"cached_tokens":1000}}`,
+	} {
+		var upstream openai.ImageUsage
+		require.NoError(t, json.Unmarshal([]byte(body), &upstream))
+		got := finalizeImageQuota(50_000, true, "gpt-image-2.5-flare", "gpt-image-2.5-flare", upstream.Convert2GeneralUsage(), 1)
+		require.Equal(t, int64(50_000), got.TotalQuota, body)
+		require.Zero(t, got.TokenQuota, "an estimate must not masquerade as measured token billing")
+	}
+}

--- a/relay/controller/image25_test.go
+++ b/relay/controller/image25_test.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor/openai"
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+)
+
+// TestGPTImage25TokenBuckets verifies normalized usage against the official token rates.
+// Parameters: t is the test runner. Returns: none; missing dispatch or incorrect rates fail the test.
+func TestGPTImage25TokenBuckets(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		"gpt-image-2.5-sunburst",
+		"gpt-image-2.5-sunburst-2026-09-08",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-flare-2026-09-08",
+	} {
+		for _, tc := range []struct {
+			label                   string
+			text, image, cached, out int
+			usd                     float64
+		}{
+			{label: "text", text: 1000, usd: 0.005},
+			{label: "image", image: 1000, usd: 0.008},
+			{label: "output", out: 1000, usd: 0.03},
+			{label: "cached_text", text: 1000, cached: 1000, usd: 0.00125},
+			{label: "cached_image", image: 1000, cached: 1000, usd: 0.002},
+			{label: "mixed", text: 100, image: 340, out: 196, usd: 0.0091},
+		} {
+			t.Run(name+"/"+tc.label, func(t *testing.T) {
+				usage := &relaymodel.Usage{
+					PromptTokens:     tc.text + tc.image,
+					CompletionTokens: tc.out,
+					PromptTokensDetails: &relaymodel.UsagePromptTokensDetails{
+						TextTokens: tc.text, ImageTokens: tc.image, CachedTokens: tc.cached,
+					},
+				}
+				for _, group := range []float64{1, 1.5} {
+					got := computeImageUsageQuota(name, usage, group)
+					require.InDelta(t, tc.usd*billingratio.QuotaPerUsd*group, got, 1e-9)
+				}
+			})
+		}
+	}
+	require.Zero(t, computeImageUsageQuota("gpt-image-2.5-sunburst", nil, 1))
+	require.Zero(t, computeImageUsageQuota("gpt-image-2.5-sunburst", &relaymodel.Usage{}, 1))
+	require.Zero(t, computeImageUsageQuota("gpt-image-unknown", &relaymodel.Usage{CompletionTokens: 1000}, 1))
+}
+
+// TestGPTImage25UsageReconciliation verifies parsing and token-only final billing together.
+// Parameters: t is the test runner. Returns: none; a duplicate render fee fails the test.
+func TestGPTImage25UsageReconciliation(t *testing.T) {
+	t.Parallel()
+	var upstream openai.ImageUsage
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"input_tokens":440,"output_tokens":196,"total_tokens":636,
+		"input_tokens_details":{"text_tokens":100,"image_tokens":340}
+	}`), &upstream))
+	usage := upstream.Convert2GeneralUsage()
+	for _, name := range []string{
+		"gpt-image-2.5-sunburst",
+		"gpt-image-2.5-sunburst-2026-09-08",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-flare-2026-09-08",
+	} {
+		cfg := openai.ModelRatios[name]
+		require.NotNil(t, cfg.Image)
+		perImage := cfg.Image.PricePerImageUsd > 0
+		require.False(t, perImage)
+		base := calculateImageBaseQuota(cfg.Image.PricePerImageUsd, cfg.Ratio, 1, 1, 1)
+		require.Positive(t, base)
+		summary := finalizeImageQuota(base, perImage, name, name, usage, 1)
+		want := int64(math.Ceil(0.0091 * billingratio.QuotaPerUsd))
+		require.Equal(t, want, summary.TotalQuota, name)
+		require.Equal(t, want, summary.TokenQuota, name)
+		require.InDelta(t, 0.0091*billingratio.QuotaPerUsd, summary.TokenQuotaFloat, 1e-9)
+		require.NotEqual(t, base+want, summary.TotalQuota, "usage replaces the estimate instead of adding a render fee")
+	}
+}
+
+// TestGPTImage25RequestDefaults verifies defaults and forwarding of new quality levels.
+// Parameters: t is the test runner. Returns: none; stale Image 2 constraints fail the test.
+func TestGPTImage25RequestDefaults(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{
+		"gpt-image-2.5-sunburst",
+		"gpt-image-2.5-sunburst-2026-09-08",
+		"gpt-image-2.5-flare",
+		"gpt-image-2.5-flare-2026-09-08",
+	} {
+		cfg := openai.ModelRatios[name]
+		require.NotNil(t, cfg.Image)
+		req := &relaymodel.ImageRequest{Model: name, Prompt: "A lighthouse", N: 1}
+		applyImageDefaults(req, cfg.Image)
+		require.Equal(t, "auto", req.Size)
+		require.Equal(t, "auto", req.Quality)
+		require.Nil(t, validateImageRequest(req, nil, cfg.Image))
+		for _, quality := range []string{"low", "medium", "high", "xhigh", "max", "auto"} {
+			req.Quality = quality
+			req.Size = "1536x864"
+			require.Nil(t, validateImageRequest(req, nil, cfg.Image))
+			multiplier, err := getImageCostRatio(req, cfg.Image)
+			require.NoError(t, err)
+			require.Equal(t, 1.0, multiplier, "size and quality costs come from actual token usage")
+			upstream := buildOpenAIImageRequest(req)
+			require.Equal(t, name, upstream.Model)
+			require.Equal(t, quality, upstream.Quality)
+			require.Equal(t, "1536x864", upstream.Size)
+			require.Equal(t, 1, upstream.N)
+		}
+	}
+}

--- a/relay/controller/image25_test.go
+++ b/relay/controller/image25_test.go
@@ -23,9 +23,9 @@ func TestGPTImage25TokenBuckets(t *testing.T) {
 		"gpt-image-2.5-flare-2026-09-08",
 	} {
 		for _, tc := range []struct {
-			label                   string
+			label                    string
 			text, image, cached, out int
-			usd                     float64
+			usd                      float64
 		}{
 			{label: "text", text: 1000, usd: 0.005},
 			{label: "image", image: 1000, usd: 0.008},

--- a/relay/controller/image25_unicode_review_test.go
+++ b/relay/controller/image25_unicode_review_test.go
@@ -1,0 +1,25 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor/openai"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+)
+
+// TestGPTImage25PromptCharacterBoundary reproduces byte-count rejection of valid
+// Unicode prompts. Parameters: t runs catalog and fallback cases. Returns: none.
+func TestGPTImage25PromptCharacterBoundary(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"gpt-image-2.5-sunburst", "gpt-image-2.5-sunburst-2026-09-08", "gpt-image-2.5-flare", "gpt-image-2.5-flare-2026-09-08"} {
+		for _, character := range []string{"a", "界", "🌈"} {
+			req := &relaymodel.ImageRequest{Model: name, Prompt: strings.Repeat(character, 32000)}
+			require.True(t, isValidImagePromptLength(req, openai.ModelRatios[name].Image), "32000 code points must fit: %s", name)
+			req.Prompt += character
+			require.False(t, isValidImagePromptLength(req, openai.ModelRatios[name].Image), "32001 code points must not fit: %s", name)
+		}
+	}
+}

--- a/relay/controller/image_request.go
+++ b/relay/controller/image_request.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/Laisky/errors/v2"
 	"github.com/gin-gonic/gin"
@@ -179,13 +180,18 @@ func isValidImageSize(req *relaymodel.ImageRequest, cfg *relayadaptor.ImagePrici
 
 // isValidImagePromptLength checks the configured or model-default prompt limit.
 // Parameters: req contains the prompt and model and cfg may override the limit.
-// Returns: true when the prompt is within the applicable limit.
+// Returns: true when the prompt is within the applicable limit; GPT Image 2.5
+// counts Unicode code points, while other models retain their legacy byte limit.
 func isValidImagePromptLength(req *relaymodel.ImageRequest, cfg *relayadaptor.ImagePricingConfig) bool {
+	length := len(req.Prompt)
+	if isGPTImage25Model(req.Model) {
+		length = utf8.RuneCountInString(req.Prompt)
+	}
 	if cfg != nil && cfg.PromptTokenLimit > 0 {
-		return len(req.Prompt) <= cfg.PromptTokenLimit
+		return length <= cfg.PromptTokenLimit
 	}
 	maxPromptLength, ok := billingratio.ImagePromptLengthLimitations[req.Model]
-	return !ok || len(req.Prompt) <= maxPromptLength
+	return !ok || length <= maxPromptLength
 }
 
 // isWithinRange checks the requested image count against configured or global

--- a/relay/controller/image_token_billing.go
+++ b/relay/controller/image_token_billing.go
@@ -1,0 +1,311 @@
+package controller
+
+import (
+	"math"
+
+	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+)
+
+// gptImageTokenBucketPricing stores USD per 1M token prices for GPT Image models.
+type gptImageTokenBucketPricing struct {
+	inputTextUSD        float64
+	cachedInputTextUSD  float64
+	inputImageUSD       float64
+	cachedInputImageUSD float64
+	outputImageUSD      float64
+}
+
+var gptImageTokenBucketPrices = map[string]gptImageTokenBucketPricing{
+	// https://platform.openai.com/docs/models/gpt-image-1
+	"gpt-image-1": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       10.0,
+		cachedInputImageUSD: 2.5,
+		outputImageUSD:      40.0,
+	},
+	// https://platform.openai.com/docs/models/gpt-image-1-mini
+	"gpt-image-1-mini": {
+		inputTextUSD:        2.0,
+		cachedInputTextUSD:  0.20,
+		inputImageUSD:       2.5,
+		cachedInputImageUSD: 0.25,
+		outputImageUSD:      8.0,
+	},
+	// https://platform.openai.com/docs/models/chatgpt-image-latest
+	"chatgpt-image-latest": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      32.0,
+	},
+	// https://platform.openai.com/docs/models/gpt-image-1.5
+	"gpt-image-1.5": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      32.0,
+	},
+	"gpt-image-1.5-2025-12-16": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      32.0,
+	},
+	// https://platform.openai.com/docs/models/gpt-image-2
+	"gpt-image-2": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	"gpt-image-2-2026-04-21": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	// GPT Image 2.5 token rates verified 2026-09-09 (not per-image estimates).
+	// https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
+	// https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
+	"gpt-image-2.5-sunburst": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	"gpt-image-2.5-sunburst-2026-09-08": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	"gpt-image-2.5-flare": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+	"gpt-image-2.5-flare-2026-09-08": {
+		inputTextUSD:        5.0,
+		cachedInputTextUSD:  1.25,
+		inputImageUSD:       8.0,
+		cachedInputImageUSD: 2.0,
+		outputImageUSD:      30.0,
+	},
+}
+
+// computeGptImageTokenQuota calculates quota for GPT image family models using five billing buckets:
+// input text, cached input text, input image, cached input image, and output image tokens.
+// Prices are expressed in USD per 1M tokens and multiplied by the groupRatio (quota multiplier) before returning quota units.
+func computeGptImageTokenQuota(modelName string, usage *relaymodel.Usage, groupRatio float64) float64 {
+	if usage == nil {
+		return 0
+	}
+	pricing, ok := gptImageTokenBucketPrices[modelName]
+	if !ok {
+		return 0
+	}
+	if isGPTImage25Model(modelName) {
+		return computeGPTImage25TokenQuota(usage, pricing, groupRatio)
+	}
+
+	var textIn, imageIn, cachedIn int
+	if usage.PromptTokensDetails != nil {
+		textIn = usage.PromptTokensDetails.TextTokens
+		imageIn = usage.PromptTokensDetails.ImageTokens
+		cachedIn = usage.PromptTokensDetails.CachedTokens
+	}
+	if textIn < 0 {
+		textIn = 0
+	}
+	if imageIn < 0 {
+		imageIn = 0
+	}
+	if cachedIn < 0 {
+		cachedIn = 0
+	}
+	totalIn := textIn + imageIn
+	if cachedIn > totalIn {
+		cachedIn = totalIn
+	}
+	cachedText := 0
+	cachedImage := 0
+	if cachedIn > 0 && totalIn > 0 {
+		cachedText = min(max(int(math.Round(float64(cachedIn)*(float64(textIn)/float64(totalIn)))), 0), cachedIn)
+		cachedImage = cachedIn - cachedText
+	}
+	normalText := max(textIn-cachedText, 0)
+	normalImage := max(imageIn-cachedImage, 0)
+	outTokens := max(usage.CompletionTokens, 0)
+
+	quota := 0.0
+	quota += float64(normalText) * pricing.inputTextUSD * billingratio.MilliTokensUsd
+	quota += float64(cachedText) * pricing.cachedInputTextUSD * billingratio.MilliTokensUsd
+	quota += float64(normalImage) * pricing.inputImageUSD * billingratio.MilliTokensUsd
+	quota += float64(cachedImage) * pricing.cachedInputImageUSD * billingratio.MilliTokensUsd
+	quota += float64(outTokens) * pricing.outputImageUSD * billingratio.MilliTokensUsd
+
+	if groupRatio > 0 {
+		quota *= groupRatio
+	}
+	return quota
+}
+
+// computeImageUsageQuota routes to the correct usage-based cost function per model.
+// Returns 0 when usage is missing or the model has no token pricing rule.
+func computeImageUsageQuota(modelName string, usage *relaymodel.Usage, groupRatio float64) float64 {
+	if usage == nil {
+		return 0
+	}
+	// Basic reliability check: some providers may omit usage entirely
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 && (usage.PromptTokensDetails == nil) {
+		return 0
+	}
+	// The bucket table is the allowlist; keep dispatch in sync with every priced
+	// alias and snapshot without maintaining a second model-name list.
+	return computeGptImageTokenQuota(modelName, usage, groupRatio)
+}
+
+// imageQuotaSummary tracks the breakdown of image billing across fixed per-image components and token-based usage.
+type imageQuotaSummary struct {
+	BaseQuota       int64
+	TokenQuota      int64
+	TokenQuotaFloat float64
+	TotalQuota      int64
+}
+
+// calculateImageBaseQuota derives the upfront quota reservation for an image request.
+// When per-image billing is enabled, the quota scales with the billed image count and tier multiplier.
+// For token-only models, the base quota falls back to the model ratio estimation.
+func calculateImageBaseQuota(imagePriceUsd, ratio, imageCostRatio, groupRatio float64, count int) int64 {
+	if count <= 0 {
+		return 0
+	}
+	if imagePriceUsd > 0 {
+		perImageQuota := math.Ceil(imagePriceUsd * billingratio.QuotaPerUsd * imageCostRatio * groupRatio)
+		if perImageQuota <= 0 {
+			return 0
+		}
+		return int64(perImageQuota) * int64(count)
+	}
+	if ratio <= 0 {
+		return 0
+	}
+	perImageQuota := math.Ceil(ratio * imageCostRatio)
+	if perImageQuota <= 0 {
+		return 0
+	}
+	return int64(perImageQuota) * int64(count)
+}
+
+// finalizeImageQuota merges token usage data with the reserved base quota to produce the final billed amount.
+// GPT Image 2.5 replaces its reserve; older models retain additive render billing.
+// Parameters: baseQuota is reserved quota, perImageBilling selects the legacy path,
+// imageModel/actualModel identify pricing, usage contains provider counts, and groupRatio
+// scales prices. Returns: the final charge and its token/reservation breakdown.
+func finalizeImageQuota(baseQuota int64, perImageBilling bool, imageModel string, actualModel string, usage *relaymodel.Usage, groupRatio float64) imageQuotaSummary {
+	summary := imageQuotaSummary{
+		BaseQuota:  baseQuota,
+		TotalQuota: baseQuota,
+	}
+	if usage == nil {
+		return summary
+	}
+
+	tokenQuotaFloat := computeImageUsageQuota(imageModel, usage, groupRatio)
+	if tokenQuotaFloat < 0 {
+		tokenQuotaFloat = 0
+	}
+	tokenQuota := int64(math.Ceil(tokenQuotaFloat))
+	if tokenQuota < 0 {
+		tokenQuota = 0
+	}
+	summary.TokenQuotaFloat = tokenQuotaFloat
+	summary.TokenQuota = tokenQuota
+
+	if isGPTImage25Model(imageModel) {
+		// A successful render needs output usage. Missing/partial/ambiguous
+		// usage keeps the explicit operator fallback, never a one-token charge.
+		if usage.CompletionTokens > 0 && tokenQuota > 0 {
+			summary.TotalQuota = tokenQuota
+		} else {
+			summary.TokenQuota = 0
+			summary.TokenQuotaFloat = 0
+		}
+		return summary
+	}
+
+	if perImageBilling {
+		if tokenQuota > 0 {
+			summary.TotalQuota += tokenQuota
+		}
+		return summary
+	}
+
+	if tokenQuota > 0 {
+		summary.TotalQuota = tokenQuota
+		return summary
+	}
+
+	fallbackFloat := computeLegacyImageTokenQuota(actualModel, usage, groupRatio)
+	if fallbackFloat > 0 {
+		fallbackQuota := int64(math.Ceil(fallbackFloat))
+		if fallbackQuota < 0 {
+			fallbackQuota = 0
+		}
+		summary.TokenQuotaFloat = fallbackFloat
+		summary.TokenQuota = fallbackQuota
+		summary.TotalQuota = baseQuota + fallbackQuota
+	}
+
+	return summary
+}
+
+// computeLegacyImageTokenQuota handles legacy token billing paths for image models lacking detailed bucket pricing.
+func computeLegacyImageTokenQuota(modelName string, usage *relaymodel.Usage, groupRatio float64) float64 {
+	if usage == nil || usage.PromptTokensDetails == nil {
+		return 0
+	}
+	switch modelName {
+	case "gpt-image-1", "gpt-image-1-mini":
+		textTokens := usage.PromptTokensDetails.TextTokens
+		if textTokens < 0 {
+			textTokens = 0
+		}
+		imageTokens := usage.PromptTokensDetails.ImageTokens
+		if imageTokens < 0 {
+			imageTokens = 0
+		}
+		quota := float64(textTokens)*5*billingratio.MilliTokensUsd + float64(imageTokens)*10*billingratio.MilliTokensUsd
+		if groupRatio > 0 {
+			quota *= groupRatio
+		}
+		return quota
+	case "chatgpt-image-latest", "gpt-image-1.5", "gpt-image-1.5-2025-12-16", "gpt-image-2", "gpt-image-2-2026-04-21":
+		textTokens := usage.PromptTokensDetails.TextTokens
+		if textTokens < 0 {
+			textTokens = 0
+		}
+		imageTokens := usage.PromptTokensDetails.ImageTokens
+		if imageTokens < 0 {
+			imageTokens = 0
+		}
+		quota := float64(textTokens)*5*billingratio.MilliTokensUsd + float64(imageTokens)*8*billingratio.MilliTokensUsd
+		if groupRatio > 0 {
+			quota *= groupRatio
+		}
+		return quota
+	default:
+		return 0
+	}
+}

--- a/relay/controller/image_token_billing.go
+++ b/relay/controller/image_token_billing.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"math"
 
+	"github.com/Laisky/one-api/relay/adaptor"
 	billingratio "github.com/Laisky/one-api/relay/billing/ratio"
 	relaymodel "github.com/Laisky/one-api/relay/model"
 )
@@ -212,8 +213,8 @@ func calculateImageBaseQuota(imagePriceUsd, ratio, imageCostRatio, groupRatio fl
 // GPT Image 2.5 replaces its reserve; older models retain additive render billing.
 // Parameters: baseQuota is reserved quota, perImageBilling selects the legacy path,
 // imageModel/actualModel identify pricing, usage contains provider counts, and groupRatio
-// scales prices. Returns: the final charge and its token/reservation breakdown.
-func finalizeImageQuota(baseQuota int64, perImageBilling bool, imageModel string, actualModel string, usage *relaymodel.Usage, groupRatio float64) imageQuotaSummary {
+// scales prices; configs optionally provides request-start channel pricing. Returns: the final charge and its token/reservation breakdown.
+func finalizeImageQuota(baseQuota int64, perImageBilling bool, imageModel string, actualModel string, usage *relaymodel.Usage, groupRatio float64, configs ...adaptor.ModelConfig) imageQuotaSummary {
 	summary := imageQuotaSummary{
 		BaseQuota:  baseQuota,
 		TotalQuota: baseQuota,
@@ -223,6 +224,9 @@ func finalizeImageQuota(baseQuota int64, perImageBilling bool, imageModel string
 	}
 
 	tokenQuotaFloat := computeImageUsageQuota(imageModel, usage, groupRatio)
+	if isGPTImage25Model(imageModel) && len(configs) > 0 {
+		tokenQuotaFloat = computeGPTImage25ConfiguredQuota(usage, configs[0], groupRatio)
+	}
 	if tokenQuotaFloat < 0 {
 		tokenQuotaFloat = 0
 	}

--- a/relay/model/image_usage.go
+++ b/relay/model/image_usage.go
@@ -1,0 +1,9 @@
+package model
+
+// UsageCachedTokensDetails preserves the provider's cached input modalities.
+// A nil parent pointer means no split was supplied; an explicit zero remains
+// authoritative. Counts are included in TextTokens/ImageTokens, not added to them.
+type UsageCachedTokensDetails struct {
+	TextTokens  int `json:"text_tokens,omitempty"`
+	ImageTokens int `json:"image_tokens,omitempty"`
+}

--- a/relay/model/misc.go
+++ b/relay/model/misc.go
@@ -144,8 +144,9 @@ type ErrorWithStatusCode struct {
 
 // UsagePromptTokensDetails contains details about the prompt tokens used in a request.
 type UsagePromptTokensDetails struct {
-	CachedTokens int `json:"cached_tokens"`
-	AudioTokens  int `json:"audio_tokens"`
+	CachedTokensDetails *UsageCachedTokensDetails `json:"cached_tokens_details,omitempty"`
+	CachedTokens        int                       `json:"cached_tokens"`
+	AudioTokens         int                       `json:"audio_tokens"`
 	// TextTokens could be zero for pure text chats
 	TextTokens     int     `json:"text_tokens"`
 	ImageTokens    int     `json:"image_tokens"`


### PR DESCRIPTION
## Summary

Add the official GPT Image 2.5 catalog entries and repair the five original reviewer findings using **behavioral reproduction before production fixes**. Existing model IDs and tariff tables are retained.

### Added model IDs

- `gpt-image-2.5-sunburst`
- `gpt-image-2.5-sunburst-2026-09-08`
- `gpt-image-2.5-flare`
- `gpt-image-2.5-flare-2026-09-08`

Both variants have text/image input and image output, independent alias/snapshot configurations, `size=auto`, `quality=auto`, a 32,000-Unicode-code-point prompt limit, and `n=1..10`. No undocumented context/output-token limit is invented.

Standard USD per million tokens: text input **5**, cached text input **1.25**, image input **8**, cached image input **2**, image output **30**. Equal token rates do not justify copying GPT Image 2 per-image estimates.

## Important: guarded enablement

For each enabled GPT Image 2.5 ID, configure the existing channel `model_configs` field `image.price_per_image_usd` as an **operator-defined advance reservation and incomplete-usage fallback tariff**. It is not an official provider price or an additional render fee. Without a positive, finite, representable reservation, the relay returns `503 image_billing_not_configured` before any paid upstream request.

The reserve scales with count, configured tier, and group multiplier. Actual billable token cost replaces the reserve; unused quota is refunded by a signed adjustment. Missing/ambiguous usage retains the configured fallback and logs its source. A reserve is an advance estimate, **not a hard provider-cost ceiling**; actual usage can exceed it and require an additional debit under existing quota policy.

See [the operational billing note](docs/usage/openai-image25-billing.md) before enabling traffic. A price-only reservation override preserves the model's Image API defaults.

## Reviewer disposition and implementation

| Finding | Verdict | Remediation |
| --- | --- | --- |
| No meaningful quota reservation before dispatch | Confirmed, necessary | Explicit reserve/fallback policy, real pre-debit before HTTP, signed settlement/refunds |
| Missing usage produces a near-free image | Confirmed, necessary | Configured fallback, distinguish fallback from measured token billing |
| Images decoder drops cached tokens | Confirmed, necessary | Preserve aggregate and modality-specific cache details through production JSON conversion |
| Fixed token table ignores channel prices | Confirmed, necessary | Retain effective request-start channel input/cache/image/output pricing through final settlement |
| Character limit enforced as UTF-8 bytes | Confirmed, necessary | Count Unicode code points for this family; test ASCII, CJK, and emoji boundaries |

Additional coverage catches asymmetric cache allocation, totals-only/partial input, duplicate reserve-plus-token fees, and physical-balance refunds. Explicit cache buckets are used instead of proportional guessing for the new family. Incomplete mixed-cache data is treated as fallback, not invented measured usage. Unclassified input totals use the documented text-rate compatibility fallback rather than being silently dropped.

Channel `ratio`, `completion_ratio`, `cached_input_ratio`, and `image.prompt_ratio` remain effective, with existing request-start time windows and usage tiers. The existing schema has no independently configurable cached-image rate: the image multiplier applies to both input buckets.

Two subsequent suggestions to weaken intentionally RED tests were **not applied**: changing the reserve case to bypass the real per-image flag, and deleting guarded-admission/fallback assertions would hide the reproduced defects. Explanations and evidence are posted in the review threads. The new workflow disables persisted checkout credentials; no existing CI gate was weakened.

## Behavioral evidence: RED → GREEN

1. First test-only commits reproduced reservation, fallback, JSON cache handling, and settlement defects through the real controller, a local HTTP server, and SQLite: [RED run](https://github.com/Laisky/one-api/actions/runs/34369588597), head `40587c2`.
2. Production fix `12e3b30` retained those assertions: [GREEN race-enabled run](https://github.com/Laisky/one-api/actions/runs/34371296464).
3. Test-only commit `ffba145` reproduced the remaining channel-pricing and Unicode defects: [RED run](https://github.com/Laisky/one-api/actions/runs/34371849008). Channel override expected 26,000 quota but got 18,500; the valid 32,000-code-point CJK boundary was rejected.
4. Production fix `e0ccdc9` retained all regression cases: **[GREEN race-enabled run](https://github.com/Laisky/one-api/actions/runs/34373063493)**.

The final focused gate executes real repository packages with Go 1.27.1:

```sh
go test -race -count=1 -timeout=5m ./relay/adaptor/openai ./relay/controller -run 'Test(GPTImage25|Image)'
```

The HTTP/SQLite regressions verify zero upstream calls on rejected requests, physical user/token quota before dispatch, final balances, signed refunds, and persisted consumption logs/request costs. They do not merely call pricing helpers with hand-normalized usage.

## Validation scope

- Final focused behavioral/race gate: **passed** on `e0ccdc9`.
- Modern, Berry, and Air frontend tests, dependency vulnerability scan, entity-response guardrail, and Gin-context guardrail: **passed** on the same head at last inspection.
- Full repository Go checks were still running/queued at last inspection; this PR does **not** claim full CI is green.
- Local checks used formatting/syntax validation and an isolated source harness because the local container has Go 1.23.2, not the required Go 1.27.1. The linked GitHub runs provide actual package/HTTP/database evidence.
- No live paid OpenAI request was made. No streaming Images or Responses image-generation-tool implementation is added.

## Official sources

- https://developers.openai.com/api/docs/models
- https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
- https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
- https://developers.openai.com/api/docs/guides/image-generation
- https://developers.openai.com/api/reference/resources/images/methods/generate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for GPT Image 2.5 image-generation models, including Sunburst and Flare variants and dated snapshots.
  - Added token-based usage billing for text and image inputs, cached inputs, and generated images.
  - Added support for quality options including low, medium, high, xhigh, max, and auto.
  - Requests now default to automatic size and quality settings when unspecified.
  - Added support for generating between 1 and 10 images per request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->