### PR TITLE
feat(deepseek): update V4.1 Flash models and scheduled pricing

### DIFF
--- a/.github/workflows/deepseek-regression.yml
+++ b/.github/workflows/deepseek-regression.yml
@@ -1,0 +1,44 @@
+name: DeepSeek regression
+
+on:
+  pull_request:
+    paths:
+      - 'relay/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/deepseek-regression.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deepseek-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-go@v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Behavioral reproductions and negative controls
+        run: |
+          set -o pipefail
+          go test -race -count=1 -timeout 10m -v -run '^TestDeepSeekReview' \
+            ./relay/controller ./relay/adaptor/openai ./relay/model 2>&1 | tee /tmp/deepseek-regression.log
+      - name: Complete affected package suites
+        run: |
+          go test -race -count=1 -timeout 10m \
+            ./relay/controller ./relay/adaptor/deepseek ./relay/adaptor/openai \
+            ./relay/model ./relay/tooling ./relay/pricing ./relay/adaptor/common/deepseekcompat
+      - name: Save regression evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: deepseek-regression-${{ github.sha }}
+          path: /tmp/deepseek-regression.log
+          retention-days: 14

--- a/.github/workflows/deepseek-regression.yml
+++ b/.github/workflows/deepseek-regression.yml
@@ -21,8 +21,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-go@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Verify checkout does not retain authentication
+        run: |
+          python3 - <<'PYTHON'
+          import subprocess
+          keys = subprocess.check_output(
+              ["git", "config", "--local", "--name-only", "--list"], text=True
+          ).lower().splitlines()
+          if any(key.endswith(".extraheader") or key == "core.sshcommand" or
+                 (key.startswith("includeif.") and key.endswith(".path")) for key in keys):
+              raise SystemExit("Checkout retained authentication configuration for later steps.")
+          print("No checkout authentication configuration remains.")
+          PYTHON
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       - name: Behavioral reproductions and negative controls
@@ -37,7 +51,7 @@ jobs:
             ./relay/model ./relay/tooling ./relay/pricing ./relay/adaptor/common/deepseekcompat
       - name: Save regression evidence
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deepseek-regression-${{ github.sha }}
           path: /tmp/deepseek-regression.log

--- a/.github/workflows/deepseek-regression.yml
+++ b/.github/workflows/deepseek-regression.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -o pipefail
           go test -race -count=1 -timeout 10m -v -run '^TestDeepSeekReview' \
-            ./relay/controller ./relay/adaptor/openai ./relay/model 2>&1 | tee /tmp/deepseek-regression.log
+            ./relay/controller ./relay/adaptor/openai ./relay/adaptor/deepseek ./relay/model ./relay/tooling 2>&1 | tee /tmp/deepseek-regression.log
       - name: Complete affected package suites
         run: |
           go test -race -count=1 -timeout 10m \
@@ -42,13 +42,3 @@ jobs:
           name: deepseek-regression-${{ github.sha }}
           path: /tmp/deepseek-regression.log
           retention-days: 14
-      - name: Snapshot public source for this review
-        if: always()
-        run: git archive --format=tar -o /tmp/deepseek-source.tar HEAD relay common model go.mod go.sum AGENTS.md
-      - name: Save temporary source snapshot
-        if: always()
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: deepseek-source-${{ github.sha }}
-          path: /tmp/deepseek-source.tar
-          retention-days: 1

--- a/.github/workflows/deepseek-regression.yml
+++ b/.github/workflows/deepseek-regression.yml
@@ -42,3 +42,13 @@ jobs:
           name: deepseek-regression-${{ github.sha }}
           path: /tmp/deepseek-regression.log
           retention-days: 14
+      - name: Snapshot public source for this review
+        if: always()
+        run: git archive --format=tar -o /tmp/deepseek-source.tar HEAD relay common model go.mod go.sum AGENTS.md
+      - name: Save temporary source snapshot
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: deepseek-source-${{ github.sha }}
+          path: /tmp/deepseek-source.tar
+          retention-days: 1

--- a/relay/adaptor/common/deepseekcompat/models.go
+++ b/relay/adaptor/common/deepseekcompat/models.go
@@ -1,0 +1,15 @@
+package deepseekcompat
+
+import "strings"
+
+// IsFlashVisionModel reports whether modelName is an official multimodal Flash
+// API name or compatibility alias. It accepts surrounding whitespace and case
+// differences, but does not match Pro or third-party open-weight identifiers.
+func IsFlashVisionModel(modelName string) bool {
+	switch strings.ToLower(strings.TrimSpace(modelName)) {
+	case "deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp":
+		return true
+	default:
+		return false
+	}
+}

--- a/relay/adaptor/deepseek/README.md
+++ b/relay/adaptor/deepseek/README.md
@@ -32,8 +32,15 @@ All values are **USD per million tokens**.
 
 Peak hours are **01:00–04:00 and 06:00–10:00 UTC, Monday–Friday**, with inclusive
 starts and exclusive ends. All remaining hours, including weekends, are off-peak.
-Base ratios represent current off-peak defaults. These configurations are not a
-historical price archive; retired price schedules are not retained for replay.
+Base ratios represent current off-peak defaults; billing resolves the schedule
+using the request start time, not the wall-clock time at settlement.
+
+The Flash rates above take effect at **2026-09-10 04:00 UTC** (12:00 Beijing time).
+Before that instant, the immediately preceding Flash defaults are retained:
+**0.22 / 0.007 / 0.66** off-peak and **0.44 / 0.014 / 1.32** peak, ordered as
+cache-miss input / cache-hit input / output. This preserves the announced boundary
+and in-flight request accounting; it is not a complete archive of earlier prices.
+The preceding rates come from the pre-update defaults at commit `e000b8eb`.
 
 At **2026-09-14 04:00 UTC** (12:00 Beijing time), DeepSeek will route the Pro name
 to V4.1 Flash and charge Flash rates, until V4.1 Pro is released. The adapter
@@ -48,6 +55,10 @@ no unannounced model name, release date, or future price is assumed.
 Function tools remain supported. The current Responses API ignores built-in
 `web_search`, so the model defaults no longer advertise native search or a
 zero-cost built-in search policy. This does not remove user-defined search functions.
+The live guide's **Compatibility Details → Tools** table explicitly marks
+`web_search` as ignored; the API reference's **tools** section likewise says
+built-in tool types are ignored. The separate note about replaying older
+`web_search_call` input items does not advertise execution of a new search.
 Old V4 open-weight IDs and quantization claims are not carried over to V4.1 aliases.
 
 Reasoning defaults to `high`. The documented mapping is `minimal`/`low` → `low`,
@@ -67,7 +78,10 @@ go test -race ./...
 
 Tests cover the catalog and aliases, modalities, unsupported capabilities,
 reasoning aliases, both pricing resolution paths, all UTC peak boundaries,
-weekends, caller timezones, and the exact Pro transition without mutating defaults.
+weekends, caller timezones, and both announced transitions without mutating defaults.
+`TestDeepSeekReviewPricingNotice` additionally checks final quota calculation for
+cache misses, cache hits, output-only and mixed usage, including the nanosecond
+before, exact instant of, and nanosecond after both Beijing-noon changes.
 Behavioral review regressions also cover native routing, every Flash image source,
 no-fetch reservations, actual-usage final charging, validating JSON boundaries,
 all alias sampling paths, and unsupported built-ins versus user function tools.

