### PR TITLE
fix(responses): keep DeepSeek tool-call turns replayable through chat fallback

### DIFF
--- a/relay/adaptor/openai/responseapi_convert_request.go
+++ b/relay/adaptor/openai/responseapi_convert_request.go
@@ -88,7 +88,7 @@ func ConvertResponseAPIToChatCompletionRequest(request *ResponseAPIRequest) (*mo
 	}
 
 	// openToolCallMsgIdx tracks an assistant message that was just emitted from a
-	// function_call item and is still "open" to receive sibling tool calls. The OpenAI
+	// function_call or assistant text item and is still "open" to receive sibling tool calls. The OpenAI
 	// Responses API represents parallel tool calls (issued in a single assistant turn) as
 	// multiple consecutive function_call items. ChatCompletion upstreams such as DeepSeek
 	// require those to live in ONE assistant message's tool_calls array; otherwise the
@@ -242,6 +242,13 @@ func ConvertResponseAPIToChatCompletionRequest(request *ResponseAPIRequest) (*mo
 			chatReq.Messages = append(chatReq.Messages, *msg)
 			// A non-tool content message ends the current tool-call turn.
 			clear(pendingToolCallIDs)
+			// An assistant text message stays open so directly following function_call
+			// items join it: Chat Completions carries a turn's text and tool calls in one
+			// assistant message, and DeepSeek requires that message to hold the turn's
+			// reasoning_content.
+			if msg.Role == "assistant" {
+				openToolCallMsgIdx = len(chatReq.Messages) - 1
+			}
 		default:
 			return nil, errors.Errorf("unsupported input item of type %T", item)
 		}

--- a/relay/adaptor/openai/responseapi_convert_request_test.go
+++ b/relay/adaptor/openai/responseapi_convert_request_test.go
@@ -92,6 +92,60 @@ func TestConvertResponseAPIToChatCompletionRequestPreservesToolCallReasoning(t *
 		"older summary-only bridge output must remain replayable")
 }
 
+// TestConvertResponseAPIToChatCompletionRequestMergesAssistantTextWithToolCalls
+// reproduces a DeepSeek thinking-mode turn where the model writes text before
+// calling a tool. Responses clients replay it as reasoning, message, and
+// function_call items; DeepSeek requires one assistant message carrying the
+// text, the tool calls, and the reasoning_content together.
+func TestConvertResponseAPIToChatCompletionRequestMergesAssistantTextWithToolCalls(t *testing.T) {
+	responseReq := &ResponseAPIRequest{
+		Model: "deepseek-v4-pro",
+		Input: ResponseAPIInput{
+			map[string]any{"role": "user", "content": "Summarize README.md"},
+			map[string]any{
+				"type": "reasoning",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Read the file first."},
+				},
+			},
+			map[string]any{
+				"type": "message",
+				"role": "assistant",
+				"content": []any{
+					map[string]any{"type": "output_text", "text": "Let me read it."},
+				},
+			},
+			map[string]any{
+				"type":      "function_call",
+				"id":        "fc_read",
+				"call_id":   "call_read",
+				"name":      "read_file",
+				"arguments": `{"path":"README.md"}`,
+			},
+			map[string]any{
+				"type":    "function_call_output",
+				"call_id": "call_read",
+				"output":  "file contents",
+			},
+		},
+	}
+
+	chatReq, err := ConvertResponseAPIToChatCompletionRequest(responseReq)
+	require.NoError(t, err)
+	require.Len(t, chatReq.Messages, 3)
+
+	assistant := chatReq.Messages[1]
+	require.Equal(t, "assistant", assistant.Role)
+	require.Equal(t, "Let me read it.", assistant.StringContent())
+	require.Len(t, assistant.ToolCalls, 1)
+	require.NotNil(t, assistant.ReasoningContent)
+	require.Equal(t, "Read the file first.", *assistant.ReasoningContent)
+
+	toolResult := chatReq.Messages[2]
+	require.Equal(t, "tool", toolResult.Role)
+	require.Equal(t, assistant.ToolCalls[0].Id, toolResult.ToolCallId)
+}
+
 // TestConvertResponseAPIToChatCompletionRequestPreservesDeepSeekFileImages verifies
 // Responses API file-backed images survive fallback conversion to Chat Completions.
 // Parameters: t is the testing handle used for assertions and test lifecycle control.