--- a/relay/adaptor/deepseek/README.md
+++ b/relay/adaptor/deepseek/README.md
@@ -1,0 +1,74 @@
+# DeepSeek model defaults
+
+Verified against the official documentation on **2026-09-10**.
+
+## API names
+
+`deepseek-flash` is the recommended name for **DeepSeek-V4.1-Flash**.
+`deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` remain accepted aliases,
+but their former models are retired. All three names have the same current
+Flash prices, text/image input support, 1,048,576-token context limit, and
+393,216-token maximum output. The `file` modality denotes uploaded **image**
+references, not arbitrary document ingestion. Images are billed using upstream
+prompt-token usage; there is no image-generation price or fixed image-token estimate.
+
+`deepseek-v4-pro` currently serves **DeepSeek-V4-Pro-0813**, with text input only
+and the same context/output limits. Its announced transition is described below.
+The retired `deepseek-chat` and `deepseek-reasoner` names remain excluded.
+
+## Current token prices
+
+All values are **USD per million tokens**.
+
+| Model | Period | Cache-miss input | Cache-hit input | Output |
+| --- | --- | ---: | ---: | ---: |
+| Flash and its aliases | Off-peak | 0.15 | 0.003 | 0.60 |
+| Flash and its aliases | Peak | 0.30 | 0.006 | 1.20 |
+| Pro before its transition | Off-peak | 0.66 | 0.022 | 1.98 |
+| Pro before its transition | Peak | 1.32 | 0.044 | 3.96 |
+
+Peak hours are **01:00–04:00 and 06:00–10:00 UTC, Monday–Friday**, with inclusive
+starts and exclusive ends. All remaining hours, including weekends, are off-peak.
+Base ratios represent current off-peak defaults. These configurations are not a
+historical price archive; retired price schedules are not retained for replay.
+
+At **2026-09-14 04:00 UTC** (12:00 Beijing time), DeepSeek will route the Pro name
+to V4.1 Flash and charge Flash rates, until V4.1 Pro is released. The adapter
+encodes this pricing change with the existing first-match time-window mechanism;
+it neither rewrites the requested model nor switches prices early. Pro capability
+metadata describes the currently available model; the scheduled overlay changes
+pricing only. Review the catalog when the future V4.1 Pro release is announced;
+no unannounced model name, release date, or future price is assumed.
+
+## Capability corrections
+
+Function tools remain supported. The current Responses API ignores built-in
+`web_search`, so the model defaults no longer advertise native search or a
+zero-cost built-in search policy. This does not remove user-defined search functions.
+Old V4 open-weight IDs and quantization claims are not carried over to V4.1 aliases.
+
+Reasoning defaults to `high`. The documented mapping is `minimal`/`low` → `low`,
+`medium`/`high`/`xhigh` → `high`, and `max`/`ultra` → `max`.
+Temperature has no effect in thinking mode. In thinking mode `top_p` has a 0.95
+floor; in non-thinking mode it is fixed at 1.0. The gateway leaves these controls
+to the provider rather than introducing local sampling rules.
+
+## Verification
+
+Run with the repository's required Go toolchain:
+
+```sh
+go test -race ./relay/adaptor/deepseek ./relay/pricing
+go test -race ./...
+```
+
+Tests cover the catalog and aliases, modalities, unsupported capabilities,
+reasoning aliases, both pricing resolution paths, all UTC peak boundaries,
+weekends, caller timezones, and the exact Pro transition without mutating defaults.
+
+## Official sources
+
+- [Models and pricing](https://api-docs.deepseek.com/quick_start/pricing/)
+- [Thinking mode](https://api-docs.deepseek.com/guides/thinking_mode/)
+- [Vision](https://api-docs.deepseek.com/guides/vision/)
+- [Responses API](https://api-docs.deepseek.com/guides/responses_api/)

--- a/relay/adaptor/deepseek/README.md
+++ b/relay/adaptor/deepseek/README.md
@@ -10,7 +10,10 @@ but their former models are retired. All three names have the same current
 Flash prices, text/image input support, 1,048,576-token context limit, and
 393,216-token maximum output. The `file` modality denotes uploaded **image**
 references, not arbitrary document ingestion. Images are billed using upstream
-prompt-token usage; there is no image-generation price or fixed image-token estimate.
+prompt-token usage. Pre-consume estimation conservatively reserves up to **1024
+tokens per image** for every Flash alias without downloading image dimensions.
+This is not a fixed final image charge: upstream usage, including cache hits,
+remains authoritative. There is no image-generation price.
 
 `deepseek-v4-pro` currently serves **DeepSeek-V4-Pro-0813**, with text input only
 and the same context/output limits. Its announced transition is described below.
@@ -58,13 +61,17 @@ to the provider rather than introducing local sampling rules.
 Run with the repository's required Go toolchain:
 
 ```sh
-go test -race ./relay/adaptor/deepseek ./relay/pricing
+go test -race ./relay/adaptor/deepseek ./relay/adaptor/openai ./relay/controller ./relay/model ./relay/tooling ./relay/pricing
 go test -race ./...
 ```
 
 Tests cover the catalog and aliases, modalities, unsupported capabilities,
 reasoning aliases, both pricing resolution paths, all UTC peak boundaries,
 weekends, caller timezones, and the exact Pro transition without mutating defaults.
+Behavioral review regressions also cover native routing, every Flash image source,
+no-fetch reservations, actual-usage final charging, validating JSON boundaries,
+all alias sampling paths, and unsupported built-ins versus user function tools.
+The DeepSeek regression workflow runs these and the complete affected packages.
 
 ## Official sources
 
@@ -72,3 +79,4 @@ weekends, caller timezones, and the exact Pro transition without mutating defaul
 - [Thinking mode](https://api-docs.deepseek.com/guides/thinking_mode/)
 - [Vision](https://api-docs.deepseek.com/guides/vision/)
 - [Responses API](https://api-docs.deepseek.com/guides/responses_api/)
+- [Current Responses API reference](https://api-docs.deepseek.com/api/create-response/)

--- a/relay/adaptor/deepseek/adaptor.go
+++ b/relay/adaptor/deepseek/adaptor.go
@@ -41,8 +41,8 @@ func (a *Adaptor) GetDefaultModelPricing() map[string]adaptor.ModelConfig {
 }
 
 // DefaultToolingConfig returns DeepSeek's provider-level tooling defaults.
-// Parameters: none. Returns: an empty separate-pricing map because built-in web
-// search is billed through normal model token usage as of 2026-08-01.
+// Parameters: none. Returns: no built-in tool pricing entries because the
+// current Responses API ignores web_search and other built-in tool types.
 func (a *Adaptor) DefaultToolingConfig() adaptor.ChannelToolConfig {
 	return DeepseekToolingDefaults
 }
@@ -86,6 +86,7 @@ func (a *Adaptor) GetRequestURL(meta *meta.Meta) (string, error) {
 
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, meta *meta.Meta) error {
 	adaptor.SetupCommonRequestHeader(c, req, meta)
+
 	req.Header.Set("Authorization", "Bearer "+meta.APIKey)
 	return nil
 }
@@ -140,9 +141,13 @@ func normalizeDeepSeekReasoningEffort(request *model.GeneralOpenAIRequest) {
 	effort := strings.ToLower(strings.TrimSpace(*request.ReasoningEffort))
 	switch effort {
 	case "low", "high", "max":
+	case "minimal":
+		effort = "low"
 	case "medium", "xhigh":
 		// DeepSeek maps both OpenAI compatibility aliases to high.
 		effort = "high"
+	case "ultra":
+		effort = "max"
 	default:
 		request.ReasoningEffort = nil
 		return

--- a/relay/adaptor/deepseek/constants.go
+++ b/relay/adaptor/deepseek/constants.go
@@ -1,215 +1,90 @@
 package deepseek
 
 import (
-	"time"
-
 	"github.com/Laisky/one-api/relay/adaptor"
 	"github.com/Laisky/one-api/relay/billing/ratio"
 )
 
-var (
-	// deepseekTextInputs lists the input modalities supported by text-only DeepSeek V4 models.
-	deepseekTextInputs = []string{"text"}
-	// deepseekVisionInputs lists the input modalities supported by DeepSeek V4 Vision models.
-	deepseekVisionInputs = []string{"text", "image", "file"}
-	// deepseekTextOutputs lists the output modalities supported by DeepSeek V4 models.
-	deepseekTextOutputs = []string{"text"}
-
-	// deepseekFlashFeatures advertises DeepSeek V4 Flash capabilities across its
-	// Chat Completions and native Responses API endpoints.
-	deepseekFlashFeatures = []string{"tools", "json_mode", "logprobs", "reasoning", "web_search"}
-	// deepseekProFeatures advertises DeepSeek V4 Pro capabilities across its
-	// Chat Completions and native Responses API endpoints.
-	deepseekProFeatures = []string{"tools", "json_mode", "logprobs", "reasoning", "web_search"}
-	// deepseekVisionFeatures advertises only capabilities explicitly documented
-	// for the experimental V4 Flash Vision model.
-	deepseekVisionFeatures = []string{"tools", "json_mode", "logprobs", "reasoning", "web_search"}
-
-	// deepseekSamplingParams lists the OpenAI-compatible sampling parameters
-	// accepted by DeepSeek Chat Completions. Temperature and top_p have no effect
-	// while thinking is enabled.
-	deepseekSamplingParams = []string{"temperature", "top_p", "stop", "max_tokens"}
-
-	// deepseekFlashReasoningEfforts lists the distinct reasoning levels supported
-	// by DeepSeek V4 Flash. The API defaults to high.
-	deepseekFlashReasoningEfforts = []string{"low", "high", "max"}
-	// deepseekProReasoningEfforts lists the distinct reasoning levels supported
-	// by DeepSeek V4 Pro. The API defaults to high.
-	deepseekProReasoningEfforts = []string{"low", "high", "max"}
-)
-
-// DeepSeek V4 regular per-token ratios. The base values are the prices in effect
-// before the scheduled peak/off-peak pricing change on 2026-08-16 16:00 UTC.
+// Prices are USD per million tokens. The base configuration uses the current
+// off-peak rate; time windows override all three prices together.
 const (
-	// deepseekV4FlashInputRatio is the V4 Flash cache-miss input ratio.
-	deepseekV4FlashInputRatio = 0.14 * ratio.MilliTokensUsd
-	// deepseekV4FlashCachedInputRatio is the V4 Flash cache-hit input ratio.
-	deepseekV4FlashCachedInputRatio = 0.0028 * ratio.MilliTokensUsd
-	// deepseekV4ProInputRatio is the V4 Pro cache-miss input ratio.
-	deepseekV4ProInputRatio = 0.435 * ratio.MilliTokensUsd
-	// deepseekV4ProCachedInputRatio is the V4 Pro cache-hit input ratio.
-	deepseekV4ProCachedInputRatio = 0.003625 * ratio.MilliTokensUsd
-
-	// deepseekV4PricingEffectiveDate is the first local date covered by the new
-	// pricing schedule. The documented activation instant is 2026-08-16 16:00
-	// UTC, which is 2026-08-17 00:00 in the schedule's Asia/Shanghai timezone.
-	deepseekV4PricingEffectiveDate = "2026-08-17"
+	deepseekFlashInputPrice       = 0.15
+	deepseekFlashCachedInputPrice = 0.003
+	deepseekFlashOutputPrice      = 0.60
+	deepseekProInputPrice         = 0.66
+	deepseekProCachedInputPrice   = 0.022
+	deepseekProOutputPrice        = 1.98
 )
 
-// deepseekV4PricingWindows returns the official post-activation off-peak and
-// peak pricing windows for one model.
-// Parameters: offPeakInput, offPeakCachedInput, and offPeakOutput are the
-// off-peak prices per million tokens; peakInput, peakCachedInput, and
-// peakOutput are the corresponding peak prices per million tokens.
-// Returns: weekday and weekend Asia/Shanghai time windows beginning on the effective date.
-func deepseekV4PricingWindows(
-	offPeakInput float64,
-	offPeakCachedInput float64,
-	offPeakOutput float64,
-	peakInput float64,
-	peakCachedInput float64,
-	peakOutput float64,
-) []adaptor.TimeWindow {
-	return []adaptor.TimeWindow{
-		{
-			Name:     "deepseek-offpeak",
-			TimeZone: "Asia/Shanghai",
-			DateFrom: deepseekV4PricingEffectiveDate,
-			Ranges: []adaptor.ClockRange{
-				{Start: "18:00", End: "09:00"},
-				{Start: "12:00", End: "14:00"},
-			},
-			Overlay: adaptor.ModelConfig{
-				Ratio:            offPeakInput * ratio.MilliTokensUsd,
-				CachedInputRatio: offPeakCachedInput * ratio.MilliTokensUsd,
-				CompletionRatio:  offPeakOutput / offPeakInput,
-			},
-		},
-		{
-			Name:       "deepseek-weekend-offpeak",
-			TimeZone:   "Asia/Shanghai",
-			DateFrom:   deepseekV4PricingEffectiveDate,
-			DaysOfWeek: []int{int(time.Saturday), int(time.Sunday)},
-			Ranges:     []adaptor.ClockRange{{Start: "00:00", End: "00:00"}},
-			Overlay: adaptor.ModelConfig{
-				Ratio:            offPeakInput * ratio.MilliTokensUsd,
-				CachedInputRatio: offPeakCachedInput * ratio.MilliTokensUsd,
-				CompletionRatio:  offPeakOutput / offPeakInput,
-			},
-		},
-		{
-			Name:     "deepseek-peak",
-			TimeZone: "Asia/Shanghai",
-			DateFrom: deepseekV4PricingEffectiveDate,
-			DaysOfWeek: []int{
-				int(time.Monday),
-				int(time.Tuesday),
-				int(time.Wednesday),
-				int(time.Thursday),
-				int(time.Friday),
-			},
-			Ranges: []adaptor.ClockRange{
-				{Start: "09:00", End: "12:00"},
-				{Start: "14:00", End: "18:00"},
-			},
-			Overlay: adaptor.ModelConfig{
-				Ratio:            peakInput * ratio.MilliTokensUsd,
-				CachedInputRatio: peakCachedInput * ratio.MilliTokensUsd,
-				CompletionRatio:  peakOutput / peakInput,
-			},
-		},
+// deepseekModelConfig constructs independent capability slices for an API name.
+// Parameters: description identifies the current version; vision enables image
+// inputs, including uploaded image files (not arbitrary document ingestion).
+// Returns: metadata shared by the current Flash and Pro API models.
+func deepseekModelConfig(description string, vision bool) adaptor.ModelConfig {
+	inputs := []string{"text"}
+	if vision {
+		inputs = append(inputs, "image", "file")
+	}
+	return adaptor.ModelConfig{
+		ContextLength:     1048576,
+		MaxOutputTokens:   393216,
+		InputModalities:   inputs,
+		OutputModalities:  []string{"text"},
+		SupportedFeatures: []string{"tools", "json_mode", "logprobs", "reasoning"},
+		// Temperature has no effect in thinking mode. top_p is effective there
+		// with a 0.95 floor; in non-thinking mode top_p is fixed at 1.0.
+		SupportedSamplingParameters: []string{"temperature", "top_p", "stop", "max_tokens"},
+		SupportedReasoningEfforts:   []string{"low", "high", "max"},
+		DefaultReasoningEffort:      "high",
+		Description:                description,
 	}
 }
 
-// ModelRatios contains the currently available DeepSeek API models and their
-// pricing and capability metadata. Model IDs, capabilities, and prices were
-// verified on 2026-09-01 against the official DeepSeek documentation:
+// deepseekFlashModelConfig returns current V4.1 Flash metadata and pricing.
+// Parameters: description distinguishes the recommended name from aliases.
+// Returns: a fresh configuration so aliases cannot share mutable pricing slices.
+func deepseekFlashModelConfig(description string) adaptor.ModelConfig {
+	cfg := deepseekModelConfig(description, true)
+	cfg.Ratio = deepseekFlashInputPrice * ratio.MilliTokensUsd
+	cfg.CachedInputRatio = deepseekFlashCachedInputPrice * ratio.MilliTokensUsd
+	cfg.CompletionRatio = deepseekFlashOutputPrice / deepseekFlashInputPrice
+	cfg.TimeWindows = deepseekPricingWindows("", "", deepseekFlashInputPrice, deepseekFlashCachedInputPrice, deepseekFlashOutputPrice)
+	return cfg
+}
+
+// deepseekProModelConfig returns the current text-only Pro metadata, preserving
+// Pro prices until its announced upstream redirection on 2026-09-14 04:00 UTC.
+// Parameters: none. Returns: current metadata with the scheduled pricing switch.
+func deepseekProModelConfig() adaptor.ModelConfig {
+	cfg := deepseekModelConfig("DeepSeek-V4-Pro-0813 with thinking and non-thinking modes, 1M context, and native Responses and Anthropic API support. From 2026-09-14 04:00 UTC, this API name is served by V4.1 Flash at Flash prices until V4.1 Pro is released.", false)
+	cfg.Ratio = deepseekProInputPrice * ratio.MilliTokensUsd
+	cfg.CachedInputRatio = deepseekProCachedInputPrice * ratio.MilliTokensUsd
+	cfg.CompletionRatio = deepseekProOutputPrice / deepseekProInputPrice
+	cfg.TimeWindows = deepseekProPricingWindows()
+	return cfg
+}
+
+// ModelRatios contains the current DeepSeek API names, including documented
+// compatibility aliases. Verified on 2026-09-10 against:
 //   - https://api-docs.deepseek.com/quick_start/pricing/
 //   - https://api-docs.deepseek.com/guides/thinking_mode/
 //   - https://api-docs.deepseek.com/guides/vision/
-//   - https://api-docs.deepseek.com/api/list-models/
-//   - https://api-docs.deepseek.com/api/create-chat-completion/
 //   - https://api-docs.deepseek.com/guides/responses_api/
 //
-// Images sent to deepseek-v4-flash-vision-exp are converted to prompt tokens by
-// DeepSeek and therefore use the normal cache-hit/cache-miss input price. They
-// must not be charged with ImagePricing, which is reserved for generated images.
-// The retired deepseek-chat and deepseek-reasoner aliases are intentionally
-// omitted; DeepSeek made them inaccessible after 2026-07-24 15:59 UTC.
+// These are current defaults, not a historical price archive. Image inputs use
+// upstream prompt-token usage, never generated-image pricing. Retired V3 names
+// deepseek-chat and deepseek-reasoner remain excluded. Old V4 weight/quantization
+// metadata is not attached to aliases now served by the newer V4.1 model.
 var ModelRatios = map[string]adaptor.ModelConfig{
-	// deepseek-v4-flash uses the DeepSeek-V4-Flash-0731 API version. Its regular
-	// price is $0.14/1M cache-miss input, $0.0028/1M cache-hit input, and
-	// $0.28/1M output.
-	"deepseek-v4-flash": {
-		Ratio:                       deepseekV4FlashInputRatio,
-		CachedInputRatio:            deepseekV4FlashCachedInputRatio,
-		CompletionRatio:             0.28 / 0.14,
-		ContextLength:               1048576,
-		MaxOutputTokens:             393216,
-		InputModalities:             deepseekTextInputs,
-		OutputModalities:            deepseekTextOutputs,
-		SupportedFeatures:           deepseekFlashFeatures,
-		SupportedSamplingParameters: deepseekSamplingParams,
-		SupportedReasoningEfforts:   deepseekFlashReasoningEfforts,
-		DefaultReasoningEffort:      "high",
-		// Official instruct weights use FP4 MoE experts and FP8 for most other parameters.
-		Quantization:  "fp4",
-		HuggingFaceID: "deepseek-ai/DeepSeek-V4-Flash",
-		Description:   "DeepSeek-V4-Flash-0731, a 284B/13B-active MoE model with thinking and non-thinking modes, 1M context, and native Responses and Anthropic API support.",
-		// The published schedule changes all token prices after 2026-08-16 16:00 UTC.
-		TimeWindows: deepseekV4PricingWindows(0.22, 0.007, 0.66, 0.44, 0.014, 1.32),
-	},
-	// deepseek-v4-flash-vision-exp is the experimental multimodal V4 Flash model.
-	// DeepSeek documents the same token prices and limits as deepseek-v4-flash.
-	// Each image is converted into prompt tokens (at most 384 tokens per image),
-	// and the API response's usage object is authoritative for final billing.
-	"deepseek-v4-flash-vision-exp": {
-		Ratio:                       deepseekV4FlashInputRatio,
-		CachedInputRatio:            deepseekV4FlashCachedInputRatio,
-		CompletionRatio:             0.28 / 0.14,
-		ContextLength:               1048576,
-		MaxOutputTokens:             393216,
-		InputModalities:             deepseekVisionInputs,
-		OutputModalities:            deepseekTextOutputs,
-		SupportedFeatures:           deepseekVisionFeatures,
-		SupportedSamplingParameters: deepseekSamplingParams,
-		SupportedReasoningEfforts:   deepseekFlashReasoningEfforts,
-		DefaultReasoningEffort:      "high",
-		Description:                 "DeepSeek-V4-Flash-Vision-Exp, an experimental multimodal V4 Flash model with text and image input, thinking and non-thinking modes, 1M context, and Chat Completions, Responses, and Anthropic API support.",
-		TimeWindows:                 deepseekV4PricingWindows(0.22, 0.007, 0.66, 0.44, 0.014, 1.32),
-	},
-	// deepseek-v4-pro costs $0.435/1M cache-miss input, $0.003625/1M cache-hit
-	// input, and $0.87/1M output before 2026-08-16 16:00 UTC. Its scheduled
-	// post-activation prices are $0.66/$0.022/$1.98 off-peak and
-	// $1.32/$0.044/$3.96 at peak for cache-miss input/cache-hit input/output.
-	"deepseek-v4-pro": {
-		Ratio:                       deepseekV4ProInputRatio,
-		CachedInputRatio:            deepseekV4ProCachedInputRatio,
-		CompletionRatio:             0.87 / 0.435,
-		ContextLength:               1048576,
-		MaxOutputTokens:             393216,
-		InputModalities:             deepseekTextInputs,
-		OutputModalities:            deepseekTextOutputs,
-		SupportedFeatures:           deepseekProFeatures,
-		SupportedSamplingParameters: deepseekSamplingParams,
-		SupportedReasoningEfforts:   deepseekProReasoningEfforts,
-		DefaultReasoningEffort:      "high",
-		// Official instruct weights use FP4 MoE experts and FP8 for most other parameters.
-		Quantization:  "fp4",
-		HuggingFaceID: "deepseek-ai/DeepSeek-V4-Pro",
-		Description:   "DeepSeek-V4-Pro-0813, a 1.6T/49B-active MoE model with thinking and non-thinking modes, 1M context, and native Responses and Anthropic API support.",
-		// The published schedule changes all token prices after 2026-08-16 16:00 UTC.
-		TimeWindows: deepseekV4PricingWindows(0.66, 0.022, 1.98, 1.32, 0.044, 3.96),
-	},
+	"deepseek-flash":               deepseekFlashModelConfig("DeepSeek-V4.1-Flash, the recommended multimodal Flash API name, with thinking and non-thinking modes, 1M context, and native Responses and Anthropic API support."),
+	"deepseek-v4-flash":            deepseekFlashModelConfig("Compatibility alias for DeepSeek-V4.1-Flash; the original V4 Flash model is retired. Supports text and image input and uses current Flash prices."),
+	"deepseek-v4-flash-vision-exp": deepseekFlashModelConfig("Compatibility alias for DeepSeek-V4.1-Flash; the experimental V4 vision model is retired. Supports text and image input and uses current Flash prices."),
+	"deepseek-v4-pro":              deepseekProModelConfig(),
 }
 
-// DeepseekToolingDefaults documents that DeepSeek does not publish separate
-// built-in tool prices; server-side web search incurs normal model token usage.
-// The explicit zero-cost entry lets policy validation allow the native tool.
+// DeepseekToolingDefaults does not advertise a separate built-in tool policy.
+// The current Responses API ignores web_search and other built-in tool types;
+// function tools remain supported and their token usage is billed normally.
 var DeepseekToolingDefaults = adaptor.ChannelToolConfig{
-	Pricing: map[string]adaptor.ToolPricingConfig{
-		// DeepSeek web search is billed through model tokens, so the gateway
-		// records an explicit zero-cost policy entry to allow the native tool.
-		"web_search": {QuotaPerCall: 0},
-	},
+	Pricing: map[string]adaptor.ToolPricingConfig{},
 }

--- a/relay/adaptor/deepseek/constants.go
+++ b/relay/adaptor/deepseek/constants.go
@@ -48,7 +48,7 @@ func deepseekFlashModelConfig(description string) adaptor.ModelConfig {
 	cfg.Ratio = deepseekFlashInputPrice * ratio.MilliTokensUsd
 	cfg.CachedInputRatio = deepseekFlashCachedInputPrice * ratio.MilliTokensUsd
 	cfg.CompletionRatio = deepseekFlashOutputPrice / deepseekFlashInputPrice
-	cfg.TimeWindows = deepseekPricingWindows("", "", deepseekFlashInputPrice, deepseekFlashCachedInputPrice, deepseekFlashOutputPrice)
+	cfg.TimeWindows = deepseekFlashPricingWindows()
 	return cfg
 }
 
@@ -71,7 +71,8 @@ func deepseekProModelConfig() adaptor.ModelConfig {
 //   - https://api-docs.deepseek.com/guides/vision/
 //   - https://api-docs.deepseek.com/guides/responses_api/
 //
-// These are current defaults, not a historical price archive. Image inputs use
+// These defaults retain the immediately preceding Flash rates for the announced
+// transition, not a complete historical price archive. Image inputs use
 // upstream prompt-token usage, never generated-image pricing. Retired V3 names
 // deepseek-chat and deepseek-reasoner remain excluded. Old V4 weight/quantization
 // metadata is not attached to aliases now served by the newer V4.1 model.

--- a/relay/adaptor/deepseek/constants_test.go
+++ b/relay/adaptor/deepseek/constants_test.go
@@ -2,137 +2,79 @@ package deepseek
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/Laisky/one-api/relay/billing/ratio"
-	"github.com/Laisky/one-api/relay/pricing"
 )
 
-// TestModelRatiosMatchOfficialCatalog verifies that the adapter exposes only
-// the model IDs currently returned by DeepSeek's official model catalog.
+// TestModelRatiosMatchOfficialCatalog checks current and compatible API names,
+// without reintroducing retired V3 names or inventing version-pinned IDs.
 func TestModelRatiosMatchOfficialCatalog(t *testing.T) {
 	t.Parallel()
-
-	require.Len(t, ModelRatios, 3)
-	require.Contains(t, ModelRatios, "deepseek-v4-flash")
-	require.Contains(t, ModelRatios, "deepseek-v4-flash-vision-exp")
-	require.Contains(t, ModelRatios, "deepseek-v4-pro")
-	require.NotContains(t, ModelRatios, "deepseek-chat")
-	require.NotContains(t, ModelRatios, "deepseek-reasoner")
+	require.ElementsMatch(t, []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro"}, (&Adaptor{}).GetModelList())
+	for _, name := range []string{"deepseek-chat", "deepseek-reasoner", "deepseek-v4-flash-vision", "deepseek-v4.1-pro"} {
+		require.NotContains(t, ModelRatios, name)
+	}
 }
 
-// TestModelRatiosMatchOfficialPricing verifies current regular prices, context
-// limits, and the scheduled peak/off-peak pricing overlays.
+// TestModelRatiosMatchOfficialPricing verifies current off-peak defaults. The
+// separate schedule tests exercise the authoritative time-dependent prices.
 func TestModelRatiosMatchOfficialPricing(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name        string
-		input       float64
-		cachedInput float64
-		output      float64
-		flashPrice  bool
-	}{
-		{name: "deepseek-v4-flash", input: 0.14, cachedInput: 0.0028, output: 0.28, flashPrice: true},
-		{name: "deepseek-v4-flash-vision-exp", input: 0.14, cachedInput: 0.0028, output: 0.28, flashPrice: true},
-		{name: "deepseek-v4-pro", input: 0.435, cachedInput: 0.003625, output: 0.87},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, cfg := range ModelRatios {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-
-			cfg := ModelRatios[tt.name]
-			require.InDelta(t, tt.input*ratio.MilliTokensUsd, cfg.Ratio, 1e-15)
-			require.InDelta(t, tt.cachedInput*ratio.MilliTokensUsd, cfg.CachedInputRatio, 1e-15)
-			require.InDelta(t, tt.output*ratio.MilliTokensUsd, cfg.Ratio*cfg.CompletionRatio, 1e-15)
+			input, cached, output := 0.15, 0.003, 0.60
+			if name == "deepseek-v4-pro" {
+				input, cached, output = 0.66, 0.022, 1.98
+			}
+			require.InDelta(t, input, cfg.Ratio/ratio.MilliTokensUsd, 1e-12)
+			require.InDelta(t, cached, cfg.CachedInputRatio/ratio.MilliTokensUsd, 1e-12)
+			require.InDelta(t, output, cfg.Ratio*cfg.CompletionRatio/ratio.MilliTokensUsd, 1e-12)
 			require.Equal(t, int32(1048576), cfg.ContextLength)
 			require.Equal(t, int32(393216), cfg.MaxOutputTokens)
-			require.Len(t, cfg.TimeWindows, 3)
-			require.Equal(t, "2026-08-17", cfg.TimeWindows[0].DateFrom)
-			require.Equal(t, "Asia/Shanghai", cfg.TimeWindows[0].TimeZone)
-
-			beforeActivation := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 16, 15, 59, 0, 0, time.UTC))
-			require.InDelta(t, cfg.Ratio, beforeActivation.Ratio, 1e-15)
-
-			offPeak := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 24, 5, 0, 0, 0, time.UTC))
-			peak := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 24, 2, 0, 0, 0, time.UTC))
-			if tt.flashPrice {
-				require.InDelta(t, 0.22*ratio.MilliTokensUsd, offPeak.Ratio, 1e-15)
-				require.InDelta(t, 0.007*ratio.MilliTokensUsd, offPeak.CachedInputRatio, 1e-15)
-				require.InDelta(t, 0.66/0.22, offPeak.CompletionRatio, 1e-15)
-				require.InDelta(t, 0.44*ratio.MilliTokensUsd, peak.Ratio, 1e-15)
-				require.InDelta(t, 0.014*ratio.MilliTokensUsd, peak.CachedInputRatio, 1e-15)
-				require.InDelta(t, 1.32/0.44, peak.CompletionRatio, 1e-15)
-			} else {
-				require.InDelta(t, 0.66*ratio.MilliTokensUsd, offPeak.Ratio, 1e-15)
-				require.InDelta(t, 0.022*ratio.MilliTokensUsd, offPeak.CachedInputRatio, 1e-15)
-				require.InDelta(t, 1.98/0.66, offPeak.CompletionRatio, 1e-15)
-				require.InDelta(t, 1.32*ratio.MilliTokensUsd, peak.Ratio, 1e-15)
-				require.InDelta(t, 0.044*ratio.MilliTokensUsd, peak.CachedInputRatio, 1e-15)
-				require.InDelta(t, 3.96/1.32, peak.CompletionRatio, 1e-15)
-			}
-			require.NotContains(t, cfg.SupportedFeatures, "structured_outputs")
-			if tt.name == "deepseek-v4-flash-vision-exp" {
-				require.Empty(t, cfg.Quantization)
-			} else {
-				require.Equal(t, "fp4", cfg.Quantization)
-			}
 		})
 	}
 }
 
-// TestDeepSeekPricingScheduleHonorsActivationAndWeekends verifies the published
-// schedule starts on the documented date and never applies weekday peak prices
-// on weekends.
-// Parameters: t is the testing handle used for assertions and test lifecycle control.
-// Returns: nothing; the test fails through t when schedule boundaries are wrong.
-func TestDeepSeekPricingScheduleHonorsActivationAndWeekends(t *testing.T) {
-	t.Parallel()
-
-	cfg := ModelRatios["deepseek-v4-flash"]
-	beforeActivation := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 16, 15, 59, 0, 0, time.UTC))
-	require.InDelta(t, cfg.Ratio, beforeActivation.Ratio, 1e-15)
-
-	atActivation := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC))
-	require.InDelta(t, 0.22*ratio.MilliTokensUsd, atActivation.Ratio, 1e-15)
-	require.InDelta(t, 0.007*ratio.MilliTokensUsd, atActivation.CachedInputRatio, 1e-15)
-
-	firstWeekdayPeakHour := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC))
-	require.InDelta(t, 0.44*ratio.MilliTokensUsd, firstWeekdayPeakHour.Ratio, 1e-15)
-
-	saturdayPeakHour := pricing.ApplyTimeWindow(cfg, time.Date(2026, 8, 22, 2, 0, 0, 0, time.UTC))
-	require.InDelta(t, 0.22*ratio.MilliTokensUsd, saturdayPeakHour.Ratio, 1e-15)
-	require.InDelta(t, 0.007*ratio.MilliTokensUsd, saturdayPeakHour.CachedInputRatio, 1e-15)
-}
-
-// TestModelRatiosMatchOfficialCapabilities verifies model-specific version,
-// modalities, reasoning effort, and endpoint capability metadata.
-// Parameters: t is the testing handle used for assertions and test lifecycle control.
-// Returns: nothing; the test fails through t when advertised capabilities are inconsistent.
+// TestModelRatiosMatchOfficialCapabilities prevents stale vision, search, and
+// open-weight metadata from being advertised for the replacement Flash model.
 func TestModelRatiosMatchOfficialCapabilities(t *testing.T) {
 	t.Parallel()
+	for name, cfg := range ModelRatios {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.ElementsMatch(t, []string{"low", "high", "max"}, cfg.SupportedReasoningEfforts)
+			require.Equal(t, "high", cfg.DefaultReasoningEffort)
+			require.ElementsMatch(t, []string{"text"}, cfg.OutputModalities)
+			require.ElementsMatch(t, []string{"tools", "json_mode", "logprobs", "reasoning"}, cfg.SupportedFeatures)
+			require.Contains(t, cfg.SupportedSamplingParameters, "temperature")
+			require.Contains(t, cfg.SupportedSamplingParameters, "top_p")
+			require.Nil(t, cfg.Image, "image inputs are prompt tokens, not generated images")
+			if name == "deepseek-v4-pro" {
+				require.ElementsMatch(t, []string{"text"}, cfg.InputModalities)
+				require.Contains(t, cfg.Description, "DeepSeek-V4-Pro-0813")
+			} else {
+				require.ElementsMatch(t, []string{"text", "image", "file"}, cfg.InputModalities)
+				require.Contains(t, cfg.Description, "DeepSeek-V4.1-Flash")
+				require.Empty(t, cfg.Quantization)
+				require.Empty(t, cfg.HuggingFaceID)
+			}
+		})
+	}
+	require.Empty(t, (&Adaptor{}).DefaultToolingConfig().Pricing, "ignored built-in tools must not be advertised as free native tools")
+}
 
-	flash := ModelRatios["deepseek-v4-flash"]
-	require.ElementsMatch(t, []string{"low", "high", "max"}, flash.SupportedReasoningEfforts)
-	require.Contains(t, flash.SupportedFeatures, "web_search")
-	require.Contains(t, flash.Description, "DeepSeek-V4-Flash-0731")
-
-	vision := ModelRatios["deepseek-v4-flash-vision-exp"]
-	require.ElementsMatch(t, []string{"text", "image", "file"}, vision.InputModalities)
-	require.ElementsMatch(t, []string{"text"}, vision.OutputModalities)
-	require.ElementsMatch(t, []string{"low", "high", "max"}, vision.SupportedReasoningEfforts)
-	require.Contains(t, vision.SupportedFeatures, "tools")
-	require.Contains(t, vision.SupportedFeatures, "json_mode")
-	require.Contains(t, vision.SupportedFeatures, "logprobs")
-	require.Contains(t, vision.SupportedFeatures, "web_search")
-	require.Nil(t, vision.Image, "image inputs are billed as prompt tokens, not per generated image")
-	require.Contains(t, vision.Description, "DeepSeek-V4-Flash-Vision-Exp")
-
-	pro := ModelRatios["deepseek-v4-pro"]
-	require.ElementsMatch(t, []string{"low", "high", "max"}, pro.SupportedReasoningEfforts)
-	require.Contains(t, pro.SupportedFeatures, "web_search")
-	require.Contains(t, pro.Description, "native Responses and Anthropic API support")
+// TestDeepSeekFlashAliasesShareCurrentConfiguration compares all alias metadata
+// except their deliberately distinct descriptions.
+func TestDeepSeekFlashAliasesShareCurrentConfiguration(t *testing.T) {
+	t.Parallel()
+	canonical := ModelRatios["deepseek-flash"]
+	canonical.Description = ""
+	for _, name := range []string{"deepseek-v4-flash", "deepseek-v4-flash-vision-exp"} {
+		alias := ModelRatios[name]
+		alias.Description = ""
+		require.Equal(t, canonical, alias, name)
+	}
 }