--- a/relay/controller/response_stream_bridge.go
+++ b/relay/controller/response_stream_bridge.go
@@ -541,10 +541,13 @@ func (h *chatToResponseStreamBridge) ensureToolCallState(c *gin.Context, tool *m
 	}
 
 	if created {
+		// Clients such as pi derive the tool call identity from call_id on the added
+		// event and never revisit it, so the added item must already carry call_id.
 		item := openai.OutputItem{
 			Id:     state.id,
 			Type:   "function_call",
 			Status: "in_progress",
+			CallId: state.id,
 			Name:   state.name,
 		}
 

--- a/relay/controller/response_stream_bridge_test.go
+++ b/relay/controller/response_stream_bridge_test.go
@@ -412,6 +412,32 @@ func TestChatToResponseStreamBridge_ToolCallArgsDoneBeforeOutputItemDone(t *test
 	assert.Equal(t, "call_b", argsDoneEv.ItemId)
 }
 
+// TestChatToResponseStreamBridge_ToolCallAddedCarriesCallID verifies the
+// function_call output_item.added event already carries call_id. Responses
+// clients such as pi build the tool call identity from call_id on the added
+// event; without it every replayed call_id is "undefined" and DeepSeek rejects
+// the duplicate tool_call_id on the next turn.
+func TestChatToResponseStreamBridge_ToolCallAddedCarriesCallID(t *testing.T) {
+	t.Parallel()
+	c, w := newBridgeTestContext(t)
+	bridge := newTestBridge(t, c)
+
+	bridge.HandleChunk(c, bridgeToolCallChunk("call_a", 0, "read_file", `{"path":"a"}`))
+	bridge.HandleChunk(c, bridgeToolCallChunk("call_b", 1, "read_file", `{"path":"b"}`))
+	bridge.HandleChunk(c, bridgeFinishChunk("tool_calls"))
+	bridge.HandleDone(c)
+
+	var callIDs []string
+	for _, e := range bridgeFindEvents(parseBridgeSSE(w.Body.String()), "response.output_item.added") {
+		var ev openai.ResponseAPIStreamEvent
+		bridgeUnmarshal(t, e, &ev)
+		if ev.Item != nil && ev.Item.Type == "function_call" {
+			callIDs = append(callIDs, ev.Item.CallId)
+		}
+	}
+	require.Equal(t, []string{"call_a", "call_b"}, callIDs)
+}
+
 // TestChatToResponseStreamBridge_MultiCallEventOrderingInterleaved exercises two
 // interleaved tool calls in a single response and asserts that for every
 // call_id, the per-call spec ordering (args.done before output_item.done) holds


### PR DESCRIPTION
## Problem

When a Responses API request falls back to Chat Completions (e.g. DeepSeek models not on the native Responses list), DeepSeek thinking mode rejects the *next* turn of an agent loop with one of:

- `The reasoning_content in the thinking mode must be passed back to the API.`
- `Duplicate value for 'tool_call_id' of undefined in message[N]`

## Causes

1. **`ConvertResponseAPIToChatCompletionRequest`**: when the model emitted text *before* calling a tool, the `message` item and the following `function_call` items were lowered into two assistant messages. The replayed reasoning landed on the text message, leaving the message that carries `tool_calls` without `reasoning_content`.
2. **`chatToResponseStreamBridge`**: the `function_call` `response.output_item.added` event carried no `call_id`. Clients that establish the tool call identity from the added event (pi, for one) recorded every call as `undefined`, so the replayed history had duplicate `tool_call_id`s.

## Fix

- Directly following `function_call` items now join an open assistant text message, so text, `tool_calls`, and `reasoning_content` live in one message as Chat Completions expects.
- The `output_item.added` item now carries `call_id` (the `done` item already did).

Both changes have regression tests that fail without the fix. `go vet` and `go test -race` pass for `relay/adaptor/openai` and `relay/controller`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of assistant responses that combine text, reasoning, and tool calls, keeping them together as one assistant message.
  - Preserved tool call IDs in streamed function-call events, including responses with multiple tool calls.

- **Tests**
  - Added coverage for combined assistant content and streamed tool-call identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->