--- a/relay/adaptor/deepseek/pricing_notice_test.go
+++ b/relay/adaptor/deepseek/pricing_notice_test.go
@@ -1,0 +1,97 @@
+package deepseek
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	modelcfg "github.com/Laisky/one-api/model"
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/pricing"
+	"github.com/Laisky/one-api/relay/quota"
+)
+
+// TestDeepSeekReviewPricingNotice verifies both announced Beijing-noon changes
+// through the production pricing resolvers and final quota calculation.
+// Parameters: t is the test handle. Returns: nothing; incorrect rates fail tests.
+func TestDeepSeekReviewPricingNotice(t *testing.T) {
+	t.Parallel()
+	// Each price triple is cache-miss input, cache-hit input, output in USD/1M.
+	// Pre-notice Flash prices preserve the immediately preceding defaults from
+	// e000b8eb; new prices and both dates follow the operator-provided notice.
+	cases := []struct {
+		at    string
+		flash [3]float64
+		pro   [3]float64
+	}{
+		{"2026-09-09T12:00:00Z", [3]float64{0.22, 0.007, 0.66}, [3]float64{0.66, 0.022, 1.98}},
+		{"2026-09-10T00:00:00Z", [3]float64{0.22, 0.007, 0.66}, [3]float64{0.66, 0.022, 1.98}},
+		{"2026-09-10T01:00:00Z", [3]float64{0.44, 0.014, 1.32}, [3]float64{1.32, 0.044, 3.96}},
+		{"2026-09-10T03:59:59.999999999Z", [3]float64{0.44, 0.014, 1.32}, [3]float64{1.32, 0.044, 3.96}},
+		{"2026-09-10T04:00:00Z", [3]float64{0.15, 0.003, 0.60}, [3]float64{0.66, 0.022, 1.98}},
+		{"2026-09-10T04:00:00.000000001Z", [3]float64{0.15, 0.003, 0.60}, [3]float64{0.66, 0.022, 1.98}},
+		{"2026-09-10T06:00:00Z", [3]float64{0.30, 0.006, 1.20}, [3]float64{1.32, 0.044, 3.96}},
+		{"2026-09-12T06:00:00Z", [3]float64{0.15, 0.003, 0.60}, [3]float64{0.66, 0.022, 1.98}},
+		{"2026-09-14T03:59:59.999999999Z", [3]float64{0.30, 0.006, 1.20}, [3]float64{1.32, 0.044, 3.96}},
+		{"2026-09-14T04:00:00Z", [3]float64{0.15, 0.003, 0.60}, [3]float64{0.15, 0.003, 0.60}},
+		{"2026-09-14T04:00:00.000000001Z", [3]float64{0.15, 0.003, 0.60}, [3]float64{0.15, 0.003, 0.60}},
+		{"2026-09-14T06:00:00Z", [3]float64{0.30, 0.006, 1.20}, [3]float64{0.30, 0.006, 1.20}},
+		{"2026-09-15T00:00:00Z", [3]float64{0.15, 0.003, 0.60}, [3]float64{0.15, 0.003, 0.60}},
+	}
+	provider := &Adaptor{}
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro"} {
+		for _, tc := range cases {
+			t.Run(name+"/"+tc.at, func(t *testing.T) {
+				t.Parallel()
+				at, err := time.Parse(time.RFC3339Nano, tc.at)
+				require.NoError(t, err)
+				want := tc.flash
+				if name == "deepseek-v4-pro" {
+					want = tc.pro
+				}
+				for label, resolve := range map[string]func(string, map[string]modelcfg.ModelConfigLocal, adaptor.Adaptor, time.Time) (adaptor.ModelConfig, bool){
+					"full": pricing.ResolveModelConfig, "token_only": pricing.ResolveModelConfigRatioOnly,
+				} {
+					t.Run(label, func(t *testing.T) {
+						cfg, ok := resolve(name, nil, provider, at)
+						require.True(t, ok)
+						require.InDelta(t, want[0], cfg.Ratio/ratio.MilliTokensUsd, 1e-12)
+						require.InDelta(t, want[1], cfg.CachedInputRatio/ratio.MilliTokensUsd, 1e-12)
+						require.InDelta(t, want[2], cfg.Ratio*cfg.CompletionRatio/ratio.MilliTokensUsd, 1e-12)
+						beijing := at.In(time.FixedZone("Beijing", 8*60*60))
+						local, found := resolve(name, nil, provider, beijing)
+						require.True(t, found)
+						require.Equal(t, cfg, local, "caller timezone must not change billing")
+					})
+				}
+				for _, usage := range []struct {
+					name                    string
+					prompt, cached, output  int
+				}{
+					{"cache_miss", 100000, 0, 0},
+					{"cache_hit", 100000, 100000, 0},
+					{"output", 0, 0, 100000},
+					{"mixed", 300000, 100000, 50000},
+				} {
+					t.Run("settlement/"+usage.name, func(t *testing.T) {
+						result := quota.Compute(quota.ComputeInput{
+							ModelName: name, ModelRatio: provider.GetModelRatio(name),
+							PricingAdaptor: provider, GroupRatio: 1, RequestTime: at,
+							Usage: &relaymodel.Usage{
+								PromptTokens: usage.prompt, CompletionTokens: usage.output,
+								PromptTokensDetails: &relaymodel.UsagePromptTokensDetails{CachedTokens: usage.cached},
+							},
+						})
+						usd := (float64(usage.prompt-usage.cached)*want[0] + float64(usage.cached)*want[1] + float64(usage.output)*want[2]) / 1000000
+						require.Equal(t, int64(math.Round(usd*ratio.QuotaPerUsd)), result.TotalQuota)
+						require.Equal(t, usage.cached, result.CachedPromptTokens)
+					})
+				}
+			})
+		}
+	}
+}

--- a/relay/adaptor/deepseek/pricing_schedule.go
+++ b/relay/adaptor/deepseek/pricing_schedule.go
@@ -1,0 +1,51 @@
+package deepseek
+
+import (
+	"time"
+
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+)
+
+// deepseekPricingWindows builds the official UTC weekday peak schedule followed
+// by an all-day off-peak fallback. First-match ordering is intentional.
+// Parameters: date bounds are inclusive/exclusive UTC dates; input, cachedInput,
+// and output are off-peak USD prices per million tokens. Peak rates are double.
+// Returns: independent windows covering every instant within the date bounds.
+func deepseekPricingWindows(dateFrom, dateTo string, input, cachedInput, output float64) []adaptor.TimeWindow {
+	return []adaptor.TimeWindow{
+		{
+			Name: "deepseek-peak", TimeZone: "UTC", DateFrom: dateFrom, DateTo: dateTo,
+			DaysOfWeek: []int{int(time.Monday), int(time.Tuesday), int(time.Wednesday), int(time.Thursday), int(time.Friday)},
+			Ranges:     []adaptor.ClockRange{{Start: "01:00", End: "04:00"}, {Start: "06:00", End: "10:00"}},
+			Overlay: adaptor.ModelConfig{
+				Ratio: 2 * input * ratio.MilliTokensUsd, CachedInputRatio: 2 * cachedInput * ratio.MilliTokensUsd,
+				CompletionRatio: output / input,
+			},
+		},
+		{
+			Name: "deepseek-offpeak", TimeZone: "UTC", DateFrom: dateFrom, DateTo: dateTo,
+			Ranges: []adaptor.ClockRange{{Start: "00:00", End: "00:00"}},
+			Overlay: adaptor.ModelConfig{
+				Ratio: input * ratio.MilliTokensUsd, CachedInputRatio: cachedInput * ratio.MilliTokensUsd,
+				CompletionRatio: output / input,
+			},
+		},
+	}
+}
+
+// deepseekProPricingWindows retains Pro prices until the announced switch to
+// Flash on September 14, 2026 at 12:00 Beijing time (04:00 UTC).
+// Parameters: none. Returns: first-match windows, including a one-day bridge
+// because DateFrom/DateTo express dates rather than arbitrary timestamps.
+func deepseekProPricingWindows() []adaptor.TimeWindow {
+	const switchDate = "2026-09-14"
+	windows := deepseekPricingWindows("", switchDate, deepseekProInputPrice, deepseekProCachedInputPrice, deepseekProOutputPrice)
+	bridge := deepseekPricingWindows(switchDate, "2026-09-15", deepseekProInputPrice, deepseekProCachedInputPrice, deepseekProOutputPrice)
+	bridge[0].Name = "deepseek-pro-final-peak"
+	bridge[0].Ranges = []adaptor.ClockRange{{Start: "01:00", End: "04:00"}}
+	bridge[1].Name = "deepseek-pro-final-offpeak"
+	bridge[1].Ranges = []adaptor.ClockRange{{Start: "00:00", End: "01:00"}}
+	windows = append(windows, bridge...)
+	return append(windows, deepseekPricingWindows(switchDate, "", deepseekFlashInputPrice, deepseekFlashCachedInputPrice, deepseekFlashOutputPrice)...)
+}

--- a/relay/adaptor/deepseek/pricing_schedule.go
+++ b/relay/adaptor/deepseek/pricing_schedule.go
@@ -49,3 +49,21 @@ func deepseekProPricingWindows() []adaptor.TimeWindow {
 	windows = append(windows, bridge...)
 	return append(windows, deepseekPricingWindows(switchDate, "", deepseekFlashInputPrice, deepseekFlashCachedInputPrice, deepseekFlashOutputPrice)...)
 }
+
+// deepseekFlashPricingWindows applies the announced Flash price change at
+// September 10, 2026, 12:00 Beijing time (04:00 UTC), not UTC midnight.
+// Parameters: none. Returns: first-match windows retaining the immediately
+// preceding Flash prices until the transition. Earlier price eras are not archived.
+func deepseekFlashPricingWindows() []adaptor.TimeWindow {
+	const switchDate = "2026-09-10"
+	// Preserve the preceding defaults from e000b8eb for in-flight requests whose
+	// request start time is before the new prices become effective.
+	windows := deepseekPricingWindows("", switchDate, 0.22, 0.007, 0.66)
+	bridge := deepseekPricingWindows(switchDate, "2026-09-11", 0.22, 0.007, 0.66)
+	bridge[0].Name = "deepseek-flash-final-old-peak"
+	bridge[0].Ranges = []adaptor.ClockRange{{Start: "01:00", End: "04:00"}}
+	bridge[1].Name = "deepseek-flash-final-old-offpeak"
+	bridge[1].Ranges = []adaptor.ClockRange{{Start: "00:00", End: "01:00"}}
+	windows = append(windows, bridge...)
+	return append(windows, deepseekPricingWindows(switchDate, "", deepseekFlashInputPrice, deepseekFlashCachedInputPrice, deepseekFlashOutputPrice)...)
+}

--- a/relay/adaptor/deepseek/pricing_schedule_test.go
+++ b/relay/adaptor/deepseek/pricing_schedule_test.go
@@ -1,0 +1,66 @@
+package deepseek
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor"
+	"github.com/Laisky/one-api/relay/billing/ratio"
+	"github.com/Laisky/one-api/relay/pricing"
+)
+
+// TestDeepSeekPricingScheduleBoundaries verifies both billing paths against an
+// independent price oracle. It checks every peak boundary, weekends, UTC date
+// changes, and both sides of the Pro-to-Flash cutover, including nanoseconds.
+func TestDeepSeekPricingScheduleBoundaries(t *testing.T) {
+	t.Parallel()
+	cutover := time.Date(2026, 9, 14, 4, 0, 0, 0, time.UTC)
+	start := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
+	for name, cfg := range ModelRatios {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			original := cfg.Clone()
+			for day := 0; day < 11; day++ {
+				for _, hour := range []int{0, 1, 4, 6, 10, 24} {
+					boundary := start.AddDate(0, 0, day).Add(time.Duration(hour) * time.Hour)
+					for _, delta := range []time.Duration{-time.Nanosecond, 0, time.Nanosecond} {
+						at := boundary.Add(delta)
+						input, cached, output := 0.15, 0.003, 0.60
+						if name == "deepseek-v4-pro" && at.Before(cutover) {
+							input, cached, output = 0.66, 0.022, 1.98
+						}
+						weekday := at.Weekday() != time.Saturday && at.Weekday() != time.Sunday
+						peak := weekday && ((at.Hour() >= 1 && at.Hour() < 4) || (at.Hour() >= 6 && at.Hour() < 10))
+						if peak {
+							input, cached, output = input*2, cached*2, output*2
+						}
+						for _, apply := range []func(adaptor.ModelConfig, time.Time) adaptor.ModelConfig{pricing.ApplyTimeWindow, pricing.ApplyTimeWindowRatioOnly} {
+							resolved := apply(cfg, at)
+							require.InDelta(t, input, resolved.Ratio/ratio.MilliTokensUsd, 1e-12, "%s input at %s", name, at)
+							require.InDelta(t, cached, resolved.CachedInputRatio/ratio.MilliTokensUsd, 1e-12, "%s cached input at %s", name, at)
+							require.InDelta(t, output, resolved.Ratio*resolved.CompletionRatio/ratio.MilliTokensUsd, 1e-12, "%s output at %s", name, at)
+							require.Empty(t, resolved.TimeWindows, "a window must cover %s", at)
+						}
+					}
+				}
+			}
+			require.Equal(t, original, cfg, "resolving prices must not mutate shared model defaults")
+		})
+	}
+}
+
+// TestDeepSeekPricingUsesUTC verifies that caller-local dates cannot turn a UTC
+// Monday peak into a Sunday off-peak or shift the Pro redirection instant.
+func TestDeepSeekPricingUsesUTC(t *testing.T) {
+	t.Parallel()
+	for name, cfg := range ModelRatios {
+		for _, hour := range []int{3, 4, 6} {
+			utc := time.Date(2026, 9, 14, hour, 0, 0, 0, time.UTC)
+			local := utc.In(time.FixedZone("UTC-7", -7*60*60))
+			require.Equal(t, pricing.ApplyTimeWindow(cfg, utc), pricing.ApplyTimeWindow(cfg, local), name)
+			require.Equal(t, pricing.ApplyTimeWindowRatioOnly(cfg, utc), pricing.ApplyTimeWindowRatioOnly(cfg, local), name)
+		}
+	}
+}

--- a/relay/adaptor/deepseek/pricing_schedule_test.go
+++ b/relay/adaptor/deepseek/pricing_schedule_test.go
@@ -13,10 +13,11 @@ import (
 
 // TestDeepSeekPricingScheduleBoundaries verifies both billing paths against an
 // independent price oracle. It checks every peak boundary, weekends, UTC date
-// changes, and both sides of the Pro-to-Flash cutover, including nanoseconds.
+// changes, and both announced price cutovers, including nanoseconds.
 func TestDeepSeekPricingScheduleBoundaries(t *testing.T) {
 	t.Parallel()
 	cutover := time.Date(2026, 9, 14, 4, 0, 0, 0, time.UTC)
+	flashCutover := time.Date(2026, 9, 10, 4, 0, 0, 0, time.UTC)
 	start := time.Date(2026, 9, 10, 0, 0, 0, 0, time.UTC)
 	for name, cfg := range ModelRatios {
 		t.Run(name, func(t *testing.T) {
@@ -30,6 +31,8 @@ func TestDeepSeekPricingScheduleBoundaries(t *testing.T) {
 						input, cached, output := 0.15, 0.003, 0.60
 						if name == "deepseek-v4-pro" && at.Before(cutover) {
 							input, cached, output = 0.66, 0.022, 1.98
+						} else if name != "deepseek-v4-pro" && at.Before(flashCutover) {
+							input, cached, output = 0.22, 0.007, 0.66
 						}
 						weekday := at.Weekday() != time.Saturday && at.Weekday() != time.Sunday
 						peak := weekday && ((at.Hour() >= 1 && at.Hour() < 4) || (at.Hour() >= 6 && at.Hour() < 10))

--- a/relay/adaptor/deepseek/reasoning_effort_test.go
+++ b/relay/adaptor/deepseek/reasoning_effort_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/Laisky/one-api/relay/model"
 )
 
-// TestNormalizeDeepSeekReasoningEffortMatchesOfficialMapping verifies the
-// current DeepSeek low, medium, high, xhigh, and max compatibility mapping.
+// TestNormalizeDeepSeekReasoningEffortMatchesOfficialMapping verifies all seven
+// documented compatibility effort values, normalization, and unknown inputs.
 // Parameters: t is the testing handle used for assertions and subtests.
 // Returns: nothing; the test fails when normalization diverges from the official mapping.
 func TestNormalizeDeepSeekReasoningEffortMatchesOfficialMapping(t *testing.T) {
@@ -21,12 +21,15 @@ func TestNormalizeDeepSeekReasoningEffortMatchesOfficialMapping(t *testing.T) {
 		want    string
 		wantNil bool
 	}{
+		{name: "minimal maps to low", input: "minimal", want: "low"},
 		{name: "low remains low", input: " low ", want: "low"},
 		{name: "medium maps to high", input: "medium", want: "high"},
 		{name: "high remains high", input: "HIGH", want: "high"},
 		{name: "xhigh maps to high", input: "xhigh", want: "high"},
 		{name: "max remains max", input: "max", want: "max"},
-		{name: "unsupported value is cleared", input: "minimal", wantNil: true},
+		{name: "ultra maps to max", input: " ULTRA ", want: "max"},
+		{name: "unsupported value is cleared", input: "unknown", wantNil: true},
+		{name: "empty value is cleared", input: " ", wantNil: true},
 	}
 
 	for _, tt := range tests {

--- a/relay/adaptor/deepseek/usage_regression_test.go
+++ b/relay/adaptor/deepseek/usage_regression_test.go
@@ -1,0 +1,63 @@
+package deepseek
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/channeltype"
+	"github.com/Laisky/one-api/relay/meta"
+	"github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/quota"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+// TestDeepSeekReviewAuthoritativeUsage proves the actual streamed/non-streamed
+// response handler and quota calculator use upstream token/cache counts instead
+// of turning a conservative image reservation into a fixed final charge.
+func TestDeepSeekReviewAuthoritativeUsage(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp"} {
+		for _, stream := range []bool{false, true} {
+			t.Run(name+"/stream-"+strconv.FormatBool(stream), func(t *testing.T) {
+				t.Parallel()
+				const usageJSON = `{"prompt_tokens":300,"completion_tokens":50,"total_tokens":350,"prompt_cache_hit_tokens":100,"prompt_cache_miss_tokens":200}`
+				body := `{"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":` + usageJSON + `}`
+				contentType := "application/json"
+				if stream {
+					body = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"}}]}\n\n" +
+						"data: {\"choices\":[],\"usage\":" + usageJSON + "}\n\n" + "data: [DONE]\n\n"
+					contentType = "text/event-stream"
+				}
+				c, _ := gin.CreateTestContext(httptest.NewRecorder())
+				c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+				metadata := &meta.Meta{ChannelType: channeltype.DeepSeek, ActualModelName: name, PromptTokens: 4096, IsStream: stream, Mode: relaymode.ChatCompletions}
+				provider := &Adaptor{}
+				usage, apiErr := provider.DoResponse(c, &http.Response{
+					StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{contentType}}, Body: io.NopCloser(strings.NewReader(body)),
+				}, metadata)
+				require.Nil(t, apiErr)
+				require.NotNil(t, usage)
+				require.Equal(t, 300, usage.PromptTokens)
+				require.Equal(t, 50, usage.CompletionTokens)
+				require.NotNil(t, usage.PromptTokensDetails)
+				require.Equal(t, 100, usage.PromptTokensDetails.CachedTokens)
+				input := quota.ComputeInput{Usage: usage, ModelName: name, GroupRatio: 1, PricingAdaptor: provider, RequestTime: time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)}
+				final := quota.Compute(input)
+				// ceil((200*0.15 + 100*0.003 + 50*0.60) * 500000/1000000).
+				require.Equal(t, int64(31), final.TotalQuota)
+				require.Equal(t, 300, final.PromptTokens)
+				require.Equal(t, 100, final.CachedPromptTokens)
+				input.Usage = &model.Usage{PromptTokens: metadata.PromptTokens}
+				require.Greater(t, quota.Compute(input).TotalQuota, final.TotalQuota, "unused image reservation must not become final usage")
+			})
+		}
+	}
+}

--- a/relay/adaptor/openai/deepseek_review_regression_test.go
+++ b/relay/adaptor/openai/deepseek_review_regression_test.go
@@ -1,0 +1,76 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/model"
+)
+
+// TestDeepSeekReviewImageEstimationNoFetch verifies every Flash alias reserves
+// the documented image bound without image downloads or OpenAI tile accounting.
+func TestDeepSeekReviewImageEstimationNoFetch(t *testing.T) {
+	original := getImageSizeFn
+	fetches := 0
+	getImageSizeFn = func(string) (int, int, error) {
+		fetches++
+		return 512, 512, nil
+	}
+	t.Cleanup(func() { getImageSizeFn = original })
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp"} {
+		for _, detail := range []string{"", "auto", "low", "high", "original"} {
+			for _, source := range []string{"https://image.invalid/picture.png", "data:image/png;base64,AAAA"} {
+				t.Run(name+"/"+detail+"/"+source, func(t *testing.T) {
+					before := fetches
+					tokens, err := CountImageTokens(source, detail, name)
+					require.NoError(t, err)
+					require.Equal(t, 1024, tokens)
+					require.Equal(t, before, fetches, "DeepSeek preflight must not fetch image dimensions")
+				})
+			}
+		}
+	}
+	// A non-DeepSeek model must retain the existing OpenAI formula.
+	tokens, err := CountImageTokens("https://image.invalid/picture.png", "high", "gpt-4o")
+	require.NoError(t, err)
+	require.Equal(t, 255, tokens)
+	require.Greater(t, fetches, 0)
+}
+
+// TestDeepSeekReviewChatImageReservation decodes Chat payloads and checks URL,
+// inline and file-backed image deltas, including typed Claude-conversion content.
+func TestDeepSeekReviewChatImageReservation(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			text := map[string]any{"type": "text", "text": strings.Repeat("Describe this image. ", 10)}
+			count := func(content any) int {
+				body, err := json.Marshal(map[string]any{"model": name, "messages": []any{map[string]any{"role": "user", "content": content}}})
+				require.NoError(t, err)
+				var request model.GeneralOpenAIRequest
+				require.NoError(t, json.Unmarshal(body, &request))
+				return CountTokenMessages(context.Background(), request.Messages, request.Model)
+			}
+			base := count([]any{text})
+			images := []any{
+				map[string]any{"type": "image_url", "image_url": map[string]any{"url": "https://image.invalid/picture.png", "detail": "low"}},
+				map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,AAAA", "detail": "low"}},
+				map[string]any{"type": "file", "file_id": "file-api-image"},
+				map[string]any{"type": "file", "file_data": "data:image/png;base64,AAAA"},
+			}
+			for index, image := range images {
+				require.Equal(t, base+1024, count([]any{text, image}), "image source %d", index)
+			}
+			require.Equal(t, base+len(images)*1024, count(append([]any{text}, images...)))
+			require.Equal(t, base, count([]any{text, map[string]any{"type": "file", "file_id": " "}}))
+			plain := []model.Message{{Role: "user", Content: []model.MessageContent{}}}
+			typed := []model.Message{{Role: "user", Content: []model.MessageContent{{Type: model.ContentTypeFile, FileID: "file-api-image"}}}}
+			require.Equal(t, CountTokenMessages(context.Background(), plain, name)+1024, CountTokenMessages(context.Background(), typed, name))
+		})
+	}
+}

--- a/relay/adaptor/openai/deepseek_review_regression_test.go
+++ b/relay/adaptor/openai/deepseek_review_regression_test.go
@@ -27,9 +27,13 @@ func TestDeepSeekReviewImageEstimationNoFetch(t *testing.T) {
 				t.Run(name+"/"+detail+"/"+source, func(t *testing.T) {
 					before := fetches
 					tokens, err := CountImageTokens(source, detail, name)
-					require.NoError(t, err)
-					require.Equal(t, 1024, tokens)
-					require.Equal(t, before, fetches, "DeepSeek preflight must not fetch image dimensions")
+					t.Run("tokens", func(t *testing.T) {
+						require.NoError(t, err)
+						require.Equal(t, 1024, tokens)
+					})
+					t.Run("no-fetch", func(t *testing.T) {
+						require.Equal(t, before, fetches, "DeepSeek preflight must not fetch image dimensions")
+					})
 				})
 			}
 		}
@@ -64,13 +68,21 @@ func TestDeepSeekReviewChatImageReservation(t *testing.T) {
 				map[string]any{"type": "file", "file_data": "data:image/png;base64,AAAA"},
 			}
 			for index, image := range images {
-				require.Equal(t, base+1024, count([]any{text, image}), "image source %d", index)
+				t.Run([]string{"url", "inline", "file_id", "file_data"}[index], func(t *testing.T) {
+					require.Equal(t, base+1024, count([]any{text, image}))
+				})
 			}
-			require.Equal(t, base+len(images)*1024, count(append([]any{text}, images...)))
-			require.Equal(t, base, count([]any{text, map[string]any{"type": "file", "file_id": " "}}))
-			plain := []model.Message{{Role: "user", Content: []model.MessageContent{}}}
-			typed := []model.Message{{Role: "user", Content: []model.MessageContent{{Type: model.ContentTypeFile, FileID: "file-api-image"}}}}
-			require.Equal(t, CountTokenMessages(context.Background(), plain, name)+1024, CountTokenMessages(context.Background(), typed, name))
+			t.Run("multiple", func(t *testing.T) {
+				require.Equal(t, base+len(images)*1024, count(append([]any{text}, images...)))
+			})
+			t.Run("empty", func(t *testing.T) {
+				require.Equal(t, base, count([]any{text, map[string]any{"type": "file", "file_id": " "}}))
+			})
+			t.Run("typed-file", func(t *testing.T) {
+				plain := []model.Message{{Role: "user", Content: []model.MessageContent{}}}
+				typed := []model.Message{{Role: "user", Content: []model.MessageContent{{Type: model.ContentTypeFile, FileID: "file-api-image"}}}}
+				require.Equal(t, CountTokenMessages(context.Background(), plain, name)+1024, CountTokenMessages(context.Background(), typed, name))
+			})
 		})
 	}
 }

--- a/relay/adaptor/openai/token.go
+++ b/relay/adaptor/openai/token.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Laisky/one-api/common/config"
 	"github.com/Laisky/one-api/common/helper"
 	imgutil "github.com/Laisky/one-api/common/image"
+	"github.com/Laisky/one-api/relay/adaptor/common/deepseekcompat"
 	"github.com/Laisky/one-api/relay/model"
 	"github.com/Laisky/one-api/relay/pricing"
 )
@@ -211,7 +212,7 @@ func CountTokenMessages(ctx context.Context,
 				}
 			}
 		}
-		if actualModel == deepseekV4VisionModelName {
+		if deepseekcompat.IsFlashVisionModel(actualModel) {
 			tokenNum += countDeepSeekFileImageTokens(message.Content)
 		}
 
@@ -229,7 +230,7 @@ func CountTokenMessages(ctx context.Context,
 // countDeepSeekFileImageTokens estimates DeepSeek file content parts without
 // downloading or decoding their image payloads.
 // Parameters: content is the raw message content; the caller has already
-// restricted this helper to the DeepSeek vision model.
+// restricted this helper to a current DeepSeek Flash vision API name.
 // Returns: the documented upper-bound token estimate for each valid file image.
 func countDeepSeekFileImageTokens(content any) int {
 	total := 0
@@ -247,14 +248,14 @@ func countDeepSeekFileImageTokens(content any) int {
 			fileID, _ := block["file_id"].(string)
 			fileData, _ := block["file_data"].(string)
 			if strings.TrimSpace(fileID) != "" || strings.TrimSpace(fileData) != "" {
-				total += deepseekV4VisionMaxImageTokens
+				total += deepseekFlashMaxImageTokens
 			}
 		}
 	case []model.MessageContent:
 		for _, block := range blocks {
 			if strings.EqualFold(block.Type, model.ContentTypeFile) &&
 				(strings.TrimSpace(block.FileID) != "" || strings.TrimSpace(block.FileData) != "") {
-				total += deepseekV4VisionMaxImageTokens
+				total += deepseekFlashMaxImageTokens
 			}
 		}
 	}
@@ -317,10 +318,10 @@ const (
 	gpt4oMiniLowDetailCost  = 2833
 	gpt4oMiniHighDetailCost = 5667
 	gpt4oMiniAdditionalCost = 2833
-	// DeepSeek documents a hard post-resize upper bound for each image. The
-	// upstream response usage remains authoritative for final billing.
-	deepseekV4VisionMaxImageTokens = 384
-	deepseekV4VisionModelName      = "deepseek-v4-flash-vision-exp"
+	// DeepSeek's current Flash model and its aliases share this post-resize
+	// image bound. It is only a pre-consume estimate; upstream usage determines
+	// the final charge. Source: https://api-docs.deepseek.com/guides/vision/
+	deepseekFlashMaxImageTokens = 1024
 )
 
 // getImageSizeFn is injected for testability
@@ -357,8 +358,8 @@ func countImageTokens(url string, detail string, model string) (_ int, err error
 	// For pre-consume estimation, use the documented per-image upper bound rather
 	// than applying OpenAI's unrelated tile formula or fetching a remote image.
 	// Post-consume billing reconciles this estimate against upstream usage.
-	if model == deepseekV4VisionModelName {
-		return deepseekV4VisionMaxImageTokens, nil
+	if deepseekcompat.IsFlashVisionModel(model) {
+		return deepseekFlashMaxImageTokens, nil
 	}
 
 	var fetchSize = true

--- a/relay/adaptor/openai/token_deepseek_file_test.go
+++ b/relay/adaptor/openai/token_deepseek_file_test.go
@@ -37,7 +37,7 @@ func TestCountTokenMessages_DeepSeekFileImagesUseDocumentedUpperBound(t *testing
 			}
 			content = append(content, fileBlock)
 			got := CountTokenMessages(ctx, []model.Message{{Role: "user", Content: content}}, modelName)
-			require.Equal(t, base+deepseekV4VisionMaxImageTokens, got)
+			require.Equal(t, base+1024, got)
 		})
 	}
 }

--- a/relay/adaptor/openai/token_deepseek_image_test.go
+++ b/relay/adaptor/openai/token_deepseek_image_test.go
@@ -26,7 +26,7 @@ func TestCountImageTokens_DeepSeekVisionUsesDocumentedUpperBound(t *testing.T) {
 				"deepseek-v4-flash-vision-exp",
 			)
 			require.NoError(t, err)
-			require.Equal(t, 384, got)
+			require.Equal(t, 1024, got)
 		})
 	}
 }

--- a/relay/controller/deepseek_review_regression_test.go
+++ b/relay/controller/deepseek_review_regression_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -28,13 +29,19 @@ func TestDeepSeekReviewNativeRouting(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			for _, channel := range []int{channeltype.DeepSeek, channeltype.OpenAI, channeltype.OpenAICompatible} {
-				meta := &metalib.Meta{ChannelType: channel, BaseURL: "https://api.deepseek.com", OriginModelName: "my-model", ActualModelName: name}
-				require.True(t, supportsNativeResponseAPI(meta), "mapped model %s on channel %d must retain native Responses routing", name, channel)
+				t.Run("channel-"+strconv.Itoa(channel), func(t *testing.T) {
+					meta := &metalib.Meta{ChannelType: channel, BaseURL: "https://api.deepseek.com", OriginModelName: "my-model", ActualModelName: name}
+					require.True(t, supportsNativeResponseAPI(meta), "mapped model must retain native Responses routing")
+				})
 			}
-			meta := &metalib.Meta{ChannelType: channeltype.DeepSeek, OriginModelName: name}
-			require.True(t, supportsNativeResponseAPI(meta), "origin name must work when actual name is absent")
-			thirdParty := &metalib.Meta{ChannelType: channeltype.OpenAI, BaseURL: "https://third-party.example/v1", ActualModelName: name}
-			require.False(t, supportsNativeResponseAPI(thirdParty), "a model name alone must not opt a third-party host into DeepSeek's contract")
+			t.Run("origin-only", func(t *testing.T) {
+				meta := &metalib.Meta{ChannelType: channeltype.DeepSeek, OriginModelName: name}
+				require.True(t, supportsNativeResponseAPI(meta), "origin name must work when actual name is absent")
+			})
+			t.Run("third-party", func(t *testing.T) {
+				thirdParty := &metalib.Meta{ChannelType: channeltype.OpenAI, BaseURL: "https://third-party.example/v1", ActualModelName: name}
+				require.False(t, supportsNativeResponseAPI(thirdParty), "a model name alone must not opt a third-party host into DeepSeek's contract")
+			})
 		})
 	}
 	require.False(t, supportsNativeResponseAPI(nil))
@@ -69,10 +76,16 @@ func TestDeepSeekReviewResponsesImageReservation(t *testing.T) {
 					map[string]any{"type": "input_image", "file_data": "data:image/png;base64,AAAA"},
 				}
 				for index, image := range images {
-					require.Equal(t, base+1024, count([]any{text, image}), "image source %d must reserve the current bound", index)
+					t.Run([]string{"url", "inline", "file_id", "file_data"}[index], func(t *testing.T) {
+						require.Equal(t, base+1024, count([]any{text, image}), "each image source must reserve the current bound")
+					})
 				}
-				require.Equal(t, base+len(images)*1024, count(append([]any{text}, images...)), "each image must be counted once")
-				require.Equal(t, base, count([]any{text, map[string]any{"type": "input_image"}}), "an empty image source must not reserve tokens")
+				t.Run("multiple", func(t *testing.T) {
+					require.Equal(t, base+len(images)*1024, count(append([]any{text}, images...)), "each image must be counted once")
+				})
+				t.Run("empty", func(t *testing.T) {
+					require.Equal(t, base, count([]any{text, map[string]any{"type": "input_image"}}), "an empty image source must not reserve tokens")
+				})
 			})
 		}
 	}

--- a/relay/controller/deepseek_review_regression_test.go
+++ b/relay/controller/deepseek_review_regression_test.go
@@ -1,0 +1,129 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor/deepseek"
+	"github.com/Laisky/one-api/relay/adaptor/openai"
+	"github.com/Laisky/one-api/relay/channeltype"
+	metalib "github.com/Laisky/one-api/relay/meta"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+// TestDeepSeekReviewNativeRouting exercises the production route decision after
+// model mapping, including aliases and third-party-host negative controls.
+func TestDeepSeekReviewNativeRouting(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, channel := range []int{channeltype.DeepSeek, channeltype.OpenAI, channeltype.OpenAICompatible} {
+				meta := &metalib.Meta{ChannelType: channel, BaseURL: "https://api.deepseek.com", OriginModelName: "my-model", ActualModelName: name}
+				require.True(t, supportsNativeResponseAPI(meta), "mapped model %s on channel %d must retain native Responses routing", name, channel)
+			}
+			meta := &metalib.Meta{ChannelType: channeltype.DeepSeek, OriginModelName: name}
+			require.True(t, supportsNativeResponseAPI(meta), "origin name must work when actual name is absent")
+			thirdParty := &metalib.Meta{ChannelType: channeltype.OpenAI, BaseURL: "https://third-party.example/v1", ActualModelName: name}
+			require.False(t, supportsNativeResponseAPI(thirdParty), "a model name alone must not opt a third-party host into DeepSeek's contract")
+		})
+	}
+	require.False(t, supportsNativeResponseAPI(nil))
+	require.False(t, supportsNativeResponseAPI(&metalib.Meta{ChannelType: channeltype.DeepSeek, ActualModelName: "deepseek-chat"}))
+}
+
+// TestDeepSeekReviewResponsesImageReservation decodes real Responses payloads
+// and checks the production pre-consume estimator for messages and tool outputs.
+func TestDeepSeekReviewResponsesImageReservation(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp"} {
+		for _, itemType := range []string{"message", "function_call_output", "custom_tool_call_output"} {
+			t.Run(name+"/"+itemType, func(t *testing.T) {
+				t.Parallel()
+				text := map[string]any{"type": "input_text", "text": strings.Repeat("Describe the image and compare its visible details. ", 10)}
+				count := func(parts []any) int {
+					item := map[string]any{"type": itemType, "role": "user", "content": parts}
+					if itemType != "message" {
+						item = map[string]any{"type": itemType, "call_id": "call-image", "output": parts}
+					}
+					body, err := json.Marshal(map[string]any{"model": name, "input": []any{item}})
+					require.NoError(t, err)
+					var request openai.ResponseAPIRequest
+					require.NoError(t, json.Unmarshal(body, &request))
+					return getResponseAPIPromptTokens(context.Background(), &request)
+				}
+				base := count([]any{text})
+				images := []any{
+					map[string]any{"type": "input_image", "image_url": "https://image.invalid/picture.png", "detail": "low"},
+					map[string]any{"type": "input_image", "image_url": "data:image/png;base64,AAAA", "detail": "low"},
+					map[string]any{"type": "input_image", "file_id": "file-api-image"},
+					map[string]any{"type": "input_image", "file_data": "data:image/png;base64,AAAA"},
+				}
+				for index, image := range images {
+					require.Equal(t, base+1024, count([]any{text, image}), "image source %d must reserve the current bound", index)
+				}
+				require.Equal(t, base+len(images)*1024, count(append([]any{text}, images...)), "each image must be counted once")
+				require.Equal(t, base, count([]any{text, map[string]any{"type": "input_image"}}), "an empty image source must not reserve tokens")
+			})
+		}
+	}
+}
+
+// TestDeepSeekReviewJSONReasoningAndSampling is the negative reproduction for
+// the claim that ultra never reaches the adaptor. It also guards top_p forwarding.
+func TestDeepSeekReviewJSONReasoningAndSampling(t *testing.T) {
+	for _, effort := range []string{"minimal", "ultra"} {
+		t.Run(effort, func(t *testing.T) {
+			body := `{"model":"deepseek-flash","messages":[{"role":"user","content":"hello"}],"reasoning_effort":"` + effort + `","thinking":{"type":"enabled"},"top_p":0.97}`
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+			request, err := getAndValidateTextRequest(c, relaymode.ChatCompletions)
+			require.NoError(t, err)
+			sanitizeChatCompletionRequest(request)
+			converted, err := (&deepseek.Adaptor{}).ConvertRequest(c, relaymode.ChatCompletions, request)
+			require.NoError(t, err)
+			encoded, err := json.Marshal(converted)
+			require.NoError(t, err)
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(encoded, &payload))
+			want := "max"
+			if effort == "minimal" {
+				want = "low"
+			}
+			require.Equal(t, want, payload["reasoning_effort"])
+			require.Equal(t, 0.97, payload["top_p"], "the gateway must not discard the provider's supported sampling control")
+		})
+	}
+}
+
+// TestDeepSeekReviewExplicitJSONBinding proves ultra must also survive the
+// validating JSON boundary, rather than depending on unvalidated JSON decoding.
+func TestDeepSeekReviewExplicitJSONBinding(t *testing.T) {
+	for _, effort := range []string{"minimal", "ultra"} {
+		t.Run(effort, func(t *testing.T) {
+			body := `{"model":"deepseek-flash","messages":[{"role":"user","content":"hello"}],"reasoning_effort":"` + effort + `"}`
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			var request relaymodel.GeneralOpenAIRequest
+			require.NoError(t, binding.JSON.Bind(req, &request))
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			converted, err := (&deepseek.Adaptor{}).ConvertRequest(c, relaymode.ChatCompletions, &request)
+			require.NoError(t, err)
+			want := "max"
+			if effort == "minimal" {
+				want = "low"
+			}
+			require.Equal(t, want, *converted.(*relaymodel.GeneralOpenAIRequest).ReasoningEffort)
+		})
+	}
+}

--- a/relay/controller/deepseek_sampling_regression_test.go
+++ b/relay/controller/deepseek_sampling_regression_test.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Laisky/one-api/relay/adaptor/deepseek"
+	"github.com/Laisky/one-api/relay/adaptor/openai"
+	"github.com/Laisky/one-api/relay/channeltype"
+	relaymodel "github.com/Laisky/one-api/relay/model"
+	"github.com/Laisky/one-api/relay/relaymode"
+)
+
+// TestDeepSeekReviewSamplingAcrossFormats checks actual request parsing and
+// serialization for every API name. Provider-controlled top_p must survive both
+// sanitizers, not only the canonical name that bypassed the old V4 predicate.
+func TestDeepSeekReviewSamplingAcrossFormats(t *testing.T) {
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro"} {
+		for _, format := range []string{"chat", "responses"} {
+			t.Run(name+"/"+format, func(t *testing.T) {
+				body := `{"model":"` + name + `","messages":[{"role":"user","content":"hello"}],"thinking":{"type":"enabled"},"top_p":0.97}`
+				if format == "responses" {
+					body = `{"model":"` + name + `","input":"hello","reasoning":{"effort":"high"},"top_p":0.97}`
+				}
+				c, _ := gin.CreateTestContext(httptest.NewRecorder())
+				c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+				c.Request.Header.Set("Content-Type", "application/json")
+				var outgoing any
+				if format == "chat" {
+					request, err := getAndValidateTextRequest(c, relaymode.ChatCompletions)
+					require.NoError(t, err)
+					sanitizeChatCompletionRequest(request)
+					outgoing, err = (&deepseek.Adaptor{}).ConvertRequest(c, relaymode.ChatCompletions, request)
+					require.NoError(t, err)
+				} else {
+					request, err := getAndValidateResponseAPIRequest(c)
+					require.NoError(t, err)
+					sanitizeResponseAPIRequest(request, channeltype.DeepSeek)
+					outgoing = request
+				}
+				encoded, err := json.Marshal(outgoing)
+				require.NoError(t, err)
+				var wire map[string]any
+				require.NoError(t, json.Unmarshal(encoded, &wire))
+				require.Equal(t, 0.97, wire["top_p"], "a supported sampling control must not disappear from the upstream payload")
+			})
+		}
+	}
+}
+
+// TestDeepSeekReviewOpenAISamplingControl keeps OpenAI's existing fixed-sampling
+// handling as a negative control when DeepSeek's sampling support is corrected.
+func TestDeepSeekReviewOpenAISamplingControl(t *testing.T) {
+	t.Parallel()
+	topP := 0.97
+	chat := &relaymodel.GeneralOpenAIRequest{Model: "gpt-5-mini", TopP: &topP}
+	sanitizeChatCompletionRequest(chat)
+	require.Nil(t, chat.TopP)
+	response := &openai.ResponseAPIRequest{Model: "gpt-5-mini", TopP: &topP}
+	sanitizeResponseAPIRequest(response, channeltype.OpenAI)
+	require.Nil(t, response.TopP)
+}

--- a/relay/controller/response_utils.go
+++ b/relay/controller/response_utils.go
@@ -270,7 +270,7 @@ func countResponseAPIContentPartTokens(ctx context.Context, partMap map[string]a
 	case "input_image":
 		url, _ := partMap["image_url"].(string)
 		detail, _ := partMap["detail"].(string)
-		if url == "" && model == "deepseek-v4-flash-vision-exp" {
+		if url == "" && deepseekcompat.IsFlashVisionModel(model) {
 			fileID, _ := partMap["file_id"].(string)
 			fileData, _ := partMap["file_data"].(string)
 			if strings.TrimSpace(fileID) != "" || strings.TrimSpace(fileData) != "" {
@@ -466,7 +466,7 @@ func supportsNativeResponseAPI(meta *metalib.Meta) bool {
 
 // supportsDeepSeekNativeResponseAPI reports whether the request targets a model
 // served by DeepSeek's native, stateless Responses endpoint. DeepSeek exposes
-// that endpoint for all currently available V4 models.
+// that endpoint for the current Flash and Pro API names and Flash aliases.
 func supportsDeepSeekNativeResponseAPI(meta *metalib.Meta) bool {
 	if meta == nil || !isDeepSeekUpstream(meta) {
 		return false
@@ -478,9 +478,7 @@ func supportsDeepSeekNativeResponseAPI(meta *metalib.Meta) bool {
 	}
 
 	// https://api-docs.deepseek.com/guides/responses_api/
-	return modelName == "deepseek-v4-flash" ||
-		modelName == "deepseek-v4-flash-vision-exp" ||
-		modelName == "deepseek-v4-pro"
+	return deepseekcompat.IsFlashVisionModel(modelName) || modelName == "deepseek-v4-pro"
 }
 
 // isDeepSeekModel checks if the model is a DeepSeek model
@@ -526,14 +524,15 @@ func shouldRouteResponseFallbackThroughDeepSeek(meta *metalib.Meta) bool {
 	return isDeepSeekUpstream(meta)
 }
 
-// isReasoningModel checks if the model is a reasoning model
+// isReasoningModel identifies models requiring OpenAI-style sampling removal.
+// DeepSeek accepts top_p in thinking mode and temperature in non-thinking mode,
+// so its canonical names and aliases must leave sampling controls to upstream.
 func isReasoningModel(modelName string) bool {
 	if modelName == "" {
 		return false
 	}
 	// Check for reasoning model prefixes (direct model names)
 	if strings.HasPrefix(modelName, "gpt-5") ||
-		strings.HasPrefix(modelName, "deepseek-v4-") ||
 		strings.HasPrefix(modelName, "o1") ||
 		strings.HasPrefix(modelName, "o3") ||
 		strings.HasPrefix(modelName, "o4") ||

--- a/relay/controller/response_utils_test.go
+++ b/relay/controller/response_utils_test.go
@@ -83,7 +83,7 @@ func TestGetResponseAPIPromptTokens_CountsDeepSeekFileImages(t *testing.T) {
 				},
 			}
 			fileTokens := getResponseAPIPromptTokens(context.Background(), fileRequest)
-			require.Equal(t, baseTokens+384, fileTokens)
+			require.Equal(t, baseTokens+1024, fileTokens)
 		})
 	}
 }
@@ -110,5 +110,5 @@ func TestGetResponseAPIPromptTokens_CountsDeepSeekToolOutputFileImages(t *testin
 	}
 
 	fileTokens := getResponseAPIPromptTokens(context.Background(), withImage)
-	require.Equal(t, 384, fileTokens)
+	require.Equal(t, 1024, fileTokens)
 }

--- a/relay/model/deepseek_review_regression_test.go
+++ b/relay/model/deepseek_review_regression_test.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin/binding"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeepSeekReviewReasoningBinding checks the shared Responses reasoning
+// schema through JSON binding, retaining rejection of unknown effort values.
+func TestDeepSeekReviewReasoningBinding(t *testing.T) {
+	t.Parallel()
+	for _, effort := range []string{"none", "default", "minimal", "low", "medium", "high", "xhigh", "max", "ultra", "unknown"} {
+		t.Run(effort, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"effort":"`+effort+`"}`))
+			req.Header.Set("Content-Type", "application/json")
+			var reasoning OpenAIResponseReasoning
+			err := binding.JSON.Bind(req, &reasoning)
+			if effort == "unknown" {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, effort, *reasoning.Effort)
+		})
+	}
+}

--- a/relay/model/general.go
+++ b/relay/model/general.go
@@ -76,8 +76,8 @@ type GeneralOpenAIRequest struct {
 	// The binding is the union of effort vocabularies across providers; per-model
 	// validation narrows it downstream (e.g. Qwen uses "default", the GPT-5.6
 	// family adds "xhigh"/"max", grok/gemini use "none", and GPT-5 advertises
-	// the legacy "minimal" alias).
-	ReasoningEffort *string `json:"reasoning_effort,omitempty" binding:"omitempty,oneof=none default minimal low medium high xhigh max"`
+	// the legacy "minimal" alias; DeepSeek accepts "ultra").
+	ReasoningEffort *string `json:"reasoning_effort,omitempty" binding:"omitempty,oneof=none default minimal low medium high xhigh max ultra"`
 	// Verbosity hints the model to be more or less expansive in its replies (GPT-5 series).
 	// Supported values: low, medium, high
 	Verbosity *string `json:"verbosity,omitempty" binding:"omitempty,oneof=low medium high"`
@@ -138,8 +138,8 @@ type GeneralOpenAIRequest struct {
 type OpenAIResponseReasoning struct {
 	// Effort defines the reasoning effort level. The binding is the union across
 	// providers; per-model validation narrows it downstream (Qwen uses
-	// "default", while the GPT-5.6 family adds "xhigh"/"max").
-	Effort *string `json:"effort,omitempty" binding:"omitempty,oneof=none default minimal low medium high xhigh max"`
+	// "default", the GPT-5.6 family adds "xhigh"/"max", and DeepSeek accepts "ultra").
+	Effort *string `json:"effort,omitempty" binding:"omitempty,oneof=none default minimal low medium high xhigh max ultra"`
 	// Summary defines whether to include a summary of the reasoning
 	Summary *string `json:"summary,omitempty" binding:"omitempty,oneof=auto concise detailed"`
 }

--- a/relay/tooling/tools_test.go
+++ b/relay/tooling/tools_test.go
@@ -518,27 +518,43 @@ func TestValidateRequestedBuiltins_OpenAIUsesProviderDefaults(t *testing.T) {
 	require.NoError(t, ValidateRequestedBuiltins("gpt-4o", meta, channel, &openai.Adaptor{}, map[string]struct{}{"web_search": {}}))
 }
 
-// TestValidateRequestedBuiltins_DeepSeekNativeWebSearch verifies the native
-// DeepSeek web_search tool is allowed without a separate per-call charge.
-// Parameters: t is the testing handle used for assertions and test lifecycle control.
-// Returns: nothing; the test fails through t when a documented native tool is blocked.
-func TestValidateRequestedBuiltins_DeepSeekNativeWebSearch(t *testing.T) {
+// TestDeepSeekReviewBuiltinPolicy verifies current DeepSeek defaults reject
+// unsupported native search, prune optional built-ins, and preserve a user's
+// function tool even when that function happens to be named web_search.
+func TestDeepSeekReviewBuiltinPolicy(t *testing.T) {
 	t.Parallel()
+	for _, name := range []string{"deepseek-flash", "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			metadata := &metalib.Meta{ChannelType: channeltype.DeepSeek, ActualModelName: name}
+			channel := &model.Channel{Type: channeltype.DeepSeek}
+			provider := &deepseekadaptor.Adaptor{}
+			require.NotContains(t, provider.DefaultToolingConfig().Pricing, "web_search")
+			require.ErrorContains(t, ValidateRequestedBuiltins(name, metadata, channel, provider,
+				map[string]struct{}{"web_search": {}}), "not allowed")
 
-	meta := &metalib.Meta{ChannelType: channeltype.DeepSeek, ActualModelName: "deepseek-v4-flash"}
-	provider := &deepseekadaptor.Adaptor{}
-	require.NoError(t, ValidateRequestedBuiltins(
-		"deepseek-v4-flash", meta, &model.Channel{Type: channeltype.DeepSeek}, provider,
-		map[string]struct{}{"web_search": {}},
-	))
+			request := &openai.ResponseAPIRequest{
+				Model: name,
+				Tools: []openai.ResponseAPITool{
+					{Type: "web_search"},
+					{Type: "function", Name: "web_search", Parameters: map[string]any{"type": "object"}},
+				},
+			}
+			removed := PruneDisallowedResponseBuiltins(request, metadata, channel, provider)
+			require.Equal(t, []string{"web_search"}, removed)
+			require.Len(t, request.Tools, 1)
+			require.Equal(t, "function", request.Tools[0].Type)
+			require.Equal(t, "web_search", request.Tools[0].Name)
+			require.NoError(t, ValidateResponseBuiltinTools(request, metadata, channel, provider))
 
-	request := &openai.ResponseAPIRequest{
-		Model: "deepseek-v4-flash",
-		Tools: []openai.ResponseAPITool{{Type: "web_search"}},
+			// A forced unsupported tool must fail validation rather than silently
+			// disappearing and changing the caller's requested behavior.
+			request.Tools = []openai.ResponseAPITool{{Type: "web_search"}}
+			request.ToolChoice = map[string]any{"type": "web_search"}
+			require.Empty(t, PruneDisallowedResponseBuiltins(request, metadata, channel, provider))
+			require.ErrorContains(t, ValidateResponseBuiltinTools(request, metadata, channel, provider), "not allowed")
+		})
 	}
-	removed := PruneDisallowedResponseBuiltins(request, meta, &model.Channel{Type: channeltype.DeepSeek}, provider)
-	require.Empty(t, removed)
-	require.Len(t, request.Tools, 1)
 }
 
 func TestNormalizeBuiltinType_ToolSearchAliases(t *testing.T) {


### PR DESCRIPTION
## Summary

Refresh DeepSeek model defaults against the official documentation and the operator-provided pricing notice dated **2026-09-10**.

- Add `deepseek-flash` (DeepSeek-V4.1-Flash), retaining `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` as compatible multimodal names with identical Flash pricing. Do not reintroduce retired V3 names or invent version-pinned API names.
- Apply the new Flash prices at **2026-09-10 04:00 UTC (12:00 Beijing)**, preserving the immediately preceding defaults before that instant.
- Preserve Pro pricing until **2026-09-14 04:00 UTC (12:00 Beijing)**, then charge the announced Flash rates for `deepseek-v4-pro`. DeepSeek performs the upstream model redirection; the gateway preserves the requested API name.
- Keep the existing UTC weekday peak/off-peak engine and request-start-time billing semantics. No shared billing-engine modification, database migration, or user-config rewrite.
- Complete the integration fixes verified through behavior tests: native Responses routing, all Flash image reservations, validating reasoning boundaries, and sampling preservation across Chat/Responses aliases.

## Prices and exact effective times

USD per million tokens; columns are cache-miss input, cache-hit input, output.

| Model / effective interval | Off-peak | Peak |
| --- | --- | --- |
| Flash, immediately preceding schedule, before Sep 10 04:00 UTC | 0.22 / 0.007 / 0.66 | 0.44 / 0.014 / 1.32 |
| Flash and aliases, from Sep 10 04:00 UTC | 0.15 / 0.003 / 0.60 | 0.30 / 0.006 / 1.20 |
| Pro, before Sep 14 04:00 UTC | 0.66 / 0.022 / 1.98 | 1.32 / 0.044 / 3.96 |
| Pro API name, from Sep 14 04:00 UTC | 0.15 / 0.003 / 0.60 | 0.30 / 0.006 / 1.20 |

Peak: **Monday–Friday 01:00–04:00 and 06:00–10:00 UTC**. All other hours and weekends are off-peak. Boundaries are start-inclusive/end-exclusive. The immediately preceding Flash rates come from pre-update commit `e000b8eb`; this is not a complete archive of earlier price eras.

### Latest notice correction: behavior-first evidence

The earlier implementation had the correct new amounts and Pro transition, but applied Flash's new prices without an activation date. This was a real omission, not evidence that the post-activation rates were wrong.

`TestDeepSeekReviewPricingNotice` was committed **before** the fix in `28c8c65`. It exercises both production pricing resolvers and `quota.Compute` settlement for cache-miss-only, cache-hit-only, output-only, and mixed usage. It covers all four API names, both Beijing-noon changes at -1 ns/exact/+1 ns, UTC midnight, peak/off-peak hours, weekends, and equivalent Beijing timestamps.

- [RED: tests-only commit 28c8c65](https://github.com/Laisky/one-api/actions/runs/34497100013): pre-activation Flash cases failed with the new prices incorrectly applied. Post-activation and Pro controls, plus the existing review regressions, passed.
- `473b464` adds the missing Flash date/time bridge and updates the existing comprehensive boundary oracle. The new notice test assertions are unchanged.
- [GREEN: commit 473b464](https://github.com/Laisky/one-api/actions/runs/34497956171): **all 12 behavioral groups pass**, including **312 leaf subcases** in the pricing-notice test; **all seven affected package suites pass** with `-race -count=1`.

## Review dispositions

**All seven existing inline review threads were read back as resolved after the latest corrections.** Resolution is not a claim that every reviewer agrees with each disposition.

| Finding | Observed behavior and disposition |
| --- | --- |
| Canonical native Responses routing | Reproduced the failure for `deepseek-flash`; fixed in `16afb8f`, retaining the DeepSeek-upstream guard. Old aliases, mapped names and third-party-host controls remain covered. Thread resolved. |
| Image reservation | Reproduced OpenAI 85-token/255-token estimates and dimension fetches for new names, zero file-image deltas, and the obsolete 384-token bound for the vision alias. All Flash names now reserve the documented conservative 1024-token bound without dimension fetches. URL, inline, file references, typed content, multiple images and nested Responses tool outputs are covered. Thread resolved. |
| `ultra` support | JSON decoding/conversion already passed; explicit Gin binding failed. Preserve documented `ultra -> max`, fix both shared binding vocabularies, retain unknown-value rejection. Reviewer accepted the correction and resolved the thread. |
| Sampling | Canonical name preserved `top_p=0.97`, but V4 aliases lost it in Chat/Responses sanitizers. Fixed the generic fixed-sampling predicate while retaining OpenAI removal as a negative control. The documented thinking-mode 0.95 floor remains; reviewer accepted and resolved the thread. |
| Native search | Re-read the live Responses Guide **Compatibility Details → Tools** table and API reference **tools** field: both mark built-in `web_search` as ignored. Historical `web_search_call` input replay is separate. Retain default rejection, optional pruning, forced-tool rejection and survival of a user function named `web_search`. The reviewer still posted a contradictory interpretation; the thread was resolved on the current full-page evidence, not on a claim of reviewer agreement. |
| Checkout credentials / mutable action refs | Disable credential persistence, verify resulting Git config by key names only, and pin actions to independently verified commit SHAs. Both threads were accepted and resolved. |

The already-passing streamed/non-streamed handler-to-quota controls remain: upstream 300 prompt / 50 output / 100 cached tokens replace a 4096-token estimate and produce 31 quota units. The 1024 image reservation must never become a fixed final charge.

## Earlier reproduction and acceptance history

| Stage | Commit | Actual evidence |
| --- | --- | --- |
| Initial tests-only reproduction | `517bea5` | [Expected failures](https://github.com/Laisky/one-api/actions/runs/34484425752). |
| Independent image and routing cases | `97c4829` | [Expected failures](https://github.com/Laisky/one-api/actions/runs/34485434437). |
| Complete reproduction and controls | `f3ac6cf` | [Seven failing groups and three already-passing control groups](https://github.com/Laisky/one-api/actions/runs/34486283405), production unchanged. |
| Integration fixes | `16afb8f` | [Eleven behavioral groups and seven affected packages pass](https://github.com/Laisky/one-api/actions/runs/34487929539). |
| Workflow hardening | `4dc3644` | [Behavioral groups, affected packages and credential guard pass](https://github.com/Laisky/one-api/actions/runs/34488439915). |

The retained `.github/workflows/deepseek-regression.yml` runs the behavioral groups and complete affected packages. It uploads only the explicit regression log, not the workspace or credentials. Existing repository CI was not disabled, loosened or bypassed. Historical red test-only commits are intentional reproduction evidence.

## Validation scope and merge gate

- Tests ran on GitHub Actions with repository-required Go **1.27.1**. Local full tests could not run because the local Go 1.23.2 toolchain cannot download the required toolchain/dependencies in this environment.
- `go vet ./...` passed on **473b464** in [PR checks](https://github.com/Laisky/one-api/actions/runs/34497956132). The repository-wide database-backed race suite was still running when this acceptance snapshot was recorded; it is **not** claimed green. Earlier repository-wide checks on `4dc3644` failed, so targeted regression success is not a substitute for the full merge gate.
- No paid live DeepSeek calls were made. Regression responses are deterministic fixtures; provider capability decisions are based on current documentation, not inferred from fixtures.
- Existing user-specific pricing overrides remain untouched. The scheduled Pro overlay changes pricing, not static capability metadata; its current metadata describes text-only V4 Pro. Review future provider announcements separately.
- No frontend changes. The PR remains unmerged.

## Official sources

- https://api-docs.deepseek.com/quick_start/pricing/
- https://api-docs.deepseek.com/guides/thinking_mode/
- https://api-docs.deepseek.com/guides/vision/
- https://api-docs.deepseek.com/guides/responses_api/#tools
- https://api-docs.deepseek.com/api/create-response/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek V4.1 model support, including Flash and compatibility aliases.
  * Updated DeepSeek pricing schedules, including the planned Pro-to-Flash transition.
  * Added support for `minimal` and `ultra` reasoning-effort aliases.
  * Improved image-token estimation with a consistent 1,024-token reservation.

* **Bug Fixes**
  * Corrected DeepSeek model capabilities, token limits, defaults, and pricing.
  * Preserved DeepSeek sampling controls such as `top_p`.
  * Native DeepSeek `web_search` requests are now rejected to match API behavior.

* **Documentation**
  * Expanded DeepSeek documentation with model details, pricing, verification guidance, tests, and official references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->